### PR TITLE
Disable query split for "all" grain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ Current
 
 ### Fixed:
 
+- [Disable Query split for "all" grain ](https:://github.com/yahoo/fili/pull/75)
+    - Before, if we requested "all" grain with multiple intervals, the `SplitQueryRequestHandler` would incorrectly split the query 
+      and we would get multiple buckets in the output. Now, the query split is disabled for "all" grain and we correctly
+      get only one bucket in the response.
+
 - [Fixed typo emit -> omit in Utils.java omitField()](https://github.com/yahoo/fili/pull/68)
 
 - [Adds read locking to all attempts to read the Lucene index](https://github.com/yahoo/fili/pull/52)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/SplitQueryRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/SplitQueryRequestHandler.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.web.handlers;
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.EMPTY_INTERVAL_FORMAT;
 
 import com.yahoo.bard.webservice.application.MetricRegistryFactory;
+import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.logging.RequestLog;
@@ -62,6 +63,11 @@ public class SplitQueryRequestHandler implements DataRequestHandler {
     ) {
         Granularity granularity = druidQuery.getGranularity();
         List<Interval> queryIntervals = druidQuery.getIntervals();
+
+        if (granularity instanceof AllGranularity) {
+           // For "all" grain there is only one response bucket, so can't really split
+           return next.handleRequest(context, request, druidQuery, response);
+        }
 
         Map<Interval, AtomicInteger> expectedIntervals = Collections.unmodifiableMap(
                 IntervalUtils.getSlicedIntervals(queryIntervals, granularity)


### PR DESCRIPTION
Query split breaks for "all" grain when multiple disjoint intervals specified. Disable split in general for "all" grain