### PR TITLE
Give more time for ClassScannerSpec tests to run

### DIFF
--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
@@ -19,7 +19,7 @@ import spock.lang.Unroll
 import java.lang.reflect.Modifier
 import java.util.regex.Pattern
 
-@Timeout(5)
+@Timeout(15)
 class ClassScannerSpec extends Specification {
 
     static ClassScanner classScanner = new ClassScanner("com.yahoo.bard")


### PR DESCRIPTION
The tests run too slowly for this timeout in an underprovisioned VM.  Given that they currently pass this timeout in all our existing pipelines, this should be a no op for well provisioned systems.