### PR TITLE
Eliminated unwanted warning about logical name to physical name mappi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@ Jobs resource. Here are the highlights of what's in this release:
 
 ### Changed:
 
+- Removed `physicalName` lookup for metrics in `TableUtils::getColumnNames` to remove spurious warnings
+     * Metrics are not mapped like dimensions are. Dimensions are aliased per physical table and metrics are aliazed per logical table.
+     * Logical metric is mapped with one or many physical metrics. Same look up logic for dimension and metrics doesn't make sense.
+
 #### Jobs:
 
 - [HashPreResponseStore moved to `test` root directory.](https://github.com/yahoo/fili/pull/39)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
@@ -38,9 +38,7 @@ public class TableUtils {
                 getDimensions(request, query)
                         .map(Dimension::getApiName)
                         .map(table::getPhysicalColumnName),
-                query.getDependentFieldNames()
-                        .stream()
-                        .map(table::getPhysicalColumnName)
+                query.getDependentFieldNames().stream()
         ).flatMap(Function.identity()).collect(Collectors.toSet());
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/TableUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/TableUtilsSpec.groovy
@@ -89,4 +89,17 @@ class TableUtilsSpec extends  Specification {
         expect:
         TableUtils.getColumnNames(request, query, new PhysicalTable("", DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:])) == [d1Name, metric1, metric2, metric3] as Set
     }
+
+    def "logicalName to physicalName mapping not required for metrics" () {
+        setup:
+        request.dimensions >> []
+        request.filterDimensions >> []
+        query.metricDimensions >> []
+        query.dependentFieldNames >> ([metric1] as Set)
+        PhysicalTable physicalTable = Mock(PhysicalTable)
+        0 * physicalTable.getPhysicalColumnName(_)
+
+        expect:
+        TableUtils.getColumnNames(request, query, physicalTable) == [metric1] as Set
+    }
 }


### PR DESCRIPTION
We don't need to look for logical name to physical name mapping for metrics.  This mapping was causing unwanted warnings in log like.

"No mapping found for logical name: '<metricName>' to physical name (will use logical name as physical name). This is unexpected and should not happen for properly configured dimensions."

Hence removed that lookup.

