### PR TITLE
Fixes the LogFormatterProvider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ Current
 
 ### Fixed:
 
+- [LogFormatterProvider incorrectly built the key for obtaining the custom LogFormatter implementation.](https://github.com/yahoo/fili/pull/87)
+
 - [Environment comma separated list variables are now correctly pulled in as a list](https://github.com/yahoo/fili/pull/82)
   * Before it was pulled in as a single sting containing commas, now environment variables are pulled in the same way as the properties files
   * Added test to test comma separated list environment variables when `FILI_TEST_LIST` environment variable exists

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogFormatterProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogFormatterProvider.java
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.logging;
 
 import com.yahoo.bard.webservice.config.SystemConfig;
 import com.yahoo.bard.webservice.config.SystemConfigProvider;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,17 +16,14 @@ public class LogFormatterProvider {
     private static final Logger LOG = LoggerFactory.getLogger(LogFormatterProvider.class);
     private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
 
-    private static final String DEFAULT_LOG_FORMATTER_IMPL = JsonLogFormatter.class.getCanonicalName();
+    public static final String LOG_FORMATTER_IMPLEMENTATION_SETTING_NAME = "log_formatter_implementation";
 
-    private static final String LOG_FORMATTER_IMPLEMENTATION_KEY = SystemConfigProvider.getInstance().getStringProperty(
-            SYSTEM_CONFIG.getPackageVariableName("log_formatter_implementation"),
-            DEFAULT_LOG_FORMATTER_IMPL
-    );
+    private static final String DEFAULT_LOG_FORMATTER_IMPL = JsonLogFormatter.class.getCanonicalName();
 
     /**
      * The instance of the Log Formatter.
      */
-    private static final LogFormatter LOG_FORMATTER = getInstance();
+    private static LogFormatter logFormatter;
 
     /**
      *  Get an instance of LogFormatter.
@@ -33,20 +31,18 @@ public class LogFormatterProvider {
      *  @return an instance of LogFormatter
      */
     public static LogFormatter getInstance() {
-        if (LOG_FORMATTER == null) {
+        if (logFormatter == null) {
+            String logFormatterImplementation = SystemConfigProvider.getInstance().getStringProperty(
+                    SYSTEM_CONFIG.getPackageVariableName(LOG_FORMATTER_IMPLEMENTATION_SETTING_NAME),
+                    DEFAULT_LOG_FORMATTER_IMPL
+            );
             try {
-                String logFormatterImplementation = SystemConfigProvider.getInstance().getStringProperty(
-                        SYSTEM_CONFIG.getPackageVariableName(LOG_FORMATTER_IMPLEMENTATION_KEY),
-                        DEFAULT_LOG_FORMATTER_IMPL
-                );
-
-                return (LogFormatter) Class.forName(logFormatterImplementation).newInstance();
+                logFormatter = (LogFormatter) Class.forName(logFormatterImplementation).newInstance();
             } catch (Exception exception) {
                 LOG.error("Exception while loading Log formatter: {}", exception);
                 throw new IllegalStateException(exception);
             }
         }
-
-        return LOG_FORMATTER;
+        return logFormatter;
     }
 }

--- a/fili-core/src/main/resources/moduleConfig.properties
+++ b/fili-core/src/main/resources/moduleConfig.properties
@@ -115,3 +115,7 @@ bard__default_asyncAfter=never
 
 # Flag to turn on case sensitive keys in keyvalue store
 bard__case_sensitive_keys_enabled = false
+
+# The implementation of the com.yahoo.bard.webservice.logging.LogFormatter to use to format the RequestLog logging
+# blocks. By default, the RequestLog is formatted as JSON.
+bard__log_formatter_implementation=com.yahoo.bard.webservice.logging.JsonLogFormatter

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/LogFormatterProviderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/LogFormatterProviderSpec.groovy
@@ -1,0 +1,67 @@
+package com.yahoo.bard.webservice.logging
+
+import static com.yahoo.bard.webservice.logging.LogFormatterProvider.LOG_FORMATTER_IMPLEMENTATION_SETTING_NAME
+
+import com.yahoo.bard.webservice.config.SystemConfig
+import com.yahoo.bard.webservice.config.SystemConfigException
+import com.yahoo.bard.webservice.config.SystemConfigProvider
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+
+class LogFormatterProviderSpec extends Specification {
+
+    @Shared LogFormatter originalLogFormatter
+    String originalLogFormatterClassName
+    SystemConfig systemConfig = SystemConfigProvider.instance;
+    String logFormatterKey = systemConfig.getPackageVariableName(LOG_FORMATTER_IMPLEMENTATION_SETTING_NAME)
+
+    def setupSpec() {
+        originalLogFormatter = LogFormatterProvider.logFormatter
+    }
+
+    def cleanupSpec() {
+        LogFormatterProvider.logFormatter = originalLogFormatter
+    }
+
+    def setup() {
+        LogFormatterProvider.logFormatter = null
+        try {
+            originalLogFormatterClassName = systemConfig.getStringProperty(logFormatterKey)
+        } catch(SystemConfigException ignored) {
+            originalLogFormatterClassName = null
+        }
+    }
+
+    def cleanup() {
+        if (originalLogFormatterClassName == null) {
+            systemConfig.clearProperty(logFormatterKey)
+        } else {
+            systemConfig.setProperty(logFormatterKey, originalLogFormatterClassName)
+        }
+    }
+
+    def "The LogFormatterProvider instantiates the configured logFormatter instance"() {
+        expect: "We haven't instantiated the log formatter yet"
+        LogFormatterProvider.logFormatter == null
+
+        when:
+        systemConfig.setProperty(logFormatterKey, TestLogFormatter.class.name)
+
+        then:
+        LogFormatterProvider.instance instanceof TestLogFormatter
+    }
+
+    def "When the LogFormatterProvider is not specified, we default to the JsonLogFormatter"() {
+        expect: "We haven't instantiated the log formatter yet"
+        LogFormatterProvider.logFormatter == null
+
+        when:
+        systemConfig.clearProperty(logFormatterKey)
+
+        then:
+        LogFormatterProvider.instance instanceof JsonLogFormatter
+    }
+
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/TestLogFormatter.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/TestLogFormatter.groovy
@@ -1,0 +1,11 @@
+package com.yahoo.bard.webservice.logging
+
+/**
+ * A Test implementation of the `LogFormatter` class for the purpose of testing the LogFormatterProvider.
+ */
+class TestLogFormatter implements LogFormatter {
+    @Override
+    String format(LogBlock logBlock) {
+        return "Hello world!"
+    }
+}


### PR DESCRIPTION
--Originally, we were requesting the LogFormatter implemnetation value twice, once at
static initialization time, and then again, _using the LogFormatter
class name as the key_. This has been corrected. We also added some
tests.

--We also made the initialization of the formatter lazy, largely because
my debugger didn't seem to be able to stop at methods that are invoked
at static initialization time, which made debugging this thing a hassle.
Making it lazy also made it a lot easier to clean up between tests.