### PR TITLE
Clean up too large to cache exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ Current
 
 ### Added:
 
-
+- [Ability to not try to cache Druid responses that are larger than the maximum size supported by the cache implementation](https://github.com/yahoo/fili/pull/93)
+    * Supported for both Cache v1 and V2
+    * Controlled with `bard__druid_max_response_length_to_cache` setting
+    * Default value is `MAX_LONG`, so no cache prevention will happen by default
 
 ### Changed:
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessor.java
@@ -5,6 +5,8 @@ package com.yahoo.bard.webservice.web.responseprocessors;
 import static com.yahoo.bard.webservice.web.handlers.PartialDataRequestHandler.getPartialIntervalsWithDefault;
 import static com.yahoo.bard.webservice.web.handlers.VolatileDataRequestHandler.getVolatileIntervalsWithDefault;
 
+import com.yahoo.bard.webservice.config.SystemConfig;
+import com.yahoo.bard.webservice.config.SystemConfigProvider;
 import com.yahoo.bard.webservice.data.cache.TupleDataCache;
 import com.yahoo.bard.webservice.druid.client.FailureCallback;
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
@@ -27,6 +29,14 @@ import javax.validation.constraints.NotNull;
 public class CacheV2ResponseProcessor implements ResponseProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(CacheV2ResponseProcessor.class);
+    private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
+
+    private final long maxDruidResponseLengthToCache = SYSTEM_CONFIG.getLongProperty(
+            SYSTEM_CONFIG.getPackageVariableName(
+                    "druid_max_response_length_to_cache"
+            ),
+            Long.MAX_VALUE
+    );
 
     private final ResponseProcessor next;
     private final String cacheKey;
@@ -79,11 +89,20 @@ public class CacheV2ResponseProcessor implements ResponseProcessor {
             String valueString = null;
             try {
                 valueString = writer.writeValueAsString(json);
-                dataCache.set(
-                        cacheKey,
-                        querySigningService.getSegmentSetId(druidQuery).orElse(null),
-                        valueString
-                );
+                int valueLength = valueString.length();
+                if (valueLength <= maxDruidResponseLengthToCache) {
+                    dataCache.set(
+                            cacheKey,
+                            querySigningService.getSegmentSetId(druidQuery).orElse(null),
+                            valueString
+                    );
+                } else {
+                    LOG.debug(
+                            "Response not cached. Length of {} exceeds max value length of {}",
+                            valueLength,
+                            maxDruidResponseLengthToCache
+                    );
+                }
             } catch (Exception e) {
                 LOG.warn(
                         "Unable to cache {}value of size: {}",

--- a/fili-core/src/main/resources/moduleConfig.properties
+++ b/fili-core/src/main/resources/moduleConfig.properties
@@ -53,6 +53,10 @@ bard__memcached_expiration_seconds = 3600
 # Data Cache
 bard__druid_cache_enabled = true
 
+# Maximum Druid response size to cache, in bytes. Defaults to MAX_LONG (9223372036854775807)
+# If using memcached, make sure this aligns with the setting memcached is using, overridden with it's -I parameter
+bard__druid_max_response_length_to_cache = 9223372036854775807
+
 # Data Cache V2 (needs the above flag set as well)
 bard__druid_cache_v2_enabled = true
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessorSpec.groovy
@@ -7,6 +7,8 @@ import static com.yahoo.bard.webservice.util.SimplifiedIntervalList.NO_INTERVALS
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.MISSING_INTERVALS_CONTEXT_KEY
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.VOLATILE_INTERVALS_CONTEXT_KEY
 
+import com.yahoo.bard.webservice.config.SystemConfig
+import com.yahoo.bard.webservice.config.SystemConfigProvider
 import com.yahoo.bard.webservice.data.cache.TupleDataCache
 import com.yahoo.bard.webservice.data.metric.mappers.ResultSetMapper
 import com.yahoo.bard.webservice.druid.client.FailureCallback
@@ -31,6 +33,8 @@ import spock.lang.Unroll
 class CacheV2ResponseProcessorSpec extends Specification {
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+
+    private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.instance
 
     ResponseProcessor next = Mock(ResponseProcessor)
     String cacheKey = "SampleKey"
@@ -153,6 +157,37 @@ class CacheV2ResponseProcessorSpec extends Specification {
         2 * next.getResponseContext() >> responseContext
         1 * next.processResponse(json, groupByQuery, null)
         0 * dataCache.set(*_)
+    }
+
+    def "Overly long data doesn't cache and then continues"() {
+        setup: "Save the old max-length-to-cache so we can restore it later"
+        String max_druid_response_length_to_cache_key = SYSTEM_CONFIG.getPackageVariableName(
+                "druid_max_response_length_to_cache"
+        )
+        long oldMaxLength = SYSTEM_CONFIG.getLongProperty(max_druid_response_length_to_cache_key)
+
+        and: "A very small max-length-to-cache"
+        long smallMaxLength = 1L
+        SYSTEM_CONFIG.resetProperty(max_druid_response_length_to_cache_key, smallMaxLength.toString())
+
+        and: "A workable response context"
+        next.getResponseContext() >> responseContext
+
+        and: "A caching response processor to test"
+        crp = new CacheV2ResponseProcessor(next, cacheKey, dataCache, querySigningService, MAPPER)
+
+        expect: "The JSON representation is longer than the small max length"
+        MAPPER.writer().writeValueAsString(json).length() > smallMaxLength
+
+        when: "We try to cache a value longer than the small max length"
+        crp.processResponse(json, groupByQuery, null)
+
+        then: "Set is never called on the cache and the next handler is called"
+        1 * next.processResponse(json, groupByQuery, null)
+        0 * dataCache.set(*_)
+
+        cleanup: "Restore the original setting for max-length-to-cache"
+        SYSTEM_CONFIG.resetProperty(max_druid_response_length_to_cache_key, oldMaxLength.toString())
     }
 
     def "Test proxy calls"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessorSpec.groovy
@@ -126,7 +126,7 @@ class CacheV2ResponseProcessorSpec extends Specification {
         then:
         2 * next.getResponseContext() >> responseContext
         1 * next.processResponse(json, groupByQuery, null)
-        0 * dataCache.set(_, _)
+        0 * dataCache.set(*_)
     }
 
     def "Partial data doesn't cache and then continues"() {
@@ -139,7 +139,7 @@ class CacheV2ResponseProcessorSpec extends Specification {
         then:
         2 * next.getResponseContext() >> responseContext
         1 * next.processResponse(json, groupByQuery, null)
-        0 * dataCache.set(cacheKey, _)
+        0 * dataCache.set(*_)
     }
 
     def "Volatile data doesn't cache and then continues"() {
@@ -152,7 +152,7 @@ class CacheV2ResponseProcessorSpec extends Specification {
         then:
         2 * next.getResponseContext() >> responseContext
         1 * next.processResponse(json, groupByQuery, null)
-        0 * dataCache.set(cacheKey, '[]')
+        0 * dataCache.set(*_)
     }
 
     def "Test proxy calls"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CachingResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CachingResponseProcessorSpec.groovy
@@ -116,7 +116,7 @@ class CachingResponseProcessorSpec extends Specification {
         then:
         2 * next.getResponseContext() >> responseContext
         1 * next.processResponse(json, groupByQuery, null)
-        0 * dataCache.set(_, _)
+        0 * dataCache.set(*_)
     }
 
     def "Partial data doesn't cache and then continues"() {
@@ -129,7 +129,7 @@ class CachingResponseProcessorSpec extends Specification {
         then:
         2 * next.getResponseContext() >> responseContext
         1 * next.processResponse(json, groupByQuery, null)
-        0 * dataCache.set(cacheKey, _)
+        0 * dataCache.set(*_)
     }
 
     def "Volatile data doesn't cache and then continues"() {
@@ -142,7 +142,7 @@ class CachingResponseProcessorSpec extends Specification {
         then:
         2 * next.getResponseContext() >> responseContext
         1 * next.processResponse(json, groupByQuery, null)
-        0 * dataCache.set(cacheKey, '[]')
+        0 * dataCache.set(*_)
     }
 
     def "Test proxy calls"() {


### PR DESCRIPTION
Adding the ability to not even try caching Druid responses that seem like they will be too big. This is fully optional, and defaults to not caching anything longer than `MAX_LONG`.

Note: This is built on the pending release. Once that merges, this PR will be updated to be based on `master` directly.