### PR TITLE
Clean up build plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Current
 
 ### Changed:
 
+- Clean up build plugins
+  * Move some plugin configs up to `pluginManagement`
+  * Make `fili-core` publish test javadocs
+  * Default source plugin to target `jar-no-fork` instead of `jar`
+  * Default javadoc plugin to target `javadoc-no-fork` as well as `jar`
+  * Move some versions up to `pluginManagement`
+  * Remove overly (and un-usedly) specified options in surfire plugin configs
+  * Make all projects pull in the `source` plugin
+
 - Corrected bug with Fili sub-module dependency specification
   * Dependency versions are now set via a fixed property at deploy time, rather than relying on `project.version`
 

--- a/fili-core/pom.xml
+++ b/fili-core/pom.xml
@@ -229,6 +229,19 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-test-javadocs</id>
+                        <goals>
+                            <goal>test-javadoc-no-fork</goal>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -511,7 +511,7 @@
                         <execution>
                             <id>attach-sources</id>
                             <goals>
-                                <goal>jar</goal>
+                                <goal>jar-no-fork</goal>
                             </goals>
                         </execution>
                     </executions>
@@ -551,6 +551,7 @@
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <version>${maven-site-plugin-version}</version>
                     <configuration>
                         <skipDeploy>true</skipDeploy>
                         <topSiteURL>scm:git:git@github.com:yahoo/fili.git</topSiteURL>
@@ -577,6 +578,7 @@
                         <execution>
                             <id>attach-javadocs</id>
                             <goals>
+                                <goal>javadoc-no-fork</goal>
                                 <goal>jar</goal>
                             </goals>
                         </execution>
@@ -625,54 +627,58 @@
                     <version>2.16</version>
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        <!-- This is done to override the testNG dependency from
-                            the parent POM that gets in the way of jUnit -->
-                        <properties combine.self="override"/>
                         <includes>
                             <include>%regex[.*Spec.*]</include>
                         </includes>
-                        <!-- ref environment variables -->
-                        <systemPropertyVariables>
-                            <ENVIRONMENT_TYPE>${env.ENVIRONMENT_TYPE}</ENVIRONMENT_TYPE>
-                        </systemPropertyVariables>
-                        <!-- java lib path -->
-                        <forkMode>once</forkMode>
-                        <argLine>-ea -Djava.library.path=/home/y/lib64</argLine>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>cobertura-maven-plugin</artifactId>
+                    <version>2.7</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin-version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin-version}</version>
+                    <configuration>
+                        <source>${source_jdk_version}</source>
+                        <target>${target_jdk_version}</target>
+                        <showDeprecation>true</showDeprecation>
+                        <showWarnings>true</showWarnings>
+                        <optimize>true</optimize>
+                        <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven-jar-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin-version}</version>
-                <configuration>
-                    <source>${source_jdk_version}</source>
-                    <target>${target_jdk_version}</target>
-                    <showDeprecation>true</showDeprecation>
-                    <showWarnings>true</showWarnings>
-                    <optimize>true</optimize>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5</version>
                 <configuration>
-                    <!-- During release:perform, enable the "distPush" profile -->
-                    <releaseProfiles>pushDist</releaseProfiles>
                     <goals>install</goals>
                     <useReleaseProfile>false</useReleaseProfile>
                 </configuration>
@@ -702,30 +708,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <reportsDirectory>${session.executionRootDirectory}/target/surefire-reports</reportsDirectory>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <!-- This is done to override the testNG dependency from
-                        the parent POM that gets in the way of jUnit -->
-                    <properties combine.self="override"/>
-                    <argLine>-ea
-                        -Dspring.profiles.active=${profiles.active}
-                    </argLine>
-                    <includes>
-                        <include>%regex[.*Spec.*]</include>
-                    </includes>
-                    <!-- ref environment variables -->
-                    <systemPropertyVariables>
-                        <ENVIRONMENT_TYPE>${env.ENVIRONMENT_TYPE}</ENVIRONMENT_TYPE>
-                    </systemPropertyVariables>
-                    <!-- java lib path -->
-                    <forkMode>once</forkMode>
-                    <argLine>-Djava.library.path=/home/y/lib64</argLine>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>${maven-site-plugin-version}</version>
                 <executions>
                     <execution>
                         <id>attach-site-descriptor</id>
@@ -805,6 +793,7 @@
                                 <reportSet>
                                     <reports>
                                         <report>javadoc-no-fork</report>
+                                        <report>test-javadoc-no-fork</report>
                                     </reports>
                                     <configuration>
                                         <aggregate>true</aggregate>


### PR DESCRIPTION
- Move some plugin configs up to `pluginManagement`
- Make `fili-core` publish test javadocs
- Default source plugin to target `jar-no-fork` instead of `jar`
- Default javadoc plugin to target `javadoc-no-fork` as well as `jar`
- Move some versions up to `pluginManagement`
- Remove overly (and un-usedly) specified options in surfire plugin configs
- Make all projects pull in the `source` plugin

Note: Targeted at `master`, but it builds on another PR. The initial commit is from the other PR.