### PR TITLE
Can now inject a subclass of `DruidQueryBuilder`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Current
 
 ### Fixed:
 
+- [Made a few injection points not useless](https://github.com/yahoo/fili/pull/98)
+    * Template types don't get the same subclass goodness that method invocation and
+        dependencies get, so this method did not allow returning a subclass of
+       `DruidQueryBuilder` or of `DruidResponseParser`.
 
 
 ### Known Issues:

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -334,7 +334,7 @@ public abstract class AbstractBinderFactory implements BinderFactory {
      *
      * @return An isntance of the {@link DruidQueryBuilder}
      */
-    protected Class<DruidQueryBuilder> buildDruidQueryBuilder() {
+    protected Class<? extends DruidQueryBuilder> buildDruidQueryBuilder() {
         return DruidQueryBuilder.class;
     }
 
@@ -343,7 +343,7 @@ public abstract class AbstractBinderFactory implements BinderFactory {
      *
      * @return An instance of the {@link DruidResponseParser}
      */
-    protected Class<DruidResponseParser> buildDruidResponseParser() {
+    protected Class<? extends DruidResponseParser> buildDruidResponseParser() {
         return DruidResponseParser.class;
     }
 


### PR DESCRIPTION
--The original return type did not allow returning the class of a
subtype of `DruidQueryBuilder` because template types are much more
rigid than standard Java types by default.