### PR TITLE
increase sleep time for flaky tests

### DIFF
--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/JobsServletReactiveChainforResultsEndpointSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/JobsServletReactiveChainforResultsEndpointSpec.groovy
@@ -162,7 +162,7 @@ class JobsServletReactiveChainforResultsEndpointSpec extends Specification {
 
         and: "We start the async chain"
         mockJobServlet.getPreResponseObservable("ticket4", apiRequest1)
-        Thread.sleep(7)
+        Thread.sleep(1000)
 
         then: "then we go to the PreResponseStore exactly once to get the ticket"
         1 * mockPreResponseStore.get(_) >> Observable.just(Mock(PreResponse))
@@ -178,7 +178,7 @@ class JobsServletReactiveChainforResultsEndpointSpec extends Specification {
         and: "We start the async chain"
         mockJobServlet.getPreResponseObservable("ticket4", apiRequest1)
         //The delay is to ensure that we get the notification after async timeout
-        Thread.sleep(5)
+        Thread.sleep(1000)
 
         and: "We receive the notification after async timeout"
         broadcastChannel.publish("ticket4")
@@ -212,7 +212,7 @@ class JobsServletReactiveChainforResultsEndpointSpec extends Specification {
         mockJobServlet.getPreResponseObservable("ticket4", apiRequest1)
 
         and: "PreResponse then becomes available in the PreResponsestore after some delay"
-        Thread.sleep(100)
+        Thread.sleep(1000)
         mockPreResponseStore.save("ticket4", PreResponseTestingUtils.buildPreResponse("2016-04-24")).subscribe()
 
         and: "We receive the notification before the async timeout"


### PR DESCRIPTION
JobsServletReactiveChainforResultsEndpointSpec had a number of tests with sleep to mimic several situations in which we get results from via BroadcastChannel notification or through PreResponseStore directly.

The Thread sleep duration was too small causing atleast 1 test to fail in Travis:
https://travis-ci.org/yahoo/fili/builds/156637523

This PR increased the sleep duration to ensure that the timeouts are not too close together