### PR TITLE
Including slf4j/logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,13 +149,11 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${version.slf4j}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${version.logback}</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- Validation -->


### PR DESCRIPTION
wikipedia-example is failing because slf4j/logback are not included in the jar.