### PR TITLE
Change csv attachment name to use '__' instead of ','

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Current
 
 ### Changed:
 
+- [CSV attachment name for multi-interval request now contain '__' instead of ','](https://github.com/yahoo/fili/pull/76)
+    - This change is made to allow running multi-api request with csv format using chrome browser.
+
 - [Allow configurable headers for Druid data requests](https:://github.com/yahoo/fili/pull/62)
     - The `AsyncDruidWebServiceImpl` now accepts a `Supplier<Map<String, String>>` argument which specifies
         the headers to add to the Druid data requests. This feature is made configurable through `SystemConfig` in

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseFormat.java
@@ -34,7 +34,8 @@ public class ResponseFormat {
         if (interval == null) {
             interval = "";
         } else {
-            interval = "_" + interval.replace("/", "_");
+            // Chrome treats ',' as duplicate header so replace it with '__' to make chrome happy.
+            interval = "_" + interval.replace("/", "_").replace(",", "__");
         }
 
         return "attachment; filename=" + uriPath + interval + ".csv";

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/HttpResponseMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/HttpResponseMakerSpec.groovy
@@ -62,7 +62,7 @@ class HttpResponseMakerSpec extends Specification {
 
         responseContext = new ResponseContext(apiRequest.dimensionFields)
 
-        paramMap.getFirst("dateTime") >> "a/b"
+        paramMap.getFirst("dateTime") >> "a/b,c/d"
         pathSegment.getPath() >> "theMockPath"
         uriInfo.getPathSegments() >>[pathSegment]
         uriInfo.getQueryParameters() >> paramMap
@@ -127,7 +127,7 @@ class HttpResponseMakerSpec extends Specification {
 
         then: "The header is set correctly"
         actual.getHeaderString(HttpHeaders.CONTENT_TYPE) == "text/csv; charset=utf-8"
-        actual.getHeaderString(HttpHeaders.CONTENT_DISPOSITION) == "attachment; filename=theMockPath_a_b.csv"
+        actual.getHeaderString(HttpHeaders.CONTENT_DISPOSITION) == "attachment; filename=theMockPath_a_b__c_d.csv"
 
         and: "Mock override: A CSV-formatted request"
         apiRequest.getFormat() >> ResponseFormatType.CSV


### PR DESCRIPTION
Chrome does not accept ',' as part of the filename so changing it to use '__' instead. 