### PR TITLE
Generalizes `RequestValidationException::getStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ Current
 
 ### Changed:
 
-
+- [`ResponseValidationException` uses `Response.StatusType` rather than `Response.Status`](https://github.com/yahoo/fili/pull/96)
+    * `Response.StatusType` is the interface that `Response.Status` implements.
+    * This will have no impact on current code in Fili that uses `ResponseValidationException`, and it allows customers to inject http
+        codes not included in `Response.Status`. 
 
 ### Deprecated:
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/RequestValidationException.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/RequestValidationException.java
@@ -10,7 +10,7 @@ import javax.ws.rs.core.Response;
  * ApiRequest Validation Failed.
  */
 public class RequestValidationException extends IOException {
-    private final Response.Status status;
+    private final Response.StatusType status;
     private final String errorHttpMsg;
 
     /**
@@ -20,7 +20,7 @@ public class RequestValidationException extends IOException {
      * @param errorHttpMsg the error HTTP message to throw back to user
      * @param msg the error message
      */
-    public RequestValidationException(Response.Status status, String errorHttpMsg, String msg) {
+    public RequestValidationException(Response.StatusType status, String errorHttpMsg, String msg) {
         super(msg);
         this.status = status;
         this.errorHttpMsg = errorHttpMsg;
@@ -33,13 +33,13 @@ public class RequestValidationException extends IOException {
      * @param errorHttpMsg the error HTTP message to throw back to user
      * @param throwable the throwable
      */
-    public RequestValidationException(Response.Status status, String errorHttpMsg, Throwable throwable) {
+    public RequestValidationException(Response.StatusType status, String errorHttpMsg, Throwable throwable) {
         super(throwable);
         this.status = status;
         this.errorHttpMsg = errorHttpMsg;
     }
 
-    public Response.Status getStatus() {
+    public Response.StatusType getStatus() {
         return status;
     }
 


### PR DESCRIPTION
--`Response.Status` does not contain a remotely complete list of HTTP
status codes, including 422: Unprocessable Entity. 422 is quite useful
when users have correct syntax but incorrect semantics (which may happen
when a Fili customer imposes table-specific restrictions in their system).

--By having `RequestValidationException::getStatus` return
`Response.StatusType` (an interface) rather than `Response.Status` (an
enum), customers may use other HTTP status codes by providing the
appropriate implementation of `Response.StatusType`.