### PR TITLE
Support custom Druid queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Current
 
 ### Changed:
 
+- [Fili now supports custom Druid query types](https://github.com/yahoo/fili/pull/57)
+    * `QueryType` has been turned into an interface, backed by an enum `DefaultQueryType`.
+        - The default implementations of `DruidResponseParser` `DruidQueryBuilder`, `WeightEvaluationQuery` and
+          `TestDruidWebService` only support `DefaultQueryType`.
+    * `DruidResponseParser` is now injectable by overriding `AbstractBinderFactory::buildDruidResponseParser` method.
+    * `DruidQueryBuilder` is now injectable by overriding `AbstractBinderFactory::buildDruidQueryBuilder` method.
+
 - [Updated commons-collections4 dependency from 4.0 to 4.1 to address a security vulnerability in the library.](https://github.com/yahoo/fili/pull/52)
   * For details see: https://commons.apache.org/proper/commons-collections/security-reports.html#Apache_Commons_Collections_Security_Vulnerabilities
   * It should be noted that Fili does not make use of any the serialization/deserialization capabilities of any classes

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -208,9 +208,9 @@ public abstract class AbstractBinderFactory implements BinderFactory {
                 bind(getGranularityParser()).to(GranularityParser.class);
 
                 // Bind the request building action classes for druid
-                bind(DruidQueryBuilder.class).to(DruidQueryBuilder.class);
+                bind(buildDruidQueryBuilder()).to(DruidQueryBuilder.class);
                 bind(TemplateDruidQueryMerger.class).to(TemplateDruidQueryMerger.class);
-                bind(DruidResponseParser.class).to(DruidResponseParser.class);
+                bind(buildDruidResponseParser()).to(DruidResponseParser.class);
                 bind(buildDruidFilterBuilder()).to(DruidFilterBuilder.class);
 
                 //Initialize the field converter
@@ -319,6 +319,24 @@ public abstract class AbstractBinderFactory implements BinderFactory {
                 afterBinding(this);
             }
         };
+    }
+
+    /**
+     * Initializes the factory that builds druid queries.
+     *
+     * @return An isntance of the {@link DruidQueryBuilder}
+     */
+    protected Class<DruidQueryBuilder> buildDruidQueryBuilder() {
+        return DruidQueryBuilder.class;
+    }
+
+    /**
+     * Initializes the class that parses responses from Druid.
+     *
+     * @return An instance of the {@link DruidResponseParser}
+     */
+    protected Class<DruidResponseParser> buildDruidResponseParser() {
+        return DruidResponseParser.class;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/DefaultQueryType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/DefaultQueryType.java
@@ -1,0 +1,32 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.druid.model;
+
+import com.yahoo.bard.webservice.util.EnumUtils;
+
+/**
+ * Druid queries that Fili supports out o the box.
+ */
+public enum DefaultQueryType implements QueryType {
+    GROUP_BY,
+    TOP_N,
+    TIMESERIES,
+    TIME_BOUNDARY,
+    SEGMENT_METADATA,
+    SEARCH,
+    LOOKBACK;
+
+    final String jsonName;
+
+    /**
+     * Constructor.
+     */
+    DefaultQueryType() {
+        this.jsonName = EnumUtils.enumJsonName(this);
+    }
+
+    @Override
+    public String toJson() {
+        return jsonName;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/QueryType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/QueryType.java
@@ -2,38 +2,18 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model;
 
-import com.yahoo.bard.webservice.util.EnumUtils;
-
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * Druid Queries the application knows about.
+ * Types of queries supported by this application.
  */
-public enum QueryType {
-    GROUP_BY,
-    TOP_N,
-    TIMESERIES,
-    TIME_BOUNDARY,
-    SEGMENT_METADATA,
-    SEARCH,
-    LOOKBACK;
-
-    final String jsonName;
+public interface QueryType {
 
     /**
-     * Constructor.
-     */
-    QueryType() {
-        this.jsonName = EnumUtils.enumJsonName(this);
-    }
-
-    /**
-     * Get the JSON version of this.
+     * Get the JSON serialization of the query type.
      *
-     * @return the json representation of this enum
+     * @return the json representation of this type
      */
     @JsonValue
-    public String toJson() {
-        return jsonName;
-    }
+    String toJson();
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/DruidSearchQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/DruidSearchQuery.java
@@ -3,7 +3,7 @@
 package com.yahoo.bard.webservice.druid.model.query;
 
 import com.yahoo.bard.webservice.data.dimension.Dimension;
-import com.yahoo.bard.webservice.druid.model.QueryType;
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType;
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource;
 import com.yahoo.bard.webservice.druid.model.filter.Filter;
 import com.yahoo.bard.webservice.druid.model.orderby.SearchSortDirection;
@@ -56,7 +56,7 @@ public class DruidSearchQuery extends AbstractDruidFactQuery<DruidSearchQuery> {
             QueryContext context,
             boolean doFork
     ) {
-        super(QueryType.SEARCH, dataSource, granularity, filter, intervals, context, doFork);
+        super(DefaultQueryType.SEARCH, dataSource, granularity, filter, intervals, context, doFork);
         this.searchDimensions = searchDimensions;
         this.query = query;
         this.sort = sort;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/GroupByQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/GroupByQuery.java
@@ -3,7 +3,7 @@
 package com.yahoo.bard.webservice.druid.model.query;
 
 import com.yahoo.bard.webservice.data.dimension.Dimension;
-import com.yahoo.bard.webservice.druid.model.QueryType;
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType;
 import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource;
 import com.yahoo.bard.webservice.druid.model.datasource.QueryDataSource;
@@ -63,7 +63,7 @@ public class GroupByQuery extends AbstractDruidAggregationQuery<GroupByQuery> {
             boolean doFork
     ) {
         super(
-                QueryType.GROUP_BY,
+                DefaultQueryType.GROUP_BY,
                 dataSource,
                 granularity,
                 dimensions,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/LookbackQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/LookbackQuery.java
@@ -3,7 +3,7 @@
 package com.yahoo.bard.webservice.druid.model.query;
 
 import com.yahoo.bard.webservice.data.dimension.Dimension;
-import com.yahoo.bard.webservice.druid.model.QueryType;
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType;
 import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource;
 import com.yahoo.bard.webservice.druid.model.datasource.QueryDataSource;
@@ -79,7 +79,7 @@ public class LookbackQuery extends AbstractDruidAggregationQuery<LookbackQuery> 
             LimitSpec limitSpec
     ) {
         super(
-                QueryType.LOOKBACK,
+                DefaultQueryType.LOOKBACK,
                 dataSource,
                 granularity,
                 Collections.<Dimension>emptySet(),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/SegmentMetadataQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/SegmentMetadataQuery.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.query;
 
-import com.yahoo.bard.webservice.druid.model.QueryType;
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType;
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -36,7 +36,7 @@ public class SegmentMetadataQuery extends AbstractDruidQuery<SegmentMetadataQuer
             QueryContext context,
             boolean doFork
     ) {
-        super(QueryType.SEGMENT_METADATA, dataSource, context, doFork);
+        super(DefaultQueryType.SEGMENT_METADATA, dataSource, context, doFork);
         this.intervals = Collections.unmodifiableCollection(intervals);
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/TimeBoundaryQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/TimeBoundaryQuery.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.query;
 
-import com.yahoo.bard.webservice.druid.model.QueryType;
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType;
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource;
 
 /**
@@ -20,7 +20,7 @@ public class TimeBoundaryQuery extends AbstractDruidQuery<TimeBoundaryQuery>
      * context.
      */
     protected TimeBoundaryQuery(DataSource dataSource, QueryContext context, boolean doFork) {
-        super(QueryType.TIME_BOUNDARY, dataSource, context, doFork);
+        super(DefaultQueryType.TIME_BOUNDARY, dataSource, context, doFork);
     }
 
     /**
@@ -29,7 +29,7 @@ public class TimeBoundaryQuery extends AbstractDruidQuery<TimeBoundaryQuery>
      * @param dataSource  The datasource
      */
     public TimeBoundaryQuery(DataSource dataSource) {
-        super(QueryType.TIME_BOUNDARY, dataSource, null, false);
+        super(DefaultQueryType.TIME_BOUNDARY, dataSource, null, false);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuery.java
@@ -3,7 +3,7 @@
 package com.yahoo.bard.webservice.druid.model.query;
 
 import com.yahoo.bard.webservice.data.dimension.Dimension;
-import com.yahoo.bard.webservice.druid.model.QueryType;
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType;
 import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource;
 import com.yahoo.bard.webservice.druid.model.filter.Filter;
@@ -45,7 +45,7 @@ public class TimeSeriesQuery extends AbstractDruidAggregationQuery<TimeSeriesQue
             boolean doFork
     ) {
         super(
-                QueryType.TIMESERIES,
+                DefaultQueryType.TIMESERIES,
                 dataSource,
                 granularity,
                 Collections.<Dimension>emptySet(),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/TopNQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/TopNQuery.java
@@ -3,7 +3,7 @@
 package com.yahoo.bard.webservice.druid.model.query;
 
 import com.yahoo.bard.webservice.data.dimension.Dimension;
-import com.yahoo.bard.webservice.druid.model.QueryType;
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType;
 import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource;
 import com.yahoo.bard.webservice.druid.model.filter.Filter;
@@ -58,7 +58,7 @@ public class TopNQuery extends AbstractDruidAggregationQuery<TopNQuery> {
             boolean doFork
     ) {
         super(
-                QueryType.TOP_N,
+                DefaultQueryType.TOP_N,
                 dataSource,
                 granularity,
                 Collections.singletonList(dimension),

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
@@ -16,7 +16,7 @@ import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
 import com.yahoo.bard.webservice.data.metric.mappers.NoOpResultSetMapper
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain
 import com.yahoo.bard.webservice.data.volatility.DefaultingVolatileIntervalsService
-import com.yahoo.bard.webservice.druid.model.QueryType
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType
 import com.yahoo.bard.webservice.druid.model.datasource.DefaultDataSourceType
 import com.yahoo.bard.webservice.druid.model.filter.Filter
 import com.yahoo.bard.webservice.druid.model.having.Having
@@ -305,7 +305,7 @@ class DruidQueryBuilderSpec extends Specification {
         def DruidAggregationQuery<?> dq = builder.buildQuery(apiRequest, resources.simpleTemplateQuery)
 
         then:
-        dq?.getQueryType() == QueryType.GROUP_BY
+        dq?.getQueryType() == DefaultQueryType.GROUP_BY
     }
 
     @Unroll
@@ -327,9 +327,9 @@ class DruidQueryBuilderSpec extends Specification {
         dq?.getQueryType() == queryType
 
         where:
-        queryType          | havingMap                         | topNDruid | isIsNot
-        QueryType.TOP_N    | null                              | "topN"    | "is not"
-        QueryType.GROUP_BY | [(resources.m1): [having] as Set] | "groupBy" | "is"
+        queryType                 | havingMap                         | topNDruid | isIsNot
+        DefaultQueryType.TOP_N    | null                              | "topN"    | "is not"
+        DefaultQueryType.GROUP_BY | [(resources.m1): [having] as Set] | "groupBy" | "is"
 
     }
 
@@ -347,7 +347,7 @@ class DruidQueryBuilderSpec extends Specification {
         DruidAggregationQuery<?> dq = builder.buildQuery(apiRequest, resources.simpleTemplateQuery)
 
         then:
-        dq?.getQueryType() == QueryType.GROUP_BY
+        dq?.getQueryType() == DefaultQueryType.GROUP_BY
     }
 
     def "Test top level buildQuery with single dimension/multiple sorts top N query"() {
@@ -366,7 +366,7 @@ class DruidQueryBuilderSpec extends Specification {
         DruidAggregationQuery<?> dq = builder.buildQuery(apiRequest, resources.simpleTemplateQuery)
 
         then:
-        dq?.getQueryType() == QueryType.GROUP_BY
+        dq?.getQueryType() == DefaultQueryType.GROUP_BY
     }
 
     def "Test top level buildQuery with multiple dimension/multiple sorts top N query"() {
@@ -387,7 +387,7 @@ class DruidQueryBuilderSpec extends Specification {
         DruidAggregationQuery<?> dq = builder.buildQuery(apiRequest, resources.simpleTemplateQuery)
 
         then:
-        dq?.getQueryType() == QueryType.GROUP_BY
+        dq?.getQueryType() == DefaultQueryType.GROUP_BY
 
     }
 
@@ -410,9 +410,9 @@ class DruidQueryBuilderSpec extends Specification {
         dq?.getQueryType() == queryType
 
         where:
-        queryType            | havingMap                         | tsDruid      | isIsNot
-        QueryType.TIMESERIES | null                              | "timeSeries" | "is not"
-        QueryType.GROUP_BY   | [(resources.m1): [having] as Set] | "groupBy"    | "is"
+        queryType                   | havingMap                         | tsDruid      | isIsNot
+        DefaultQueryType.TIMESERIES | null                              | "timeSeries" | "is not"
+        DefaultQueryType.GROUP_BY   | [(resources.m1): [having] as Set] | "groupBy"    | "is"
     }
 
     @Unroll
@@ -446,13 +446,13 @@ havingMap:#havingMap"""() {
         dq?.getQueryType() == queryType
 
         where:
-        queryType          | havingMap                         | nDims | nested | nSorts | flag  | query
-        QueryType.TOP_N    | null                              | 1     | false  | 1      | true  | "topN"
-        QueryType.GROUP_BY | [(resources.m1): [having] as Set] | 1     | false  | 1      | true  | "groupBy"
-        QueryType.GROUP_BY | null                              | 2     | false  | 1      | true  | "groupBy"
-        QueryType.GROUP_BY | null                              | 1     | true   | 1      | true  | "groupBy"
-        QueryType.GROUP_BY | null                              | 1     | false  | 2      | true  | "groupBy"
-        QueryType.GROUP_BY | null                              | 1     | false  | 1      | false | "groupBy"
+        queryType                 | havingMap                         | nDims | nested | nSorts | flag  | query
+        DefaultQueryType.TOP_N    | null                              | 1     | false  | 1      | true  | "topN"
+        DefaultQueryType.GROUP_BY | [(resources.m1): [having] as Set] | 1     | false  | 1      | true  | "groupBy"
+        DefaultQueryType.GROUP_BY | null                              | 2     | false  | 1      | true  | "groupBy"
+        DefaultQueryType.GROUP_BY | null                              | 1     | true   | 1      | true  | "groupBy"
+        DefaultQueryType.GROUP_BY | null                              | 1     | false  | 2      | true  | "groupBy"
+        DefaultQueryType.GROUP_BY | null                              | 1     | false  | 1      | false | "groupBy"
     }
 
     @Unroll
@@ -481,11 +481,11 @@ havingMap:#havingMap"""() {
         dq?.getQueryType() == queryType
 
         where:
-        queryType            | havingMap                         | nDims | nested | nSorts | query
-        QueryType.TIMESERIES | null                              | 0     | false  | 0      | "timeSeries"
-        QueryType.GROUP_BY   | [(resources.m1): [having] as Set] | 0     | false  | 0      | "groupBy"
-        QueryType.GROUP_BY   | null                              | 1     | false  | 0      | "groupBy"
-        QueryType.GROUP_BY   | null                              | 0     | true   | 0      | "groupBy"
-        QueryType.GROUP_BY   | null                              | 0     | false  | 1      | "groupBy"
+        queryType                   | havingMap                         | nDims | nested | nSorts | query
+        DefaultQueryType.TIMESERIES | null                              | 0     | false  | 0      | "timeSeries"
+        DefaultQueryType.GROUP_BY   | [(resources.m1): [having] as Set] | 0     | false  | 0      | "groupBy"
+        DefaultQueryType.GROUP_BY   | null                              | 1     | false  | 0      | "groupBy"
+        DefaultQueryType.GROUP_BY   | null                              | 0     | true   | 0      | "groupBy"
+        DefaultQueryType.GROUP_BY   | null                              | 0     | false  | 1      | "groupBy"
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/DruidSearchQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/DruidSearchQuerySpec.groovy
@@ -11,7 +11,7 @@ import com.yahoo.bard.webservice.data.dimension.DimensionField
 import com.yahoo.bard.webservice.data.dimension.MapStore
 import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
 import com.yahoo.bard.webservice.data.dimension.impl.NoOpSearchProvider
-import com.yahoo.bard.webservice.druid.model.QueryType
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
 import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter
 import com.yahoo.bard.webservice.druid.model.orderby.DefaultSearchSortDirection
@@ -43,7 +43,7 @@ class DruidSearchQuerySpec extends Specification {
     }
 
     DruidSearchQuery defaultQuery(Map vars) {
-        vars.queryType = QueryType.SEARCH
+        vars.queryType = DefaultQueryType.SEARCH
         vars.dataSource = vars.dataSource ?: new TableDataSource(new PhysicalTable("table_name", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
         vars.granularity = vars.granularity ?: DAY
         vars.filter = vars.filter ?: null

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
@@ -4,9 +4,9 @@ package com.yahoo.bard.webservice.druid.model.query
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.YEAR
-import static com.yahoo.bard.webservice.druid.model.QueryType.GROUP_BY
-import static com.yahoo.bard.webservice.druid.model.QueryType.TIMESERIES
-import static com.yahoo.bard.webservice.druid.model.QueryType.TOP_N
+import static com.yahoo.bard.webservice.druid.model.DefaultQueryType.GROUP_BY
+import static com.yahoo.bard.webservice.druid.model.DefaultQueryType.TIMESERIES
+import static com.yahoo.bard.webservice.druid.model.DefaultQueryType.TOP_N
 import static org.hamcrest.Matchers.both
 import static org.hamcrest.Matchers.greaterThan
 import static org.hamcrest.Matchers.is
@@ -26,7 +26,7 @@ import com.yahoo.bard.webservice.data.filterbuilders.DefaultDruidFilterBuilder
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQueryMerger
 import com.yahoo.bard.webservice.data.time.StandardGranularityParser
 import com.yahoo.bard.webservice.data.volatility.VolatileIntervalsService
-import com.yahoo.bard.webservice.druid.model.QueryType
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType
 import com.yahoo.bard.webservice.druid.model.aggregation.SketchCountAggregation
 import com.yahoo.bard.webservice.table.resolver.DefaultPhysicalTableResolver
 import com.yahoo.bard.webservice.web.DataApiRequest
@@ -249,7 +249,7 @@ class WeightEvaluationQuerySpec extends Specification {
         // TIME_SERIES  | _ // Same for timeseries
     }
 
-    DruidAggregationQuery getLargeDimensionQueryStub(Granularity granularity, QueryType queryType) {
+    DruidAggregationQuery getLargeDimensionQueryStub(Granularity granularity, DefaultQueryType queryType) {
         // Dimension stubs with large cardinalities
         Dimension d1 = Stub(Dimension)
         Dimension d2 = Stub(Dimension)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/EnumUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/EnumUtilsSpec.groovy
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.util
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 import static com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation.DefaultPostAggregationType
 
-import com.yahoo.bard.webservice.druid.model.QueryType
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType
 import com.yahoo.bard.webservice.druid.model.filter.Filter
 
 import spock.lang.Specification
@@ -33,7 +33,7 @@ class EnumUtilsSpec extends Specification {
         where:
         a                                       || b
         DAY                                     || "day"
-        QueryType.GROUP_BY                      || "groupBy"
+        DefaultQueryType.GROUP_BY               || "groupBy"
         Filter.DefaultFilterType.SELECTOR       || "selector"
         DefaultPostAggregationType.FIELD_ACCESS || "fieldAccess"
         TestEnum.THIS_IS_A_TEST                 || "thisIsATest"

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
@@ -18,7 +18,7 @@ import com.yahoo.bard.webservice.data.metric.MetricColumn
 import com.yahoo.bard.webservice.data.metric.mappers.ResultSetMapper
 import com.yahoo.bard.webservice.druid.client.FailureCallback
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback
-import com.yahoo.bard.webservice.druid.model.QueryType
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType
 import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
 import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation
@@ -106,7 +106,7 @@ class ResultSetResponseProcessorSpec extends Specification {
         postAggs.add(postAgg1)
         postAgg1.getName() >> "postAgg1"
 
-        QueryType queryType = QueryType.GROUP_BY
+        DefaultQueryType queryType = DefaultQueryType.GROUP_BY
         groupByQuery.getQueryType() >> queryType
         groupByQuery.getDimensions() >> dimensions
         groupByQuery.getAggregations() >> aggregations
@@ -162,7 +162,7 @@ class ResultSetResponseProcessorSpec extends Specification {
         ResultSet rs = Mock(ResultSet)
 
         1 * druidResponseParser.parse(_, _, _) >> {
-            JsonNode json, Schema schema, QueryType type -> captureSchema = schema; captureJson = json; rs
+            JsonNode json, Schema schema, DefaultQueryType type -> captureSchema = schema; captureJson = json; rs
         }
         ResultSet actual
 

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/models/druid/client/impl/TestDruidWebService.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/models/druid/client/impl/TestDruidWebService.java
@@ -7,6 +7,7 @@ import com.yahoo.bard.webservice.druid.client.DruidWebService;
 import com.yahoo.bard.webservice.druid.client.FailureCallback;
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
 import com.yahoo.bard.webservice.druid.client.SuccessCallback;
+import com.yahoo.bard.webservice.druid.model.DefaultQueryType;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 import com.yahoo.bard.webservice.druid.model.query.WeightEvaluationQuery;
 import com.yahoo.bard.webservice.util.JsonSlurper;
@@ -114,7 +115,12 @@ public class TestDruidWebService implements DruidWebService {
         }
 
         // Set the response to use based on the type of the query we're processing
-        switch (lastQuery.getQueryType()) {
+        if (!(lastQuery.getQueryType() instanceof DefaultQueryType)) {
+            throw new IllegalArgumentException("Illegal query type : " + lastQuery.getQueryType());
+        }
+
+        DefaultQueryType defaultQueryType = (DefaultQueryType) lastQuery.getQueryType();
+        switch (defaultQueryType) {
             case GROUP_BY:
             case TOP_N:
             case TIMESERIES:


### PR DESCRIPTION
--`QueryType` has been turned into an interface backed by an enum.

--The `DruidResponseParser` and `DruidQueryBuilder` are now injectable.