### PR TITLE
Add ability to sort mixed-type lists to JsonSlurper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ Current
     
 - [#45, removing sorting from weight check queries](https://github.com/yahoo/fili/pull/46)
 
+- [`JsonSlurper` can now handle sorting lists with mixed-type entries](https://github.com/yahoo/fili/pull/58)
+  * even if the list starts with a string, number, or boolean
 
 ### Known Issues:
 


### PR DESCRIPTION
Before, if a list started with a `Comparable` (ie. string, boolean, or number), it would be sorted using the objects' comparability. This broke if the list contained more than 1 type, like a String and a Map. With this change, that is fixed, and it _should_ retain any sorts that existed before.

Note: Only impacts test code