### PR TITLE
Corrected bug with Fili sub-module dependency specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Current
 
 ### Changed:
 
+- Corrected bug with Fili sub-module dependency specification
+  * Dependency versions are now set via a fixed property at deploy time, rather than relying on `project.version`
+
 - Cleaned up dependencies in pom files
   * Moved version management of dependencies up to the parent Pom's dependency management section
   * Cleaned up the parent Pom's dependency section to only be those dependencies that truly _every_ sub-project should 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ Current
 
 ### Fixed:
 
+- [Fixes a bug where job metadata was being stored in the `ApiJobStore` even when the results came back synchronously](https://github.com/yahoo/fili/pull/49)
+  * The workflow that updates the job's metadata with `success` was running even when the query was synchronous. That 
+    update also caused the ticket to be stored in the `ApiJobStore`.
+  * The delay operator didn't stop the "update" workflow from executing because it viewed an `Observable::onCompleted`
+    call as a message for the purpose of the delay. Since the two observables that that the metadata update gated on are
+    empty when the query is synchronous, the "update metadata" workflow was being triggered every time.
+  * The delay operator was replaced by `zipWith` as a gating mechanism.
+    
 - [#45, removing sorting from weight check queries](https://github.com/yahoo/fili/pull/46)
 
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/SynchronousQueriesAreNotStoredSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/SynchronousQueriesAreNotStoredSpec.groovy
@@ -1,0 +1,47 @@
+package com.yahoo.bard.webservice.async
+
+import com.yahoo.bard.webservice.util.JsonSlurper
+
+/**
+ * Verifies that synchronous queries are not stored in the JobStore.
+ */
+class SynchronousQueriesAreNotStoredSpec extends AsyncFunctionalSpec {
+    @Override
+    Map<String, Closure<String>> getResultsToTargetFunctions() {
+        return [
+                data: {"data/shapes/day"},
+                jobs: {"jobs"}
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Void>> getResultAssertions() {
+        return [
+                data: {assert it.status == 200},
+                jobs: {
+                    assert !new JsonSlurper().parseText(it.readEntity(String)).jobs
+                }
+        ]
+    }
+
+    @Override
+    Map<String, Closure<Map<String, List<String>>>> getQueryParameters() {
+        return [
+                data: {[
+                        metrics: ["height"],
+                        asyncAfter: ["never"],
+                        dateTime: ["2016-08-30/2016-08-31"]
+                ]},
+                jobs: {[
+                        //'greg' is the UserId hard-coded in TestBinderFactory::buildJobRowBuilder and used for
+                        //all queries created in the test environment.
+                        filters: ["userId-eq[greg]"]
+                ]}
+        ]
+    }
+
+    @Override
+    Closure<String> getFakeDruidResponse() {
+        return {"[]"}
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
+
+        <version.fili>0.6-SNAPSHOT</version.fili>
+
         <version.slf4j>1.7.12</version.slf4j>
         <version.servlet>3.1.0</version.servlet>
         <version.jersey>2.22</version.jersey>
@@ -121,22 +124,22 @@
             <dependency>
                 <groupId>com.yahoo.fili</groupId>
                 <artifactId>fili-system-config</artifactId>
-                <version>${project.version}</version>
+                <version>${version.fili}</version>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.fili</groupId>
                 <artifactId>fili-core</artifactId>
-                <version>${project.version}</version>
+                <version>${version.fili}</version>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.fili</groupId>
                 <artifactId>fili</artifactId>
-                <version>${project.version}</version>
+                <version>${version.fili}</version>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.fili</groupId>
                 <artifactId>fili-core</artifactId>
-                <version>${project.version}</version>
+                <version>${version.fili}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>

--- a/travis/deploy.bash
+++ b/travis/deploy.bash
@@ -15,6 +15,12 @@ if [[ ${MATCHING_TAG} != "" ]]; then
         echo "ERROR Unable to set version via Maven. Aborting publication."
         exit ${MAVEN_RETURN_CODE}
     fi
+    mvn versions:update-property -Dproperty=version.fili -DnewVersion=$(git describe) -DgenerateBackupPoms=false
+    MAVEN_RETURN_CODE=$?
+    if [[ ${MAVEN_RETURN_CODE} -ne 0 ]]; then
+        echo "ERROR Unable to update property via Maven. Aborting publication."
+        exit ${MAVEN_RETURN_CODE}
+    fi
 
     echo "INFO Deploying: "
     mvn deploy --settings travis/bintray-settings.xml
@@ -32,7 +38,7 @@ fi
 mvn verify
 MAVEN_RETURN_CODE=$?
 if [[ ${MAVEN_RETURN_CODE} -ne 0 ]]; then
-    echo "ERROR Maven did not succeed."
+    echo "ERROR Maven verify did not succeed."
     exit ${MAVEN_RETURN_CODE}
 fi
 


### PR DESCRIPTION
Dependency versions are now set via a fixed property at deploy time, rather than
relying on `project.version`