### PR TITLE
Synchronous queries are no longer stored in ApiJobStore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ Current
 
 ### Fixed:
 
+- [Fixes a bug where job metadata was being stored in the `ApiJobStore` even when the results came back synchronously](https://github.com/yahoo/fili/pull/49)
+  * The workflow that updates the job's metadata with `success` was running even when the query was synchronous. That 
+    update also caused the ticket to be stored in the `ApiJobStore`.
+  * The delay operator didn't stop the "update" workflow from executing because it viewed an `Observable::onCompleted`
+    call as a message for the purpose of the delay. Since the two observables that that the metadata update gated on are
+    empty when the query is synchronous, the "update metadata" workflow was being triggered every time.
+  * The delay operator was replaced by `zipWith` as a gating mechanism.
+    
 - [#45, removing sorting from weight check queries](https://github.com/yahoo/fili/pull/46)
 
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/SynchronousQueriesAreNotStoredSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/SynchronousQueriesAreNotStoredSpec.groovy
@@ -1,0 +1,47 @@
+package com.yahoo.bard.webservice.async
+
+import com.yahoo.bard.webservice.util.JsonSlurper
+
+/**
+ * Verifies that synchronous queries are not stored in the JobStore.
+ */
+class SynchronousQueriesAreNotStoredSpec extends AsyncFunctionalSpec {
+    @Override
+    Map<String, Closure<String>> getResultsToTargetFunctions() {
+        return [
+                data: {"data/shapes/day"},
+                jobs: {"jobs"}
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Void>> getResultAssertions() {
+        return [
+                data: {assert it.status == 200},
+                jobs: {
+                    assert !new JsonSlurper().parseText(it.readEntity(String)).jobs
+                }
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Map<String, List<String>>>> getQueryParameters() {
+        return [
+                data: {[
+                        metrics: ["height"],
+                        asyncAfter: ["never"],
+                        dateTime: ["2016-08-30/2016-08-31"]
+                ]},
+                jobs: {[
+                        //'greg' is the UserId hard-coded in TestBinderFactory::buildJobRowBuilder and used for
+                        //all queries created in the test environment.
+                        filters: ["userId-eq[greg]"]
+                ]}
+        ]
+    }
+
+    @Override
+    Closure<String> getFakeDruidResponse() {
+        return {"[]"}
+    }
+}


### PR DESCRIPTION
-- The `delay` operator considers `Observable::onCompleted` to be an
"emitted item." Therefore, the job row was still being stored in the
ApiJobStore even when the query was synchronous.

--This has been fixed by replacing `delay` with a subscription, and/or
zip when appropriate.