### PR TITLE
PhysicalTable uses `getAvailableIntervals`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Current
 
 ### Changed:
 
+- [`PhysicalTable` now uses `getAvailableIntervals` internally rather than directly referencing its intervals](https://github.com/yahoo/fili/pull/79)
+
 - [CSV attachment name for multi-interval request now contain '__' instead of ','](https://github.com/yahoo/fili/pull/76)
     - This change is made to allow running multi-api request with csv format using chrome browser.
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -67,7 +67,7 @@ public class PhysicalTable extends Table {
 
     @Override
     public Set<Column> getColumns() {
-        return availableIntervalsRef.get().keySet();
+        return getAvailableIntervals().keySet();
     }
 
     @Override
@@ -174,7 +174,7 @@ public class PhysicalTable extends Table {
      * @return Set of intervals associated with a column, empty if column is missing
      */
     public Set<Interval> getIntervalsByColumnName(String columnName) {
-        Set<Interval> result = availableIntervalsRef.get().get(new Column(columnName));
+        Set<Interval> result = getAvailableIntervals().get(new Column(columnName));
         if (result != null) {
             return result;
         }
@@ -189,7 +189,7 @@ public class PhysicalTable extends Table {
      */
     public DateTime getTableAlignment() {
         return getTimeGrain().roundFloor(
-                IntervalUtils.firstMoment(availableIntervalsRef.get().values()).orElse(new DateTime())
+                IntervalUtils.firstMoment(getAvailableIntervals().values()).orElse(new DateTime())
         );
     }
 


### PR DESCRIPTION
--`PhysicalTable::getAvailableIntervals` returns
`availableIntervalsRef.get()`. However, the other methods didn't actually
use `getAvailableIntervals` internally. Instead, they used
`availableIntervalsRef.get()` directly. As a result, overriding
`getAvailableIntervals` would not actually be sufficient to restrict a
`PhysicalTable`'s view of its availability, despite the method name.

--Now, all invocations of `availableIntervalsRef.get()` have been
replaced with `getAvailableIntervals`, making it much easier to enforce
a consistent view of availability simply by overriding
`getAvailableIntervals`.