### PR TITLE
Fix and refactor role based filter to allow CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,15 @@ Current
 
 ### Fixed:
 
+- [Fix and refactor role based filter to allow CORS](https://github.com/yahoo/fili/pull/99)
+    * Fix `RoleBasedAuthFilter` to bypass `OPTIONS` request for CORS
+    * Discovered a bug where `user_roles` is declared but unset still reads as a list with empty string (included a temporary fix by commenting the variable declaration)
+    * Refactored `RoleBasedAuthFilter` and `RoleBasedAuthFilterSpec` for better testing
+
 - [Made a few injection points not useless](https://github.com/yahoo/fili/pull/98)
     * Template types don't get the same subclass goodness that method invocation and
         dependencies get, so this method did not allow returning a subclass of
        `DruidQueryBuilder` or of `DruidResponseParser`.
-
 
 ### Known Issues:
 

--- a/fili-core/src/main/resources/moduleConfig.properties
+++ b/fili-core/src/main/resources/moduleConfig.properties
@@ -104,8 +104,8 @@ bard__updated_metadata_collection_names_enabled = false
 # change the predefined order of Durations, Threads, Preface at the start and of Epilogue at the end of the log line.
 # bard__requestlog_loginfo_order = BardQueryInfo,DataRequest,DimensionRequest,MetricRequest,SliceRequest,TableRequest,FeatureFlagRequest,DruidResponse
 
-# List of allowed user roles
-bard__user_roles=
+# List of allowed user roles, must provide value if uncommented
+# bard__user_roles=
 
 # Default wait to use when no asyncAfter parameter is specified. It can be the String 'never' (all requests are
 #synchronous), the String 'always' (all requests are asynchronous) or a time duration in milliseconds.


### PR DESCRIPTION
* Fix `RoleBasedAuthFilter` to bypass `OPTIONS` request for CORS
* Discovered a bug where `user_roles` is declared but unset still reads as a list with empty string (included a temporary fix by deleting the variable declaration)
* Refactored `RoleBasedAuthFilter` and `RoleBasedAuthFilterSpec` for better testing