### PR TITLE
Add in filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ Current
 
 ### Added:
 
-- [Support for X-Request-ID](https://github.com/yahoo/fili/pull/68)
-- [Documentation for topN](https://github.com/yahoo/fili/pull/43)
+- [Support for Druid's In Filter](https://github.com/yahoo/fili/pull/64)
+    * The in-filter only works with Druid versions 0.9.0 and up.
 
+- [Support for X-Request-ID](https://github.com/yahoo/fili/pull/68)
+
+- [Documentation for topN](https://github.com/yahoo/fili/pull/43)
 
 ### Changed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@ Jobs resource. Here are the highlights of what's in this release:
 
 ### Changed:
 
+- Removed `physicalName` lookup for metrics in `TableUtils::getColumnNames` to remove spurious warnings
+     * Metrics are not mapped like dimensions are. Dimensions are aliased per physical table and metrics are aliazed per logical table.
+     * Logical metric is mapped with one or many physical metrics. Same look up logic for dimension and metrics doesn't make sense.
+
 #### Jobs:
 
 - [HashPreResponseStore moved to `test` root directory.](https://github.com/yahoo/fili/pull/39)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/filter/DimensionalFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/filter/DimensionalFilter.java
@@ -38,11 +38,10 @@ public abstract class DimensionalFilter<T extends DimensionalFilter<? super T>> 
      * Get a new instance of this filter with the given Dimension.
      *
      * @param dimension  Dimension of the new filter
-     * @param <T> Type of the filter
      *
      * @return a new instance of this filter with the given dimension
      */
-    public abstract <T> T withDimension(Dimension dimension);
+    public abstract T withDimension(Dimension dimension);
 
     @Override
     public int hashCode() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/filter/Filter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/filter/Filter.java
@@ -32,7 +32,7 @@ public abstract class Filter {
      * Valid types for druid filters.
      */
     public enum DefaultFilterType implements FilterType {
-        SELECTOR, REGEX, AND, OR, NOT, EXTRACTION, SEARCH;
+        SELECTOR, REGEX, AND, OR, NOT, EXTRACTION, SEARCH, IN;
 
         final String jsonName;
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/filter/InFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/filter/InFilter.java
@@ -1,0 +1,72 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.druid.model.filter;
+
+import com.yahoo.bard.webservice.data.dimension.Dimension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Fili model of the Druid In Filter: http://druid.io/docs/0.9.1.1/querying/filters.html.
+ * <p>
+ * An In Filter is a generalization of the {@link SelectorFilter}. Rather than filtering on a specific value for a
+ * specific diimension, the In Filter takes a list of values. A dimension satisfies the In Filter iff its value is
+ * contained in the specified list. It is logically equivalent to an {@link OrFilter} wrapped around a collection of
+ * {@link SelectorFilter}.
+ * <p>
+ * Note that Druid's in filter is only supported by Druid versions 0.9.0 and greater.
+ */
+public class InFilter extends DimensionalFilter<InFilter> {
+
+    private final List<String> values;
+
+    /**
+     * Constructor.
+     *
+     * @param dimension  The dimension to perform an in filter on
+     * @param values  The values to filter on
+     */
+    public InFilter(Dimension dimension, @NotNull List<String> values) {
+        super(dimension, DefaultFilterType.IN);
+        this.values = values;
+    }
+
+    //CHECKSTYLE:OFF
+    @Override
+    public InFilter withDimension(Dimension dimension) {
+        return new InFilter(dimension, getValues());
+    }
+
+    public InFilter withValues(List<String> values) {
+        return new InFilter(getDimension(), values);
+    }
+    //CHECKSTYLE:ON
+
+    /**
+     * Return the list of values to filter on.
+     *
+     * @return The list of values to filter on
+     */
+    public List<String> getValues() {
+        return Collections.unmodifiableList(values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), values);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+
+        InFilter inFilter = (InFilter) o;
+
+        return super.equals(inFilter) && Objects.equals(values, inFilter.values);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
@@ -38,9 +38,7 @@ public class TableUtils {
                 getDimensions(request, query)
                         .map(Dimension::getApiName)
                         .map(table::getPhysicalColumnName),
-                query.getDependentFieldNames()
-                        .stream()
-                        .map(table::getPhysicalColumnName)
+                query.getDependentFieldNames().stream()
         ).flatMap(Function.identity()).collect(Collectors.toSet());
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/TableUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/TableUtilsSpec.groovy
@@ -89,4 +89,17 @@ class TableUtilsSpec extends  Specification {
         expect:
         TableUtils.getColumnNames(request, query, new PhysicalTable("", DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:])) == [d1Name, metric1, metric2, metric3] as Set
     }
+
+    def "logicalName to physicalName mapping not required for metrics" () {
+        setup:
+        request.dimensions >> []
+        request.filterDimensions >> []
+        query.metricDimensions >> []
+        query.dependentFieldNames >> ([metric1] as Set)
+        PhysicalTable physicalTable = Mock(PhysicalTable)
+        0 * physicalTable.getPhysicalColumnName(_)
+
+        expect:
+        TableUtils.getColumnNames(request, query, physicalTable) == [metric1] as Set
+    }
 }


### PR DESCRIPTION
We don't currently have a Filter for Druid's In Filter. I'd like to have one, so I've added it. 😄 

Note that we are not currently using it, though we should be able to use it to simplify the filter builders. 

I tried, but fixing the tests turned out to be taking more time than I can really afford right now. Especially if we want to make the tests readable.