### PR TITLE
Refactored TimeGrainDictionary out of StandardGranularityParser so as…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Current
 
 ### Changed:
 
+- [The `getGrainMap` method in `StandardGranularityParser` class is renamed to `getDefaultGrainMap` and is made public static.](https://github.com/yahoo/fili/pull/88)
+    - Created new class `GranularityDictionary` and bind getGranularityDictionary to it
+
 - [`PhysicalTable` now uses `getAvailableIntervals` internally rather than directly referencing its intervals](https://github.com/yahoo/fili/pull/79)
 
 - [CSV attachment name for multi-interval request now contain '__' instead of ','](https://github.com/yahoo/fili/pull/76)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/time/GranularityDictionary.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/time/GranularityDictionary.java
@@ -1,0 +1,13 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.time;
+
+import com.yahoo.bard.webservice.druid.model.query.Granularity;
+
+import java.util.HashMap;
+
+/**
+ * Map of Granularity name to Granularity.
+ */
+public class GranularityDictionary extends HashMap<String, Granularity> {
+}


### PR DESCRIPTION
… to expose the dictionary for extension and modification in binding as well as being able to be gotten outside of the GranularityParser interface.