### PR TITLE
Support passing X-Request-ID to Druid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Current
 
 ### Added:
 
+- [Support for X-Request-ID](https://github.com/yahoo/fili/pull/68)
 - [Documentation for topN](https://github.com/yahoo/fili/pull/43)
 
 
@@ -57,6 +58,8 @@ Current
 
 
 ### Fixed:
+
+- [Fixed typo emit -> omit in Utils.java omitField()](https://github.com/yahoo/fili/pull/68)
 
 - [Adds read locking to all attempts to read the Lucene index](https://github.com/yahoo/fili/pull/52)
   * Before, if Fili attempted to read from the Lucene indices (i.e. processing a query with filters)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogBlock.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogBlock.java
@@ -37,6 +37,18 @@ public class LogBlock {
     }
 
     /**
+     * Create a new LogBlock with the same body but updated uuid.
+     *
+     * @param uuid  New uuid.
+     * @return New LogBlock with updated uuid.
+     */
+    public LogBlock withUuid(String uuid) {
+        LogBlock newLogBlock = new LogBlock(uuid);
+        body.entrySet().forEach(entry -> newLogBlock.body.put(entry.getKey(), entry.getValue()));
+        return newLogBlock;
+    }
+
+    /**
      * Add an entry of given class in this LogBlock that holds no information.
      * It is meant to be used only to define the order of {@link LogInfo} parts inside a LogBlock.
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -401,6 +401,19 @@ public class RequestLog {
     }
 
     /**
+     * Prepend an id prefix to generated druid query id.
+     *
+     * @param idPrefix  Prefix for queryId sent to druid
+     */
+    public static void addIdPrefix(String idPrefix) {
+        RequestLog current = RLOG.get();
+        String newId = idPrefix + getId();
+        current.info = current.info.withUuid(newId);
+        current.logId = newId;
+        MDC.put(ID_KEY, newId);
+    }
+
+    /**
      * Overwrite current thread's request log context.
      * It first clears the request log of the current thread and then fills it with the contents found in ctx
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/Utils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/Utils.java
@@ -196,16 +196,16 @@ public class Utils {
      * This method is recursive.
      *
      * @param node The root of the tree of json nodes.
-     * @param fieldName The name of the node to be emitted.
+     * @param fieldName The name of the node to be omitted.
      * @param mapper  The object mapper that creates and empty node.
      */
-    public static void emitField(JsonNode node, String fieldName, ObjectMapper mapper) {
+    public static void omitField(JsonNode node, String fieldName, ObjectMapper mapper) {
         if (node.has("context")) {
             ((ObjectNode) node).replace(fieldName, mapper.createObjectNode());
         }
 
         for (JsonNode child : node) {
-            emitField(child, fieldName, mapper);
+            omitField(child, fieldName, mapper);
         }
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheRequestHandler.java
@@ -133,7 +133,7 @@ public class CacheRequestHandler extends BaseDataRequestHandler {
      */
     protected String getKey(DruidAggregationQuery<?> druidQuery) throws JsonProcessingException {
         JsonNode root = mapper.valueToTree(druidQuery);
-        Utils.emitField(root, "context", mapper);
+        Utils.omitField(root, "context", mapper);
         return writer.writeValueAsString(root);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
@@ -156,7 +156,7 @@ public class CacheV2RequestHandler extends BaseDataRequestHandler {
      */
     protected String getKey(DruidAggregationQuery<?> druidQuery) throws JsonProcessingException {
         JsonNode root = mapper.valueToTree(druidQuery);
-        Utils.emitField(root, "context", mapper);
+        Utils.omitField(root, "context", mapper);
         return writer.writeValueAsString(root);
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/GroovyTestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/GroovyTestUtils.groovy
@@ -39,8 +39,8 @@ abstract class GroovyTestUtils extends Specification {
             JsonNode actualRoot = MAPPER.readTree(actual);
             JsonNode expectedRoot = MAPPER.readTree(expected);
 
-            Utils.emitField(actualRoot, "context", MAPPER);
-            Utils.emitField(expectedRoot, "context", MAPPER);
+            Utils.omitField(actualRoot, "context", MAPPER);
+            Utils.omitField(expectedRoot, "context", MAPPER);
 
             def actualProcessed = MAPPER.writer().withDefaultPrettyPrinter().writeValueAsString(actualRoot);
             def expectedProcessed = MAPPER.writer().withDefaultPrettyPrinter().writeValueAsString(expectedRoot);

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory
 import spock.lang.Specification
 import spock.lang.Timeout
 
+import javax.ws.rs.core.MultivaluedHashMap
 import javax.ws.rs.core.MultivaluedMap
 import javax.ws.rs.core.Response
 
@@ -69,6 +70,13 @@ abstract class BaseDataServletComponentSpec extends Specification {
         jtb = buildTestBinder()
 
         populatePhysicalTableAvailability()
+    }
+
+    /**
+     * Used to append headers to API request made by this spec.
+     */
+    MultivaluedHashMap<String, String> getAdditionalApiRequestHeaders() {
+        return [:]
     }
 
     /**
@@ -206,7 +214,7 @@ abstract class BaseDataServletComponentSpec extends Specification {
         }
 
         // Make the call
-        Response response = httpCall.request().get()
+        Response response = httpCall.request().headers(getAdditionalApiRequestHeaders()).get()
         if (response.status != 200) {
             LOG.error( "***  *** Response status: ${response.status}: ${response.readEntity(String)}")
         }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/RequestIdPrefixesDruidQueryIdSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/RequestIdPrefixesDruidQueryIdSpec.groovy
@@ -1,0 +1,87 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.endpoints
+
+import com.yahoo.bard.webservice.data.dimension.BardDimensionField
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
+import com.yahoo.bard.webservice.util.JsonSlurper
+import com.yahoo.bard.webservice.util.JsonSortStrategy
+import com.yahoo.bard.webservice.web.filters.BardLoggingFilter
+import org.apache.commons.lang.StringUtils
+
+import javax.ws.rs.core.MultivaluedHashMap
+
+
+class RequestIdPrefixesDruidQueryIdSpec extends BaseDataServletComponentSpec {
+    def prefixId = UUID.randomUUID().toString();
+
+    @Override
+    def setup() {
+        DimensionDictionary dimensionStore = jtb.configurationLoader.dimensionDictionary
+        dimensionStore.findByApiName("color").with {
+            addDimensionRow(BardDimensionField.makeDimensionRow(it, "Foo", "FooDesc"))
+            addDimensionRow(BardDimensionField.makeDimensionRow(it, "Bar", "BarDesc"))
+            addDimensionRow(BardDimensionField.makeDimensionRow(it, "Baz", "BazDesc"))
+        }
+    }
+
+    @Override
+    Class<?>[] getResourceClasses() {
+        [ DataServlet.class, BardLoggingFilter.class ]
+    }
+
+    @Override
+    String getTarget() {
+        return "data/shapes/week/color"
+    }
+
+    @Override
+    Map<String, List<String>> getQueryParams() {
+        [
+                "metrics": ["width","depth"],
+                "dateTime": ["2014-06-02/2014-06-30"],
+                "sort": ["width|desc","depth|asc"]
+        ]
+    }
+
+    @Override
+    boolean compareResult(String result, String expectedResult, JsonSortStrategy sortStrategy = JsonSortStrategy.SORT_MAPS) {
+        def parsedJson = new JsonSlurper(sortStrategy).parseText(result)
+        if (parsedJson.context != null) {
+            return parsedJson.context.queryId.startsWith(prefixId)
+        }
+        // Default to true-- the base spec runs an extra test which we consider a noop.
+        return true
+    }
+
+    @Override
+    String getExpectedDruidQuery() {
+        // Noop
+        """{}"""
+    }
+
+    @Override
+    String getFakeDruidResponse() {
+        // Noop
+        """[]"""
+    }
+
+    @Override
+    String getExpectedApiResponse() {
+        // Noop
+        """{}"""
+    }
+
+    @Override
+    MultivaluedHashMap<String, String> getAdditionalApiRequestHeaders() {
+        return ["x-request-id": prefixId]
+    }
+
+    def "verify invalid x-request-id values"() {
+        BardLoggingFilter filter = new BardLoggingFilter()
+        assert !filter.isValidRequestId('abcd$') // Invalid char
+        assert !filter.isValidRequestId(StringUtils.leftPad('a', 200, 'a')) // Too long
+        assert !filter.isValidRequestId('') // empty string
+        assert !filter.isValidRequestId(null) // null
+    }
+}


### PR DESCRIPTION
A note from offline discussion, HTTP headers are case **in**sensitive. See [RFC 7230](https://tools.ietf.org/html/rfc7230) for more information.