### PR TITLE
Async functional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Current
 -------
 
 ### Added:
+-  [Functional tests for Asynchronous queries](https://github.com/yahoo/fili/pull/35)
+
 - [Enrich jobs endpoint with filtering functionality] (https://github.com/yahoo/fili/pull/26)
    * Jobs endpoint now supports filters
 
@@ -35,6 +37,7 @@ Current
 
 
 ### Changed:
+-  [TestDruidWebService::jsonResponse is now a Producer<String>](https://github.com/yahoo/fili/pull/35)
 
 - [ISSUE-17](https://github.com/yahoo/fili/issues/17) [Added pagination parameters to PreResponse] (https://github.com/yahoo/fili/pull/19) 
    * Updated `JobsServlet::handlePreResponseWithError` to update `ResultSet` object with pagination parameters

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/async/jobs/payloads/DefaultJobPayloadBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/async/jobs/payloads/DefaultJobPayloadBuilder.java
@@ -2,7 +2,13 @@
 // Licensed under the terms of the Apache license. Please see LICENSE file distributed with this work for terms.
 package com.yahoo.bard.webservice.async.jobs.payloads;
 
-import com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField;
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.DATE_CREATED;
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.DATE_UPDATED;
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.JOB_TICKET;
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.QUERY;
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.STATUS;
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.USER_ID;
+
 import com.yahoo.bard.webservice.async.jobs.jobrows.JobRow;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 import com.yahoo.bard.webservice.web.JobRequestFailedException;
@@ -31,16 +37,16 @@ public class DefaultJobPayloadBuilder implements JobPayloadBuilder {
         Map<String, String> job = new LinkedHashMap<>();
 
         String ticket = jobRow.getId();
-        Map<String, String> fieldValueMap = jobRow.getRowMap();
 
-        job.put("query", fieldValueMap.get(DefaultJobField.QUERY.getName()));
+        job.put(QUERY.getName(), jobRow.get(QUERY));
         job.put("results", JobPayloadBuilder.getResultsUrl(ticket, uriInfo));
         job.put("syncResults", JobPayloadBuilder.getSyncResultsUrl(ticket, uriInfo));
         job.put("self", JobPayloadBuilder.getSelfUrl(ticket, uriInfo));
-        job.put("status", fieldValueMap.get(DefaultJobField.STATUS.getName()));
-        job.put("jobTicket", fieldValueMap.get(DefaultJobField.JOB_TICKET.getName()));
-        job.put("dateCreated", fieldValueMap.get(DefaultJobField.DATE_CREATED.getName()));
-        job.put("userId", fieldValueMap.get(DefaultJobField.USER_ID.getName()));
+        job.put(STATUS.getName(), jobRow.get(STATUS));
+        job.put(JOB_TICKET.getName(), jobRow.get(JOB_TICKET));
+        job.put(DATE_CREATED.getName(), jobRow.get(DATE_CREATED));
+        job.put(DATE_UPDATED.getName(), jobRow.get(DATE_UPDATED));
+        job.put(USER_ID.getName(), jobRow.get(USER_ID));
 
         //throw exception if any of the JobFields are missing in the map
         if (job.containsValue(null)) {
@@ -50,7 +56,7 @@ public class DefaultJobPayloadBuilder implements JobPayloadBuilder {
                     .map(Map.Entry::getKey)
                     .collect(Collectors.toSet());
 
-            String msg = ErrorMessageFormat.JOB_MAPPING_FAILED.format(ticket, fieldValueMap, missingFields);
+            String msg = ErrorMessageFormat.JOB_MAPPING_FAILED.format(ticket, jobRow.getRowMap(), missingFields);
             LOG.error(msg);
             throw new JobRequestFailedException(msg);
         }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncDruidSendsErrorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncDruidSendsErrorSpec.groovy
@@ -1,0 +1,151 @@
+package com.yahoo.bard.webservice.async
+
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobStatus.FAILURE
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobStatus.PENDING
+
+import com.yahoo.bard.webservice.util.GroovyTestUtils
+
+import spock.util.concurrent.AsyncConditions
+import spock.util.concurrent.PollingConditions
+
+/**
+ * Verifies that the job status is updated to error, and results links return the error message when Druid experiences
+ * an error.
+ */
+class AsyncDruidSendsErrorSpec extends AsyncFunctionalSpec {
+    /*
+        This executes the following requests, and expects the following responses. All caps are placeholders.
+             Send:
+                 http://localhost:9998/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=0
+             Receive:
+                 {
+                     "self": "http://localhost:9998/jobs/gregUUID",
+                     "userId": "greg",
+                     "ticket": "gregUUID",
+                     "results": "http://localhost:9998/jobs/gregUUID/results",
+                     "syncResults": "http://localhost:9998/jobs/gregUUID/results?asyncAfter=never",
+                     "dateCreated": "DATETIME",
+                     "dateUpdated": "SAME_DATETIME_AS_ABOVE",
+                     "status": "pending"
+                 }
+             Send:
+                 http://localhost:9998/jobs/gregUUID/results?asyncAfter=never
+             Receive:
+                {
+                    "status" : 500,
+                    "statusName" : "Internal Server Error",
+                    "reason" : "All the things have broken.",
+                    "description" : "All the things have broken.",
+                    "druidQuery" : null
+                }
+            Send:
+                 http://localhost:9998/jobs/gregUUID/results
+            Receive:
+                {
+                    "status" : 500,
+                    "statusName" : "Internal Server Error",
+                    "reason" : "All the things have broken.",
+                    "description" : "All the things have broken.",
+                    "druidQuery" : null
+                }
+
+            Send:
+                 http://localhost:9998/jobs/gregUUID
+            Receive:
+                {
+                     "self": "http://localhost:9998/jobs/gregUUID",
+                     "userId": "greg",
+                     "ticket": "gregUUID",
+                     "results": "http://localhost:9998/jobs/gregUUID/results",
+                     "syncResults": "http://localhost:9998/jobs/gregUUID/results?asyncAfter=never",
+                     "dateCreated": "DATETIME",
+                     "dateUpdated": "SAME_DATETIME_AS_ABOVE",
+                     "status": "failure"
+                }
+    */
+
+    static final String QUERY =
+            "http://localhost:9998/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=0"
+
+    static final String ERROR_MESSAGE = """{
+                        "status" : 500,
+                        "statusName" : "Internal Server Error",
+                        "reason" : "All the things have broken.",
+                        "description" : "All the things have broken.",
+                        "druidQuery" : null
+                    }"""
+
+    @Override
+    Map<String, Closure<String>> getResultsToTargetFunctions() {
+        [
+                data: { "data/shapes/day" },
+                //By querying the syncResults link first, we wait until the results are ready, thanks to the
+                //BroadcastChannel. So we have no race condition between the data request updating the job ticket, and
+                //the query for the job metadata
+                syncResults: { AsyncTestUtils.extractTargetFromField(it.data.readEntity(String), "syncResults") },
+                results: { AsyncTestUtils.extractTargetFromField(it.data.readEntity(String), "results") },
+                jobs: { AsyncTestUtils.buildTicketLookup(it.data.readEntity(String)) }
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Void>> getResultAssertions() {
+        [
+                data: {
+                    assert it.status == 202
+                    AsyncTestUtils.validateJobPayload(it.readEntity(String), QUERY, PENDING.name)
+                },
+                syncResults: {
+                    // However, there was a problem in the backend, and the job failed. So when we go to get the
+                    // results, we instead get the error status (500) of the error, along with an error message
+                    // describing the problem.
+                    assert it.status == 500
+                    assert GroovyTestUtils.compareJson(it.readEntity(String), ERROR_MESSAGE)
+                },
+                results: {
+                    // This returns the same results as syncResults, since the two only differ in how long they
+                    // wait for a response.
+                    assert it.status == 500
+                    assert GroovyTestUtils.compareJson(it.readEntity(String), ERROR_MESSAGE)
+                },
+                jobs: { response ->
+                    // The job metadata is the same as the metadata returned by the data endpoint, except the status is
+                    // failure rather than pending.
+                    //There is a small window between when the results are stored and the job row's status is updated.
+                    PollingConditions pollingConditions = new PollingConditions()
+                    pollingConditions.eventually {
+                        assert response.status == 200
+                        AsyncTestUtils.validateJobPayload(response.readEntity(String), QUERY, FAILURE.name)
+                    }
+                }
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Map<String, List<String>>>> getQueryParameters() {
+        [
+                data: {[
+                        metrics: ["height"],
+                        asyncAfter: ["0"],
+                        dateTime: ["2016-08-30/2016-08-31"]
+                ]},
+                syncResults: {
+                    AsyncTestUtils.extractQueryParameters(
+                            new URI(AsyncTestUtils.getJobFieldValue(it.data.readEntity(String), "syncResults"))
+                    )
+                },
+                results: {[:]},
+                jobs: {[:]},
+        ]
+    }
+
+    @Override
+    Closure<String> getFakeDruidResponse() {
+        return {"All the things have broken."}
+    }
+
+    @Override
+    int getDruidStatusCode() {
+        return 500
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncFunctionalSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncFunctionalSpec.groovy
@@ -1,0 +1,215 @@
+package com.yahoo.bard.webservice.async
+
+import com.yahoo.bard.webservice.application.JerseyTestBinder
+import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
+import com.yahoo.bard.webservice.table.availability.AvailabilityTestingUtils
+import com.yahoo.bard.webservice.web.endpoints.BaseDataServletComponentSpec
+import com.yahoo.bard.webservice.web.endpoints.DataServlet
+import com.yahoo.bard.webservice.web.endpoints.JobsServlet
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+
+import org.joda.time.Interval
+
+import spock.lang.Specification
+import spock.lang.Timeout
+
+import javax.validation.constraints.NotNull
+import javax.ws.rs.core.Response
+
+/**
+ * Serves as a base class for testing asynchronous processes.
+ *
+ * This test allows us to execute a series of queries one after the other, and use the results of previous queries to
+ * build subsequent queries.
+ * <p>
+ * As such, this spec expects a map of closures rather than a single target. The test will do something similar to, but
+ * not quite a reduction over this map. First, it will execute the first closure in the map (note that we are using the
+ * fact that Groovy's maps have a well-defined ordering) to get a target. We will make a request to the test server
+ * using that target (plus query parameters). Then we will take the result of that query (a Response), verify it, and
+ * pass it into the next closure, which will build the next target to make a request against. We will get the result,
+ * verify it, and then pass it and the result from the first request to the third closure to get the third target to
+ * execute, and so on.
+ * <p>
+ * The keys of the map are arbitrary, but must be consistent across the maps of target builders, the map of
+ * result verifiers, and the map of query parameters within a single specification. Essentially, the keys
+ * serve as names for each request.
+ * <p>
+ * Note that this test is expected to be used for testing asynchronous interactions, _not_ that Bard constructs the
+ * correct Druid query for a given request. For tests of that nature, see the {@link BaseDataServletComponentSpec}.
+ */
+@Timeout(30)
+abstract class AsyncFunctionalSpec extends Specification {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+
+    JerseyTestBinder jtb
+
+    /**
+     * Returns a map of closures, each of which transforms a map of named Responses into request targets.
+     * <p>
+     * The map keys (i.e. names) are arbitrary, but used to associate targets with query parameters and result
+     * validation routines.
+     * <p>
+     * Each closure is a function Map&ltString, Response&gt -> String that takes a map of named responses, and returns a
+     * target to make a request with.
+     *
+     * @return a map of closures that derives request targets from maps of named query Responses
+     */
+    abstract Map<String, Closure<String>> getResultsToTargetFunctions()
+
+    /**
+     * Returns a map of closures, each of which is an operation Response -> Void that takes a query response, and
+     * performs whatever validation on the Response that needs to be performed.
+     * <p>
+     * The key for each validation must correspond to the key of the target of the associated request.
+     *
+     * @return a map of closures that take a query result, and performs whatever validation needs to be performed.
+     */
+    abstract Map<String, Closure<Void>> getResultAssertions()
+
+    /**
+     * Get the map of closures generating query parameters for each target.
+     * <p>
+     * Each closure is a function Map&ltString, Response&gt -> Map&ltString, List&ltString&gt&gt that takes
+     * named Responses and returns the query parameters for the associated query.
+     * <p>
+     * The key for each query parameter generator must correspond to the key of the associated target
+     *
+     * @return The map of query parameters for each target.
+     */
+    abstract Map<String, Closure<Map<String, List<String>>>> getQueryParameters()
+
+    /**
+     * Returns the classes for the Jetty resources (i.e. servlets) that need to be set up in the test environment.
+     *
+     * @return An array of classes representing Jetty resources
+     */
+    Class<?>[] getResourceClasses() {
+        return [DataServlet.class, JobsServlet.class]
+    }
+
+    /**
+     * Returns the generator for the Druid response that should be returned by the backend
+     *
+     * @return The closure that generates the Druid response that should be returned by the test framework's Druid stub
+     */
+    abstract Closure<String> getFakeDruidResponse()
+
+    /**
+     * Returns the status code that the fake Druid should send when sending results back.
+     *
+     * @return The status code that the fake Druid should use when sending results back, defaults to 200 (OK)
+     */
+    int getDruidStatusCode() {
+        return 200
+    }
+
+    def setup() {
+        // Create the test web container to test the resources
+        jtb = buildTestBinder()
+
+        populatePhysicalTableAvailability()
+    }
+
+    /**
+     * Populates the interval availability of the physical tables.
+     * <p>
+     * By default, every Physical table believes that it has complete data from January 1st 2010 to December 31 2500.
+     */
+    void populatePhysicalTableAvailability() {
+        AvailabilityTestingUtils.populatePhysicalTableCacheIntervals(jtb, new Interval("2010-01-01/2500-12-31"))
+    }
+
+    def cleanup() {
+        // Release the test web container
+        jtb.tearDown()
+    }
+
+    JerseyTestBinder buildTestBinder() {
+        new JerseyTestBinder(getResourceClasses())
+    }
+
+    void validateJson(String json) {
+        MAPPER.readTree(json)
+    }
+
+    @Timeout(10)
+    def "The asynchronous workflow executes correctly"() {
+        given: "Initialize the backend with the fake Druid response"
+        injectDruidResponse(getFakeDruidResponse())
+
+        and: "The map of all previous responses"
+        Map<String, Response> previousResponses = [:]
+
+        and: "The closures that perform verification against the results"
+        Map<String, Closure<Void>> resultValidations = getResultAssertions()
+
+        and: "The query parameters for each request"
+        Map<String, Closure<Map<String, List<String>>>> queryParameters = getQueryParameters()
+
+        expect: "All the asynchronous interactions behave appropriately"
+        getResultsToTargetFunctions().each {interactionName, resultsToTarget ->
+            //First, we make a request.
+            Response response = makeAbstractRequest(
+                    // To make a request, we need the target (i.e. path), which may be constructed using responses from
+                    // previous requests
+                    resultsToTarget(previousResponses),
+                    // We also need any query parameters. So we extract the function
+                    // <Map, Response> -> Map<String, List<String>> with the same name as the current request-response
+                    // cycle from the queryParameters map, and use it to build the query parameters.
+                    queryParameters[interactionName](previousResponses)
+            )
+            response.bufferEntity()
+            // Once the response comes back, we need to validate it. So we pull out the appropriate response validation,
+            // and pass it the response.
+            resultValidations[interactionName](response)
+            previousResponses[interactionName] = response
+        }
+    }
+
+    /**
+     *  Injects the closure generating the fake Druid response into the Druid backend used by the test harness, if
+     *  applicable.
+     *
+     *  @param  druidResponse The fake response to be injected.
+     */
+    def injectDruidResponse(Closure<String> druidResponse) {
+        if (jtb.nonUiDruidWebService instanceof TestDruidWebService) {
+            int statusCode = getDruidStatusCode()
+            jtb.nonUiDruidWebService.statusCode = statusCode
+            if (statusCode == 200) {
+                jtb.nonUiDruidWebService.jsonResponse = druidResponse
+            } else {
+                jtb.nonUiDruidWebService.reasonPhrase = druidResponse.call()
+            }
+        }
+    }
+
+    /**
+     * Makes a request to the Druid backend.
+     *
+     * @param target  The request target
+     * @param queryParams The query parameters for the request, must be non-null
+     *
+     * @return The response from the Druid backend used by the harness
+     */
+    Response makeAbstractRequest(String target, @NotNull Map<String, List<String>> queryParameters) {
+        // Set target of call
+        if (queryParameters == null) {
+            throw new IllegalArgumentException("Query parameters not found for target $target. Please double-check " +
+                    "your map keys.")
+        }
+        def httpCall = jtb.getHarness().target(target)
+
+        // Add query params to call
+        queryParameters.each { String key, List<String> values ->
+            httpCall = httpCall.queryParam(key, values.join(","))
+        }
+
+        // Make the call
+        return httpCall.request().get()
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncInvalidApiRequest.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncInvalidApiRequest.groovy
@@ -1,0 +1,57 @@
+package com.yahoo.bard.webservice.async
+
+import com.yahoo.bard.webservice.util.GroovyTestUtils
+
+/**
+ * Verifies that when the user has a syntax error (or some other error that triggers an InvalidApiRequestException) that
+ * the error is returned immediately.
+ */
+class AsyncInvalidApiRequest extends AsyncFunctionalSpec {
+    /*
+        This executes the following requests, and expects the following responses. All caps are placeholders.
+             Send:
+                 http://localhost:9998/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&asyncAfter=0
+             Receive:
+                {
+                    "status": 400,
+                    "statusName": "Bad Request",
+                    "reason": "com.yahoo.bard.webservice.web.BadApiRequestException",
+                    "description": "Required parameter metrics is missing or empty. Use 'metrics=METRICNAME1,METRICNAME2' in the query string.",
+                    "druidQuery": null
+                }
+    */
+
+    String EXPECTED_ERROR_MESSAGE =
+            """{
+                    "status": 400,
+                    "statusName": "Bad Request",
+                    "reason": "com.yahoo.bard.webservice.web.BadApiRequestException",
+                    "description": "Required parameter metrics is missing or empty. Use 'metrics=METRICNAME1,METRICNAME2' in the query string.",
+                    "druidQuery": null
+            }"""
+
+    @Override
+    Map<String, Closure<String>> getResultsToTargetFunctions() {
+        [ data: { "data/shapes/day" } ]
+    }
+
+    @Override
+    Map<String, Closure<Void>> getResultAssertions() {
+        [ data: { assert GroovyTestUtils.compareJson(it.readEntity(String), EXPECTED_ERROR_MESSAGE) } ]
+    }
+
+    @Override
+    Map<String, Closure<Map<String, List<String>>>> getQueryParameters() {
+        [
+                data: { [
+                        asyncAfter: ["0"],
+                        dateTime: ["2016-08-30/2016-08-31"]
+                ] }
+        ]
+    }
+
+    @Override
+    Closure<String> getFakeDruidResponse() {
+        return {"I will never leave this curly prison."}
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncResultsNotReadySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncResultsNotReadySpec.groovy
@@ -1,0 +1,128 @@
+package com.yahoo.bard.webservice.async
+
+import com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField
+import com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobStatus
+
+import spock.lang.Timeout
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import javax.ws.rs.core.Response
+
+/**
+ * Verifies that if the result of an asynchronous query is not ready yet, then the user gets back the exact same payload
+ * from the jobs endpoint they received from the data endpoint.
+ */
+@Timeout(30)
+class AsyncResultsNotReadySpec extends AsyncFunctionalSpec {
+    /*
+        This executes the following requests, and expects the following responses. All caps are placeholders.
+             Send:
+                 http://localhost:9998/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=0
+             Receive:
+                 {
+                     "self": "http://localhost:9998/jobs/gregUUID",
+                     "userId": "greg",
+                     "ticket": "gregUUID",
+                     "results": "http://localhost:9998/jobs/gregUUID/results",
+                     "syncResults": "http://localhost:9998/jobs/gregUUID/results?asyncAfter=never",
+                     "dateCreated": "DATETIME",
+                     "dateUpdated": "SAME_DATETIME_AS_ABOVE",
+                     "status": "pending"
+                 }
+            Send:
+                 http://localhost:9998/jobs/gregUUID/results?asyncAfter=0
+            Receive:
+                SAME AS ABOVE
+            Send:
+                 http://localhost:9998/jobs/gregUUID
+            Receive:
+                SAME AS ABOVE
+    */
+
+    final CountDownLatch validationFinished = new CountDownLatch(3)
+
+    static final String QUERY =
+            "http://localhost:9998/data/shapes/day/color?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=0"
+
+    @Override
+    Map<String, Closure<String>> getResultsToTargetFunctions() {
+        [
+                data: {"data/shapes/day/color"},
+                jobs: {AsyncTestUtils.buildTicketLookup(it.data.readEntity(String))},
+                results: {payloads ->
+                    String dataPayload = payloads.data.readEntity(String)
+                    "jobs/${AsyncTestUtils.getJobFieldValue(dataPayload, DefaultJobField.JOB_TICKET.name)}/results"
+                }
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Void>> getResultAssertions() {
+        [
+                data: {Response response ->
+                    try {
+                        assert response.status == 202
+                        AsyncTestUtils.validateJobPayload(
+                                response.readEntity(String),
+                                QUERY,
+                                DefaultJobStatus.PENDING.name
+                        )
+                    } finally {
+                        validationFinished.countDown()
+                    }
+                },
+                jobs: {Response response ->
+                    try {
+                        assert response.status == 200
+                        //The jobs endpoint returns job metadata containing the same expected value as the data endpoint
+                        AsyncTestUtils.validateJobPayload(
+                                response.readEntity(String),
+                                QUERY,
+                                DefaultJobStatus.PENDING.name
+                        )
+                    } finally {
+                        validationFinished.countDown()
+                    }
+                },
+                results: {Response response ->
+                    try {
+                        assert response.status == 200
+                        //The results endpoint returns job metadata containing the same expected value as the data
+                        // endpoint
+                        AsyncTestUtils.validateJobPayload(
+                                response.readEntity(String),
+                                QUERY,
+                                DefaultJobStatus.PENDING.name
+                        )
+                    } finally {
+                        validationFinished.countDown()
+                    }
+                }
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Map<String, List<String>>>> getQueryParameters() {
+        [
+                data: {[
+                        metrics: ["height"],
+                        asyncAfter: ["0"],
+                        dateTime: ["2016-08-30/2016-08-31"]
+                ]},
+                jobs: {[:]},
+                results: { [ asyncAfter: ["0"] ] }
+        ]
+    }
+
+    @Override
+    Closure<String> getFakeDruidResponse() {
+        return {
+            //We don't want the backend to return until all the validation has been performed, to simulate the backend
+            //taking a while to respond.
+            validationFinished.await()
+            return "[]"
+        }
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncResultsReadySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncResultsReadySpec.groovy
@@ -1,0 +1,153 @@
+package com.yahoo.bard.webservice.async
+
+import com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobStatus
+import com.yahoo.bard.webservice.util.GroovyTestUtils
+
+import spock.util.concurrent.PollingConditions
+
+/**
+ * Verifies that when the results of an asynchronous request are ready, that the job status is updated to "success" and
+ * the results are accessible through both the {@code results} and {@code syncResults} links.
+ */
+class AsyncResultsReadySpec extends AsyncFunctionalSpec {
+    /*
+        This executes the following requests, and expects the following responses. All caps are placeholders.
+             Send:
+                 http://localhost:9998/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=0
+             Receive:
+                 {
+                     "self": "http://localhost:9998/jobs/gregUUID",
+                     "userId": "greg",
+                     "ticket": "gregUUID",
+                     "results": "http://localhost:9998/jobs/gregUUID/results",
+                     "syncResults": "http://localhost:9998/jobs/gregUUID/results?asyncAfter=never",
+                     "dateCreated": "DATETIME",
+                     "dateUpdated": "SAME_DATETIME_AS_ABOVE",
+                     "status": "pending"
+                 }
+             Send:
+                 http://localhost:9998/jobs/gregUUID/results?asyncAfter=never
+             Receive:
+                {
+                     "rows" : [
+                          {
+                            "dateTime" : "2016-08-30 00:00:00.000",
+                            "height" : 100
+                          }
+                     ]
+                }
+            Send:
+                 http://localhost:9998/jobs/gregUUID/results
+            Receive:
+                {
+                     "rows" : [
+                          {
+                            "dateTime" : "2016-08-30 00:00:00.000",
+                            "height" : 100
+                          }
+                     ]
+                }
+            Send:
+                 http://localhost:9998/jobs/gregUUID
+            Receive:
+                {
+                     "self": "http://localhost:9998/jobs/gregUUID",
+                     "userId": "greg",
+                     "ticket": "gregUUID",
+                     "results": "http://localhost:9998/jobs/gregUUID/results",
+                     "syncResults": "http://localhost:9998/jobs/gregUUID/results?asyncAfter=never",
+                     "dateCreated": "DATETIME",
+                     "dateUpdated": "SAME_DATETIME_AS_ABOVE",
+                     "status": "success"
+                }
+    */
+
+    static final String QUERY =
+            "http://localhost:9998/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=0"
+
+    @Override
+    Map<String, Closure<String>> getResultsToTargetFunctions() {
+        [
+                data: { "data/shapes/day" },
+                //By querying the syncResults link first, we wait until the results are ready, thanks to the
+                //BroadcastChannel. Thus, we wait until the results are ready before verifying that the job status
+                //has been updated correctly.
+                syncResults: { AsyncTestUtils.extractTargetFromField(it.data.readEntity(String), "syncResults") },
+                results: { AsyncTestUtils.extractTargetFromField(it.data.readEntity(String), "results") },
+                jobs: { AsyncTestUtils.buildTicketLookup(it.data.readEntity(String)) }
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Void>> getResultAssertions() {
+        [
+                data: {
+                    assert it.status == 202
+                    AsyncTestUtils.validateJobPayload(it.readEntity(String), QUERY, DefaultJobStatus.PENDING.name)
+                },
+                syncResults: {
+                    assert it.status == 200
+                    assert GroovyTestUtils.compareJson(it.readEntity(String), getExpectedApiResponse())
+                },
+                results: {
+                    assert it.status == 200
+                    assert GroovyTestUtils.compareJson(it.readEntity(String), getExpectedApiResponse())
+                },
+                jobs: { response ->
+                    PollingConditions pollingConditions = new PollingConditions()
+                    pollingConditions.eventually {
+                        assert response.status == 200
+                        AsyncTestUtils.validateJobPayload(
+                                response.readEntity(String),
+                                QUERY,
+                                DefaultJobStatus.SUCCESS.name
+                        )
+                    }
+                }
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Map<String, List<String>>>> getQueryParameters() {
+        [
+                data: {[
+                        metrics: ["height"],
+                        asyncAfter: ["0"],
+                        dateTime: ["2016-08-30/2016-08-31"]
+                ]},
+                syncResults: {
+                    AsyncTestUtils.extractQueryParameters(
+                            new URI(AsyncTestUtils.getJobFieldValue(it.data.readEntity(String), "syncResults"))
+                    )
+                },
+                results: {[:]},
+                jobs: {[:]},
+        ]
+    }
+
+    @Override
+    Closure<String> getFakeDruidResponse() {
+        return {
+            """[
+                    {
+                        "version" : "v1",
+                        "timestamp": "2016-08-30",
+                        "result" : {
+                            "height" : 100
+                        }
+                    }
+            ]"""
+        }
+    }
+
+    String getExpectedApiResponse() {
+        """{
+              "rows" : [
+                  {
+                    "dateTime" : "2016-08-30 00:00:00.000",
+                    "height" : 100
+                  }
+              ]
+        }"""
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncTestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncTestUtils.groovy
@@ -1,0 +1,115 @@
+package com.yahoo.bard.webservice.async
+
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.DATE_CREATED
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.DATE_UPDATED
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.JOB_TICKET
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.QUERY
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.STATUS
+import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.USER_ID
+
+import com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField
+import com.yahoo.bard.webservice.util.GroovyTestUtils
+import com.yahoo.bard.webservice.util.JsonSlurper
+
+import org.joda.time.DateTime
+
+import javax.ws.rs.core.UriBuilder
+
+/**
+ * Contains a collection of functions to aid in testing asynchronous
+ * queries. Particularly around parsing asynchronous payloads and extracting
+ * from them the information needed by subsequent requests.
+ */
+class AsyncTestUtils {
+
+   static final JsonSlurper JSON_PARSER = new JsonSlurper()
+
+   /**
+    * Given a JSON representation of the job metadata sent to the user, and a job payload field, returns the value
+    * at that field in the specified job metadata.
+    *
+    * @param response  The job information to extract the field from
+    * @param field  The field whose data is of interest
+    *
+    * @return The value of the specified field in the specified job payload
+    */
+   static String getJobFieldValue(String response, String field) {
+      JSON_PARSER.parseText(response)[field]
+   }
+
+   /**
+    * Given a JSON representation of the job information sent to the user, returns the URI path for a point lookup of
+    * that job's metadata.
+    *
+    * @param response  The job information to extract the ticket from
+    *
+    * @return The target to do a point lookup of that job
+    */
+   static String buildTicketLookup(String response) {
+        "jobs/${getJobFieldValue(response, JOB_TICKET.name)}"
+   }
+
+   /**
+    * Validates that the passed in asynchronous payload has all of the appropriate fields with reasonably correct
+    * values.
+    *
+    * @param asynchronousPayload  The payload to verify
+    * @param query  The query that triggered the job
+    * @param status  The job's expected status
+    */
+   static void validateJobPayload(String asynchronousPayload, String query, String status) {
+      Map payloadJson = JSON_PARSER.parseText(asynchronousPayload)
+      //The test payload builder always sets the user id to greg in TestBinderFactory::buildJobRowBuilder.
+      assert payloadJson[USER_ID.name] == "greg"
+      assert payloadJson[JOB_TICKET.name].startsWith(payloadJson[USER_ID.name])
+      assert payloadJson[STATUS.name] == status
+      assert GroovyTestUtils.compareURL(payloadJson[QUERY.name] as String, query)
+      assert GroovyTestUtils.compareURL(
+              payloadJson["results"],
+              "http://localhost:9998/jobs/${payloadJson[JOB_TICKET.name]}/results"
+      )
+      assert GroovyTestUtils.compareURL(
+              payloadJson["syncResults"],
+              "http://localhost:9998/jobs/${payloadJson[JOB_TICKET.name]}/results&asyncAfter=never"
+      );
+      //Validate that the dates are valid dates
+      DateTime.parse(payloadJson[DATE_CREATED.name])
+      DateTime.parse(payloadJson[DATE_UPDATED.name])
+   }
+
+   /**
+    * Returns the target (i.e. path) of an HttpRequest.
+    *
+    * @param httpRequest  The request to turn into a target
+    *
+    * @return The path component of the request
+    */
+   static String extractTarget(String httpRequest) {
+       new URI(httpRequest).path
+   }
+
+    /**
+     * Returns the target of the link stored in the specified field of the specified asynchronous payload.
+     *
+     * @param jobMetadata  The JSON String from which to extract the results link
+     * @param jobField  The JSON field in the jobMetadata containing the link
+     */
+   static String extractTargetFromField(String jobMetadata, String jobField) {
+      extractTarget(getJobFieldValue(jobMetadata, jobField))
+   }
+
+   /**
+    * Given a URI representing a query, extracts the query parameters as a map of Strings (the parameter names) to
+    * lists of Strings (the parameter values).
+    *
+    * @param query  The query whose parameters should be extracted
+    *
+    * @return The map of query parameters
+    */
+   static Map<String, List<String>> extractQueryParameters(URI query) {
+      query.query.split("&").collectEntries { parameter ->
+         def (String key, String value) = parameter.tokenize("=")
+         return [(key): value.tokenize(",")]
+      }
+   }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/jobs/payloads/DefaultJobPayloadBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/jobs/payloads/DefaultJobPayloadBuilderSpec.groovy
@@ -48,6 +48,7 @@ class DefaultJobPayloadBuilderSpec extends Specification {
                 status: "success",
                 jobTicket: "ticket1",
                 dateCreated: "2016-01-01",
+                dateUpdated: "2016-01-01",
                 userId: "momo"
         ]
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataServletSpec.groovy
@@ -43,7 +43,7 @@ class PartialDataServletSpec extends Specification {
 
     def setup() {
         jtb = new JerseyTestBinder(DataServlet.class)
-        jtb.nonUiDruidWebService.jsonResponse = response
+        jtb.nonUiDruidWebService.jsonResponse = {response}
 
         Interval interval = new Interval("2014-05-01/2014-06-01")
         AvailabilityTestingUtils.populatePhysicalTableCacheIntervals(jtb, interval)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/cache/MemTupleDataCacheSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/cache/MemTupleDataCacheSpec.groovy
@@ -142,7 +142,7 @@ class MemTupleDataCacheSpec extends Specification {
            }"""
 
         when: "initial request"
-        jtb.nonUiDruidWebService.jsonResponse = response
+        jtb.nonUiDruidWebService.jsonResponse = {response}
 
         String result = jtb.getHarness().target("data/shapes/day/color")
             .queryParam("metrics","width")
@@ -153,7 +153,7 @@ class MemTupleDataCacheSpec extends Specification {
         GroovyTestUtils.compareJson(result, expected)
 
         when: "subsequent request"
-        jtb.nonUiDruidWebService.jsonResponse = response
+        jtb.nonUiDruidWebService.jsonResponse = {response}
 
         result = jtb.getHarness().target("data/shapes/day/color")
             .queryParam("metrics","width")
@@ -164,7 +164,7 @@ class MemTupleDataCacheSpec extends Specification {
         GroovyTestUtils.compareJson(result, expected)
 
         when: "druid result changes only value"
-        jtb.nonUiDruidWebService.jsonResponse = "[]"
+        jtb.nonUiDruidWebService.jsonResponse = {"[]"}
 
         result = jtb.getHarness().target("data/shapes/day/color")
             .queryParam("metrics","width")
@@ -176,7 +176,7 @@ class MemTupleDataCacheSpec extends Specification {
 
         when: "druid result changes both value and segment metadata"
         defaultCheckSum = ~expectedCheckSum
-        jtb.nonUiDruidWebService.jsonResponse = "[]"
+        jtb.nonUiDruidWebService.jsonResponse = {"[]"}
         expected = """{ "rows":[] }"""
 
         result = jtb.getHarness().target("data/shapes/day/color")
@@ -190,7 +190,7 @@ class MemTupleDataCacheSpec extends Specification {
         when: "subsequent queries after change and first cache miss"
         expectedCheckSum = ~expectedCheckSum
         defaultCheckSum = expectedCheckSum
-        jtb.nonUiDruidWebService.jsonResponse = "[]"
+        jtb.nonUiDruidWebService.jsonResponse = {"[]"}
         expected = """{ "rows":[] }"""
 
         result = jtb.getHarness().target("data/shapes/day/color")
@@ -202,7 +202,7 @@ class MemTupleDataCacheSpec extends Specification {
         GroovyTestUtils.compareJson(result, expected)
 
         when: "force cache bypass"
-        jtb.nonUiDruidWebService.jsonResponse = "[]"
+        jtb.nonUiDruidWebService.jsonResponse = {"[]"}
 
         result = jtb.getHarness().target("data/shapes/day/color")
             .queryParam("metrics","width")

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/cache/MemcachedCacheSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/cache/MemcachedCacheSpec.groovy
@@ -141,7 +141,7 @@ class MemcachedCacheSpec extends Specification {
            }"""
 
         when: "initial request"
-        jtb.nonUiDruidWebService.jsonResponse = response
+        jtb.nonUiDruidWebService.jsonResponse = {response}
 
         String result = jtb.getHarness().target("data/shapes/day/color")
             .queryParam("metrics","width")
@@ -152,7 +152,7 @@ class MemcachedCacheSpec extends Specification {
         GroovyTestUtils.compareJson(result, expected)
 
         when: "Change druid result"
-        jtb.nonUiDruidWebService.jsonResponse = "[]"
+        jtb.nonUiDruidWebService.jsonResponse = {"[]"}
 
         result = jtb.getHarness().target("data/shapes/day/color")
             .queryParam("metrics","width")
@@ -163,7 +163,7 @@ class MemcachedCacheSpec extends Specification {
         GroovyTestUtils.compareJson(result, expected)
 
         when: "force cache bypass"
-        jtb.nonUiDruidWebService.jsonResponse = "[]"
+        jtb.nonUiDruidWebService.jsonResponse = {"[]"}
 
         expected = """{ "rows":[] }"""
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoaderSpec.groovy
@@ -139,7 +139,7 @@ class DataSourceMetadataLoaderSpec extends Specification {
         metadataService = jtb.testBinderFactory.getDataSourceMetaDataService()
         dimensionDict = jtb.configurationLoader.getDimensionDictionary()
         tableDict = jtb.configurationLoader.getPhysicalTableDictionary()
-        druidWS.jsonResponse = fullDataSourceMetadataJson
+        druidWS.jsonResponse = {fullDataSourceMetadataJson}
 
         expectedIntervalsMap = [:]
         dimensions123.each {
@@ -182,7 +182,7 @@ class DataSourceMetadataLoaderSpec extends Specification {
                 druidWS,
                 MAPPERS.getMapper()
         )
-        druidWS.jsonResponse = gappyDataSourceMetadataJson
+        druidWS.jsonResponse = {gappyDataSourceMetadataJson}
         PhysicalTable table = Mock(PhysicalTable)
         DataSourceMetadata capture
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentMetadataLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentMetadataLoaderSpec.groovy
@@ -118,7 +118,7 @@ class SegmentMetadataLoaderSpec extends Specification {
                 }
         }
         """
-        druidWS.jsonResponse = json
+        druidWS.jsonResponse = {json}
 
     }
 
@@ -135,7 +135,7 @@ class SegmentMetadataLoaderSpec extends Specification {
     def "Test segment metadata can deserialize JSON correctly"() {
         setup:
         SegmentMetadataLoader loader = new SegmentMetadataLoader(tableDict, dimensionDict, druidWS, MAPPER)
-        druidWS.jsonResponse = gappySegmentMetadataJson
+        druidWS.jsonResponse = {gappySegmentMetadataJson}
         PhysicalTable table = Mock(PhysicalTable)
         SegmentMetadata capture
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/JobsApiRequestSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/JobsApiRequestSpec.groovy
@@ -98,6 +98,7 @@ class JobsApiRequestSpec extends Specification {
                 status : "success",
                 jobTicket : "ticket1",
                 dateCreated : "2016-01-01",
+                dateUpdated: "2016-01-01",
                 userId : "momo"
         ]
 
@@ -284,6 +285,7 @@ class JobsApiRequestSpec extends Specification {
                 self : "https://localhost:9998/v1/jobs/1",
                 status : "pending",
                 dateCreated : "0001-04-29T00:00:00.000Z",
+                dateUpdated : "0001-04-30T00:00:00.000Z",
                 userId : "Number 1"
         ]
 
@@ -295,6 +297,7 @@ class JobsApiRequestSpec extends Specification {
                 self : "https://localhost:9998/v1/jobs/2",
                 status : "pending",
                 dateCreated : "0002-04-29T00:00:00.000Z",
+                dateUpdated : "0002-04-30T00:00:00.000Z",
                 userId : "Number 2"
         ]
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
@@ -59,6 +59,10 @@ abstract class BaseDataServletComponentSpec extends Specification {
 
     String getFakeDruidResponse() { "[]" }
 
+    Closure<String> getFakeDruidResponseClosure() {
+        return { getFakeDruidResponse() }
+    }
+
 
     def setup() {
         // Create the test web container to test the resources
@@ -114,7 +118,7 @@ abstract class BaseDataServletComponentSpec extends Specification {
         validateFakeDruidResponse(getFakeDruidResponse())
         validateExpectedApiResponse(getExpectedApiResponse())
 
-        injectDruidResponse(getFakeDruidResponse())
+        injectDruidResponse(getFakeDruidResponseClosure())
 
         when: "We send a request"
         Response response = makeAbstractRequest()
@@ -138,15 +142,28 @@ abstract class BaseDataServletComponentSpec extends Specification {
         GroovyTestUtils.compareJson(result, expectedResult, sortStrategy)
     }
 
+
     /**
-     *  Injects the fake Druid response into the Druid backend used by the test harness, if applicable.
+     *  Injects the fake Druid response into the Druid backend used by the test harness, if
+     *  applicable.
      *
      *  @param  druidResponse The fake response to be injected.
      */
-    def injectDruidResponse(String druidResponse) {
+    void injectDruidResponse(String druidResponse) {
+        injectDruidResponse {druidResponse}
+    }
+
+    /**
+     *  Injects the closure generating the fake Druid response into the Druid backend used by the test harness, if
+     *  applicable.
+     *
+     *  @param  druidResponse The closure generating the fake response to be injected.
+     */
+    void injectDruidResponse(Closure<String> druidResponse) {
         if (jtb.nonUiDruidWebService instanceof TestDruidWebService) {
             jtb.nonUiDruidWebService.jsonResponse = druidResponse
         }
+
     }
 
     /*

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
@@ -142,7 +142,6 @@ abstract class BaseDataServletComponentSpec extends Specification {
         GroovyTestUtils.compareJson(result, expectedResult, sortStrategy)
     }
 
-
     /**
      *  Injects the fake Druid response into the Druid backend used by the test harness, if
      *  applicable.

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
@@ -138,7 +138,7 @@ class ErrorDataServletSpec extends Specification {
         setup:
         DruidServiceConfig oldConfig = nonUiTestWebService.serviceConfig
         nonUiTestWebService.serviceConfig = new DruidServiceConfig("Non-Ui Broker", oldConfig.url, 123, oldConfig.priority)
-        nonUiTestWebService.jsonResponse = standardGoodDruidResponse
+        nonUiTestWebService.jsonResponse = {standardGoodDruidResponse}
         String expectedDruidQuery = standardGoodDruidQuery
 
         expect:
@@ -803,7 +803,7 @@ class ErrorDataServletSpec extends Specification {
 
     def "Test empty result returns correct 200 result"() {
         setup:
-        nonUiTestWebService.jsonResponse = "[]"
+        nonUiTestWebService.jsonResponse = {"[]"}
         nonUiTestWebService.weightResponse = "[]"
 
         // create 10 dimensionRows per dimension to get past worst case estimate

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/JobsServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/JobsServletSpec.groovy
@@ -32,6 +32,7 @@ class JobsServletSpec extends Specification {
                 "status": "success",
                 "jobTicket": "ticket1",
                 "dateCreated": "2016-01-01",
+                "dateUpdated": "2016-01-01",
                 "userId": "momo"
         }"""
 
@@ -49,6 +50,7 @@ class JobsServletSpec extends Specification {
               "jobs": [
                 {
                   "dateCreated": "2016-01-01",
+                  "dateUpdated": "2016-01-01",
                   "jobTicket": "ticket1",
                   "query": "https://localhost:9998/v1/data/QUERY",
                   "results": "http://localhost:9998/jobs/ticket1/results",
@@ -118,6 +120,7 @@ class JobsServletSpec extends Specification {
                 "status": "pending",
                 "jobTicket": "ticket2",
                 "dateCreated": "2016-01-01",
+                "dateUpdated": "2016-01-01",
                 "userId": "dodo"
         }"""
 
@@ -160,11 +163,11 @@ class JobsServletSpec extends Specification {
 
     def "/jobs endpoint returns the payload for all the jobs in the ApiJobStore"() {
         setup:
-
         String expectedResponse = """
                {"jobs":[
                         {
                             "dateCreated":"2016-01-01",
+                            "dateUpdated":"2016-01-01",
                             "jobTicket":"ticket1",
                             "query":"https://localhost:9998/v1/data/QUERY",
                             "results":"http://localhost:9998/jobs/ticket1/results",
@@ -175,6 +178,7 @@ class JobsServletSpec extends Specification {
                         },
                         {
                             "dateCreated":"2016-01-01",
+                            "dateUpdated":"2016-01-01",
                             "jobTicket":"ticket2",
                             "query":"https://localhost:9998/v1/data/QUERY",
                             "results":"http://localhost:9998/jobs/ticket2/results",
@@ -185,6 +189,7 @@ class JobsServletSpec extends Specification {
                         },
                         {
                             "dateCreated": "2016-01-01",
+                            "dateUpdated":"2016-01-01",
                             "jobTicket": "ticket3p",
                             "query": "https://localhost:9998/v1/data/QUERY",
                             "results": "http://localhost:9998/jobs/ticket3p/results",
@@ -209,6 +214,7 @@ class JobsServletSpec extends Specification {
         String expectedResponse = """{"jobs":[
                                         {
                                             "dateCreated":"2016-01-01",
+                                            "dateUpdated":"2016-01-01",
                                             "jobTicket":"ticket1",
                                             "query":"https://localhost:9998/v1/data/QUERY",
                                             "results":"http://localhost:9998/jobs/ticket1/results",
@@ -235,7 +241,6 @@ class JobsServletSpec extends Specification {
     }
 
     def "jobs/ticket3p/results returns the number of results we requested through pagination parameters"() {
-        setup:
         when: "We send a request for the first row from the results"
         String result1 = makeRequest("/jobs/ticket3p/results", [asyncAfter: ["5"], perPage: [1], page: [1]])
 


### PR DESCRIPTION
Adds the functional tests for asynchronous queries.

In order to support this, I had to slightly modify the TestDruidServlet to have a `Producer<String>` that generates a fake Druid response on demand, rather than having the Druid response directly. This was needed to support delaying the Druid response, so that we could test the path where results aren't yet ready from the backend.

The base spec for the asynchronous queries is rather complex, and I still don't think I explained it well. Suggestions on improving the documentation for that test are especially welcome.
