### PR TITLE
ResponseException stores the JSON sent to Druid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,12 @@ Current
 
 ### Deprecated:
 
-
+- [All constructors of `ResponseException` that do not take an `ObjectWriter`](https://github.com/yahoo/fili/pull/70)
+    * An `ObjectWriter` is required in order to ensure that the exception correctly serializes its associated Druid query
 
 ### Fixed:
+
+- [Druid queries are now serialized correctly when logging `ResponseExceptions`](https://github.com/yahoo/fili/pull/70)
 
 - [Disable Query split for "all" grain ](https:://github.com/yahoo/fili/pull/75)
     - Before, if we requested "all" grain with multiple intervals, the `SplitQueryRequestHandler` would incorrectly split the query 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/async/ResponseException.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/async/ResponseException.java
@@ -5,6 +5,13 @@ package com.yahoo.bard.webservice.async;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.core.Response;
 
 /**
@@ -12,6 +19,7 @@ import javax.ws.rs.core.Response;
  * type is enforced as Exception.
  */
 public class ResponseException extends Exception {
+    private static final Logger LOG = LoggerFactory.getLogger(ResponseException.class);
 
     private final int statusCode;
     private final String reason;
@@ -20,12 +28,66 @@ public class ResponseException extends Exception {
     private final Throwable cause;
 
     /**
+     * Class constructor with all the parameters to prepare the error response, plus a writer to serialize the Druid
+     * query.
+     *
+     * @param statusCode  Http status code for the error
+     * @param reason  Reason for the error
+     * @param description  Description for the error
+     * @param druidQuery  The druid query being processed
+     * @param cause  Exception object with error details
+     * @param objectWriter  The writer to use to serialize the Druid query
+     */
+    public ResponseException(
+            int statusCode,
+            String reason,
+            String description,
+            DruidQuery<?> druidQuery,
+            Throwable cause,
+            ObjectWriter objectWriter
+    ) {
+        super(buildMessage(reason, description, statusCode, druidQuery, cause, objectWriter));
+        this.statusCode = statusCode;
+        this.reason = reason;
+        this.description = description;
+        this.druidQuery = druidQuery;
+        this.cause = cause;
+    }
+
+    /**
+     * Class constructor with throwable, other parameters and a mapper for serializing the druid query.
+     *
+     * @param statusType  Status type of the response
+     * @param druidQuery  The druid query being processed
+     * @param error  Exception object with error details
+     * @param writer  Writer for serializing the druid query
+     */
+    public ResponseException(
+            Response.StatusType statusType,
+            DruidAggregationQuery<?> druidQuery,
+            Throwable error,
+            ObjectWriter writer
+    ) {
+        this(
+                statusType.getStatusCode(),
+                ErrorUtils.getReason(error),
+                ErrorUtils.getDescription(error),
+                druidQuery,
+                error,
+                writer
+        );
+    }
+
+    /**
      * Class constructor with throwable and other parameters.
      *
      * @param statusType  Status type of the response
      * @param druidQuery  The druid query being processed
      * @param error  Exception object with error details
+     * @deprecated In order to ensure correct serialization of the Druid Query, an ObjectWriter with all appropriate
+     * configuration should be passed in to the constructor
      */
+    @Deprecated
     public ResponseException(Response.StatusType statusType, DruidAggregationQuery<?> druidQuery, Throwable error) {
         this(
                 statusType.getStatusCode(),
@@ -43,7 +105,10 @@ public class ResponseException extends Exception {
      * @param reason  Reason for the error
      * @param description  Description for the error
      * @param druidQuery  The druid query being processed
+     * @deprecated In order to ensure correct serialization of the Druid Query, an ObjectWriter with all appropriate
+     * configuration should be passed in to the constructor
      */
+    @Deprecated
     public ResponseException(int statusCode, String reason, String description, DruidQuery<?> druidQuery) {
         this(statusCode, reason, description, druidQuery, null);
     }
@@ -56,7 +121,10 @@ public class ResponseException extends Exception {
      * @param description  Description for the error
      * @param druidQuery  The druid query being processed
      * @param cause  Exception object with error details
+     * @deprecated In order to ensure correct serialization of the Druid Query, an ObjectWriter with all appropriate
+     * configuration should be passed in to the constructor
      */
+    @Deprecated
     public ResponseException(
             int statusCode,
             String reason,
@@ -64,12 +132,7 @@ public class ResponseException extends Exception {
             DruidQuery<?> druidQuery,
             Throwable cause
     ) {
-        super(buildMessage(reason, description, statusCode, druidQuery, cause));
-        this.statusCode = statusCode;
-        this.reason = reason;
-        this.description = description;
-        this.druidQuery = druidQuery;
-        this.cause = cause;
+        this(statusCode, reason, description, druidQuery, cause, new ObjectMapper().writer());
     }
 
     /**
@@ -80,6 +143,7 @@ public class ResponseException extends Exception {
      * @param statusCode  The status code received from Druid
      * @param druidQuery  The druid query that triggered the invalid response
      * @param cause  The cause of this exception, if any
+     * @param objectWriter  The writer to use to serialize the Druid query for the exception message
      *
      * @return A Stringification of the parameters to serve as this exception's message
      */
@@ -88,14 +152,27 @@ public class ResponseException extends Exception {
             String description,
             int statusCode,
             DruidQuery<?> druidQuery,
-            Throwable cause
+            Throwable cause,
+            ObjectWriter objectWriter
     ) {
+        String druidQueryString;
+        try {
+            druidQueryString = objectWriter.writeValueAsString(druidQuery);
+        } catch (JsonProcessingException jse) {
+            try {
+                druidQueryString = druidQuery.toString();
+            } catch (Exception e) {
+                LOG.warn("Error invoking a druid query's toString.", e);
+                druidQueryString = "QUERY'S `toString` FAILED";
+            }
+            LOG.warn(String.format("Failed to serialize druid query %s", druidQueryString), jse);
+        }
         return String.format(
-                "Reason: %s, Description: %s, statusCode: %d, druid query: %s, cause: %s",
+                "reason: %s, description: %s, statusCode: %d, druid query: %s, cause: %s",
                 reason,
                 description,
                 statusCode,
-                druidQuery,
+                druidQueryString,
                 cause
         );
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
@@ -492,7 +492,9 @@ public class JobsServlet extends EndpointServlet {
                     (Integer) responseContext.get(ResponseContextKeys.STATUS.getName()),
                     (String) responseContext.get(ResponseContextKeys.ERROR_MESSAGE.getName()),
                     (String) responseContext.get(ResponseContextKeys.ERROR_MESSAGE.getName()),
-                    null
+                    null, // Druid query
+                    null, // cause
+                    writer
             );
             return Observable.error(responseException);
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/MappingResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/MappingResponseProcessor.java
@@ -108,7 +108,14 @@ public abstract class MappingResponseProcessor implements ResponseProcessor {
             @Override
             public void invoke(int statusCode, String reason, String responseBody) {
                 LOG.error(ErrorMessageFormat.ERROR_FROM_DRUID.logFormat(responseBody, statusCode, reason, druidQuery));
-                responseEmitter.onError(new ResponseException(statusCode, reason, responseBody, druidQuery));
+                responseEmitter.onError(new ResponseException(
+                        statusCode,
+                        reason,
+                        responseBody,
+                        druidQuery,
+                        null,
+                        getObjectMappers().getMapper().writer()
+                ));
             }
         };
     }
@@ -129,7 +136,12 @@ public abstract class MappingResponseProcessor implements ResponseProcessor {
             @Override
             public void invoke(Throwable error) {
                 LOG.error(ErrorMessageFormat.FAILED_TO_SEND_QUERY_TO_DRUID.logFormat(druidQuery), error);
-                responseEmitter.onError(new ResponseException(Status.INTERNAL_SERVER_ERROR, druidQuery, error));
+                responseEmitter.onError(new ResponseException(
+                        Status.INTERNAL_SERVER_ERROR,
+                        druidQuery,
+                        error,
+                        objectMappers.getMapper().writer()
+                ));
             }
         };
     }
@@ -149,5 +161,9 @@ public abstract class MappingResponseProcessor implements ResponseProcessor {
 
     public DataApiRequest getDataApiRequest() {
         return apiRequest;
+    }
+
+    protected ObjectMappersSuite getObjectMappers() {
+        return objectMappers;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
@@ -118,10 +118,20 @@ public class ResultSetResponseProcessor extends MappingResponseProcessor impleme
             responseEmitter.onCompleted();
         } catch (PageNotFoundException invalidPage) {
             LOG.debug(invalidPage.getLogMessage());
-            responseEmitter.onError(new ResponseException(invalidPage.getErrorStatus(), druidQuery, invalidPage));
+            responseEmitter.onError(new ResponseException(
+                    invalidPage.getErrorStatus(),
+                    druidQuery,
+                    invalidPage,
+                    getObjectMappers().getMapper().writer()
+            ));
         } catch (Exception exception) {
             LOG.error("Exception processing druid call in success", exception);
-            responseEmitter.onError(new ResponseException(Status.INTERNAL_SERVER_ERROR, druidQuery, exception));
+            responseEmitter.onError(new ResponseException(
+                    Status.INTERNAL_SERVER_ERROR,
+                    druidQuery,
+                    exception,
+                    getObjectMappers().getMapper().writer()
+            ));
         }
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/workflows/DefaultAsynchronousWorkflowsBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/workflows/DefaultAsynchronousWorkflowsBuilderSpec.groovy
@@ -7,9 +7,9 @@ import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.JOB_T
 import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.STATUS
 
 import com.yahoo.bard.webservice.async.ResponseException
-import com.yahoo.bard.webservice.async.jobs.stores.ApiJobStore
 import com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobStatus
 import com.yahoo.bard.webservice.async.jobs.jobrows.JobRow
+import com.yahoo.bard.webservice.async.jobs.stores.ApiJobStore
 import com.yahoo.bard.webservice.async.preresponses.stores.PreResponseStore
 import com.yahoo.bard.webservice.data.ResultSet
 import com.yahoo.bard.webservice.druid.model.query.AllGranularity
@@ -19,6 +19,8 @@ import com.yahoo.bard.webservice.util.Either
 import com.yahoo.bard.webservice.web.PreResponse
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseContext
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys
+
+import com.fasterxml.jackson.databind.ObjectWriter
 
 import org.joda.time.DateTime
 
@@ -30,6 +32,7 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Timeout
 import spock.lang.Unroll
+
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
@@ -61,7 +64,9 @@ class DefaultAsynchronousWorkflowsBuilderSpec extends Specification {
             404,
             "not found",
             "not found",
-            Mock(DruidAggregationQuery)
+            Mock(DruidAggregationQuery),
+            null, // cause
+            Stub(ObjectWriter) { writeValueAsString(_) >> "" }  //Not serializing the exception
     )
 
     @Subject DefaultAsynchronousWorkflowsBuilder asynchronousProcessBuilder = new DefaultAsynchronousWorkflowsBuilder(


### PR DESCRIPTION
-- `DruidAggregationQuery` does not have `toString` defined.
Furthermore, it would be non-trivial to define a `toString` that
serializes the query into the actual query sent to Druid (we would need
to inject a `ObjectMapper` from the `ObjectMapperSuite` into the
aggregation query). Therefore, the `ResponseException` now takes an
`ObjectWriter` that can be used to serialize the druid query that is
logged.