### PR TITLE
Populate the Dimension Cache from an avro file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ snapshot-pom.xml
 report
 /target
 /checkstyle-style-local.xml
+
+# Binary avro files should be ignored
+*.avro

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ Current
 
 ### Added:
 
+
 - [Customize Logging Format in RequestLog](https://github.com/yahoo/fili/pull/81)
+
+- [Populate Dimension Rows from an AVRO file](https://github.com/yahoo/fili/pull/86)
+    * Added `AvroDimensionRowParser` class that parses an AVRO data file (.avro) after validating the AVRO schema (.avsc).
+    * Added a functional Interface `DimensionFieldMapper` that maps field name based on the user implementation.
 
 - [Support for Druid's In Filter](https://github.com/yahoo/fili/pull/64)
     * The in-filter only works with Druid versions 0.9.0 and up.

--- a/fili-core/pom.xml
+++ b/fili-core/pom.xml
@@ -208,10 +208,62 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
         </dependency>
+
+        <!-- Apache Avro Libraries -->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.avro</groupId>
+                                    <artifactId>avro-tools</artifactId>
+                                    <version>1.7.7</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.basedir}/src/test/resources/jar</outputDirectory>
+                                    <destFileName>avro-tools.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-test-resources</phase>
+                        <configuration>
+                            <tasks>
+                                <exec
+                                        dir="${project.basedir}/src/test/scripts"
+                                        executable="./createAvro.bash"
+                                        failonerror="true">
+                                </exec>
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParser.java
@@ -1,0 +1,194 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.dimension;
+
+import com.yahoo.bard.webservice.data.cache.HashDataCache.Pair;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Parses an AVRO file into Dimension Rows.
+ */
+public class AvroDimensionRowParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AvroDimensionRowParser.class);
+    private final ObjectMapper objectMapper;
+
+    private final DimensionFieldNameMapper dimensionFieldNameMapper;
+
+    /**
+     * Constructs an AvroDimensionRowParser object based on the DimensionFieldNameMapper object.
+     *
+     * @param dimensionFieldNameMapper Object that defines the dimension field name transformations
+     * @param objectMapper Object that is used to construct mapper objects
+     */
+    public AvroDimensionRowParser(DimensionFieldNameMapper dimensionFieldNameMapper, ObjectMapper objectMapper) {
+        this.dimensionFieldNameMapper = memoize(dimensionFieldNameMapper);
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Validates the schema of the given AVRO file with the Dimension schema configured by the user.
+     *
+     * <p>
+     * The sample schema is expected to be in the following format
+     * <pre><code>
+     * {
+     *    "type" : "record",
+     *    "name" : "TUPLE_0",
+     *    "fields" : [
+     *    {
+     *    "name" : "FOO_ID",
+     *    "type" : [ "null","int" ]
+     *    },
+     *    {
+     *    "name" : "FOO_DESC",
+     *    "type" : [ "null", "string" ]
+     *    }
+     *    ]
+     * }
+     * </code></pre>
+     *
+     * @param dimension The dimension object used to configure the dimension
+     * @param avroSchemaPath The path of the AVRO schema file (.avsc)
+     *
+     * @return true if the schema is valid, false otherwise
+     *
+     * @throws IllegalArgumentException thrown if JSON object `fields` is not present
+     */
+    private boolean doesSchemaContainAllDimensionFields(Dimension dimension, String avroSchemaPath)
+        throws IllegalArgumentException {
+
+        // Convert the AVRO schema file into JsonNode Object
+        JsonNode jsonAvroSchema = convertFileToJsonNode(avroSchemaPath);
+
+        jsonAvroSchema = Optional.ofNullable(jsonAvroSchema.get("fields")).orElseThrow(() -> {
+                String msg = "`fields` is a required JSON field in the avro schema";
+                LOG.error(msg);
+                return new IllegalArgumentException(msg);
+        });
+
+        // Populating the set of avro field names
+        Set<String> avroFields = StreamSupport.stream(jsonAvroSchema.spliterator(), false)
+                .map(jsonNode -> jsonNode.get("name"))
+                .map(JsonNode::asText)
+                .collect(Collectors.toSet());
+
+        // True only if all of the mapped dimension fields are present in the Avro schema
+        return dimension.getDimensionFields().stream()
+                .map(dimensionField -> dimensionFieldNameMapper.convert(dimension, dimensionField))
+                .allMatch(avroFields::contains);
+    }
+
+    /**
+     * Parses the avro file and populates the dimension rows after validating the schema.
+     *
+     * @param dimension The dimension object used to configure the dimension
+     * @param avroFilePath The path of the AVRO data file (.avro)
+     * @param avroSchemaPath The path of the AVRO schema file (.avsc)
+     *
+     * @return A set of dimension rows
+     *
+     * @throws IllegalArgumentException thrown if JSON object `fields` is not present
+     */
+    public Set<DimensionRow> parseAvroFileDimensionRows(Dimension dimension, String avroFilePath, String avroSchemaPath)
+        throws IllegalArgumentException {
+
+        if (doesSchemaContainAllDimensionFields(dimension, avroSchemaPath)) {
+
+            DataFileReader<GenericRecord> dataFileReader;
+            String filePath = avroSchemaPath;
+            try {
+                // Creates an AVRO schema object based on the parsed AVRO schema file (.avsc)
+                Schema schema = new Schema.Parser().parse(new File(filePath));
+
+                // Creates an AVRO DatumReader object based on the AVRO schema object
+                DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(schema);
+
+                filePath = avroFilePath;
+                // Creates an AVRO DataFileReader object that reads the AVRO data file one record at a time
+                dataFileReader = new DataFileReader<>(new File(avroFilePath), datumReader);
+
+            } catch (IOException e) {
+                String msg = String.format("Unable to process the file, at the location %s", filePath);
+                LOG.error(msg, e);
+                throw new IllegalArgumentException(msg, e);
+            }
+
+            // Generates a set of dimension Rows after retrieving the appropriate fields
+            return StreamSupport.stream(dataFileReader.spliterator(), false)
+                    .map(genericRecord -> dimension.getDimensionFields().stream().collect(
+                             Collectors.toMap(
+                                 DimensionField::getName,
+                                 dimensionField -> genericRecord.get(
+                                     dimensionFieldNameMapper.convert(dimension, dimensionField)
+                                 ).toString()
+                             )
+                         )
+                    )
+                    .map(dimension::parseDimensionRow)
+                    .collect(Collectors.toSet());
+        } else {
+            String msg = "The AVRO schema file does not contain all the configured dimension fields";
+            LOG.error(msg);
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    /**
+     * Constructs a JSON Node object from the avro schema file.
+     *
+     * @param avroSchemaPath The path of the AVRO schema file (.avsc)
+     *
+     * @return JsonNode object
+     *
+     * @throws IllegalArgumentException thrown if there is an error parsing the avro files
+     */
+    private JsonNode convertFileToJsonNode(String avroSchemaPath) throws IllegalArgumentException {
+
+        try {
+            return objectMapper.readTree(new File(avroSchemaPath));
+        } catch (JsonProcessingException e) {
+            String msg = "Unable to process the Json";
+            LOG.error(msg, e);
+            throw new IllegalArgumentException(msg, e);
+        } catch (IOException e) {
+            String msg = String.format("Unable to process the file, at the location %s", avroSchemaPath);
+            LOG.error(msg, e);
+            throw new IllegalArgumentException(msg, e);
+        }
+    }
+
+    /**
+     * Returns a memoized converter function for the dimension field name mapping.
+     *
+     * @param dimensionFieldNameMapper Object that defines the dimension field name transformations
+     * @return Memoized function that converts the dimension field name based on the user mapping
+     */
+    private DimensionFieldNameMapper memoize(DimensionFieldNameMapper dimensionFieldNameMapper) {
+        Map<Pair<Dimension, DimensionField>, String> cache = new HashMap<>();
+        return (dimension, dimensionField) -> cache.computeIfAbsent(
+                new Pair<>(dimension, dimensionField),
+                key -> dimensionFieldNameMapper.convert(key.getKey(), key.getValue())
+        );
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionFieldNameMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionFieldNameMapper.java
@@ -1,0 +1,32 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.dimension;
+
+import java.util.Locale;
+
+/**
+ * Maps a Dimension Field value to a string.
+ */
+@FunctionalInterface
+public interface DimensionFieldNameMapper {
+
+    /**
+     * A converter function for the dimension field Mapping.
+     *
+     * @param dimension The dimension object used to configure the Dimension
+     * @param dimensionField The dimension field object
+     *
+     * @return the converted string for the dimension field
+     */
+    String convert(Dimension dimension, DimensionField dimensionField);
+
+    /**
+     * A default implementation of the converter method which uses underscore as a separator.
+     *
+     * @return an instance of DimensionFieldNameMapper
+     */
+    static DimensionFieldNameMapper underscoreSeparatedConverter () {
+        return (dimension, dimensionField) ->
+                    (dimension.getApiName() + "_" + dimensionField.getName()).toUpperCase(Locale.ENGLISH);
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParserSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParserSpec.groovy
@@ -1,0 +1,61 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.dimension
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
+import com.yahoo.bard.webservice.data.dimension.impl.ScanSearchProviderManager
+import spock.lang.Specification
+
+
+class AvroDimensionRowParserSpec extends Specification {
+    def LinkedHashSet<DimensionField> dimensionFields
+    def KeyValueStoreDimension dimension
+    def AvroDimensionRowParser avroDimensionRowParser
+
+    def setup() {
+        dimensionFields = [BardDimensionField.ID, BardDimensionField.DESC]
+        dimension = new KeyValueStoreDimension("foo", "desc-foo", dimensionFields, MapStoreManager.getInstance("foo"), ScanSearchProviderManager.getInstance("foo"))
+        avroDimensionRowParser = new AvroDimensionRowParser(DimensionFieldNameMapper.underscoreSeparatedConverter(), new ObjectMapper())
+    }
+
+    def "Schema file containing all the dimension fields and data parses to expected rows"() {
+        given:
+        DimensionRow dimensionRow1 = BardDimensionField.makeDimensionRow(dimension, "12345", "bar")
+        DimensionRow dimensionRow2 = BardDimensionField.makeDimensionRow(dimension, "67890", "baz")
+        Set<DimensionRow> dimSet = [dimensionRow1, dimensionRow2] as Set
+
+        expect:
+        avroDimensionRowParser.parseAvroFileDimensionRows(dimension, "src/test/resources/avroFilesTesting/sampleData.avro", "src/test/resources/avroFilesTesting/sampleData.avsc") == dimSet
+    }
+
+    def "Invalid schema - Schema file does not exist throws an IllegalArgumentException"() {
+        when:
+        avroDimensionRowParser.parseAvroFileDimensionRows(dimension, "src/test/resources/avroFilesTesting/sampleData.avro", "src/test/resources/avroFilesTesting/foo.avsc")
+
+        then:
+        IllegalArgumentException exception = thrown(IllegalArgumentException)
+        exception.message == "Unable to process the file, at the location src/test/resources/avroFilesTesting/foo.avsc"
+    }
+
+    def "Schema file does not contain all the dimension fields throws an IllegalArgumentException"() {
+        given:
+        dimensionFields.add(BardDimensionField.FIELD1)
+
+        when:
+        avroDimensionRowParser.parseAvroFileDimensionRows(dimension, "src/test/resources/avroFilesTesting/sampleData.avro", "src/test/resources/avroFilesTesting/sampleData.avsc")
+
+        then:
+        IllegalArgumentException exception = thrown(IllegalArgumentException)
+        exception.message == "The AVRO schema file does not contain all the configured dimension fields"
+    }
+
+    def "Schema file does not contain the required `fields` section in its JSON throws an IllegalArgumentException" () {
+        when:
+        avroDimensionRowParser.parseAvroFileDimensionRows(dimension, "src/test/resources/avroFilesTesting/sampleData.avro", "src/test/resources/avroFilesTesting/invalidSchema.avsc")
+
+        then:
+        IllegalArgumentException exception = thrown(IllegalArgumentException)
+        exception.message == "`fields` is a required JSON field in the avro schema"
+    }
+}

--- a/fili-core/src/test/resources/avroFilesTesting/invalidSchema.avsc
+++ b/fili-core/src/test/resources/avroFilesTesting/invalidSchema.avsc
@@ -1,0 +1,18 @@
+{
+    "type" : "record",
+    "name" : "TUPLE_0",
+    "foo" : [
+        {
+            "name" : "FOO_ID",
+            "type" : [ "null","int" ]
+        },
+        {
+            "name" : "FOO_DESC",
+            "type" : [ "null", "string" ]
+        },
+        {
+            "name" : "MISCELLANEOUS",
+            "type" : [ "null", "string" ]
+        }
+    ]
+}

--- a/fili-core/src/test/resources/avroFilesTesting/sampleData.avsc
+++ b/fili-core/src/test/resources/avroFilesTesting/sampleData.avsc
@@ -1,0 +1,18 @@
+{  
+    "type" : "record",
+    "name" : "TUPLE_0",
+    "fields" : [  
+        {  
+            "name" : "FOO_ID",
+            "type" : [ "null","int" ]
+        },
+        {  
+            "name" : "FOO_DESC",
+            "type" : [ "null", "string" ]
+        },
+        {  
+            "name" : "MISCELLANEOUS",
+            "type" : [ "null", "string" ]
+        }
+    ]
+}

--- a/fili-core/src/test/resources/avroFilesTesting/sampleData.json
+++ b/fili-core/src/test/resources/avroFilesTesting/sampleData.json
@@ -1,0 +1,2 @@
+{ "FOO_ID" : { "int" : 12345 }, "FOO_DESC" : { "string" : "bar" }, "MISCELLANEOUS" : { "string" : "Field1" } }
+{ "FOO_ID" : { "int" : 67890 }, "FOO_DESC" : { "string" : "baz" }, "MISCELLANEOUS" : { "string" : "Field2" } }

--- a/fili-core/src/test/scripts/createAvro.bash
+++ b/fili-core/src/test/scripts/createAvro.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright 2016 Yahoo Inc.
+# Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+# This script turns the avro json data file into the binary avro data file based on the avro schema file using
+# the avro-tools.jar.
+
+# Clear the existing avro binary file.
+rm -rf ../resources/avroFilesTesting/sampleData.avro
+
+# The below command takes in a schema file and an associated avro data json file and converts it to an avro binary file.
+java -jar ../resources/jar/avro-tools.jar fromjson \
+--schema-file ../resources/avroFilesTesting/sampleData.avsc \
+../resources/avroFilesTesting/sampleData.json > ../resources/avroFilesTesting/sampleData.avro
+
+# Removing the jar file after the conversion is done.
+rm -rfR ../resources/jar/

--- a/fili-system-config/pom.xml
+++ b/fili-system-config/pom.xml
@@ -34,7 +34,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
                 <executions>
                     <execution>
                         <phase>generate-test-resources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,13 @@
                 <version>4.1</version>
             </dependency>
 
+            <!-- Apache Avro Libraries -->
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>1.8.0</version>
+            </dependency>
+
             <!-- All things Spring -->
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -654,6 +661,11 @@
                         <optimize>true</optimize>
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.7</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
- Adding `AvroDimensionRowParser` class that parses an AVRO data file(.avro) after validating the AVRO schema (.avsc).

- Adding a functional Interface `DimensionFieldMapper` that maps field name based on the user implementation.