### PR TITLE
Fix list environment variable not pulled in correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ Current
 
 ### Fixed:
 
+- [Environment comma separated list variables are now correctly pulled in as a list](https://github.com/yahoo/fili/pull/82)
+  * Before it was pulled in as a single sting containing commas, now environment variables are pulled in the same way as the properties files
+  * Added test to test comma separated list environment variables when `FILI_TEST_LIST` environment variable exists
+
 - [Druid queries are now serialized correctly when logging `ResponseExceptions`](https://github.com/yahoo/fili/pull/70)
 
 - [Disable Query split for "all" grain ](https:://github.com/yahoo/fili/pull/75)

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/LayeredFileSystemConfig.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/LayeredFileSystemConfig.java
@@ -107,7 +107,7 @@ public class LayeredFileSystemConfig implements SystemConfig {
             // Use PropertiesConfiguration to hold environment variables to ensure same behavior as properties files
             PropertiesConfiguration environmentConfiguration = new PropertiesConfiguration();
 
-            for (Map.Entry entry  : System.getenv().entrySet()) {
+            for (Map.Entry entry : System.getenv().entrySet()) {
                 // addProperty will parse string as list with delimiter set
                 environmentConfiguration.addProperty(entry.getKey().toString(), entry.getValue());
             }

--- a/fili-system-config/src/test/groovy/com/yahoo/bard/webservice/config/LayeredFileSystemConfigSpec.groovy
+++ b/fili-system-config/src/test/groovy/com/yahoo/bard/webservice/config/LayeredFileSystemConfigSpec.groovy
@@ -22,11 +22,14 @@ class LayeredFileSystemConfigSpec extends SystemConfigSpec {
 
     private static final String ENVIRONMENT_PROPERTY_KEY = "JAVA_HOME"
 
+    // This environment is set in build container for testing purposes only
+    private static final String ENVIRONMENT_LIST_PROPERTY_KEY = "FILI_TEST_LIST"
+
     private SystemConfig systemConfig = new LayeredFileSystemConfig()
 
     @Override
     SystemConfig getTestSystemConfig() {
-        new LayeredFileSystemConfig();
+        new LayeredFileSystemConfig()
     }
 
     @Requires({System.getenv(ENVIRONMENT_PROPERTY_KEY) != null})
@@ -39,6 +42,15 @@ class LayeredFileSystemConfigSpec extends SystemConfigSpec {
         expect:
         systemConfig.getStringProperty(MODULE_1_PREFIX + TEST_PROPERTY) == "test1"
         systemConfig.getStringProperty(MODULE_2_PREFIX + TEST_PROPERTY) == "test2"
+    }
+
+    @Requires({System.getenv(ENVIRONMENT_LIST_PROPERTY_KEY) != null})
+    def "A comma separated list environment variable gets parsed correctly as a list"() {
+        setup:
+        List<String> expectedList = System.getenv(ENVIRONMENT_LIST_PROPERTY_KEY).split(",").toList()
+
+        expect:
+        systemConfig.getListProperty(ENVIRONMENT_LIST_PROPERTY_KEY) == expectedList
     }
 
     @Requires({System.getenv(ENVIRONMENT_PROPERTY_KEY) != null})

--- a/travis/deploy.bash
+++ b/travis/deploy.bash
@@ -34,6 +34,9 @@ if [[ ${MATCHING_TAG} != "" ]]; then
     exit 0
 fi
 
+# Set environment variable for testing purposes
+export FILI_TEST_LIST=a,2,bc,234
+
 # We're not on a release tag, so build and test the code
 mvn verify
 MAVEN_RETURN_CODE=$?


### PR DESCRIPTION
Comma seperated list environment variables was pulled in as a single string before, this PR pulls environment variables through the `PropertiesConfiguration` so that the behavior is consistent with file based properties.