### PR TITLE
YAML-based configuration

### DIFF
--- a/fili-core/pom.xml
+++ b/fili-core/pom.xml
@@ -125,6 +125,10 @@
             <artifactId>jackson-dataformat-csv</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
             <!--TODO: switch back to jackson parser-->
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMaker.java
@@ -1,0 +1,59 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.makers;
+
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
+import com.yahoo.bard.webservice.data.metric.mappers.NoOpResultSetMapper;
+import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
+import com.yahoo.bard.webservice.druid.model.aggregation.FilteredAggregation;
+import com.yahoo.bard.webservice.druid.model.filter.Filter;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Build a Filtered Aggregation logical metric.
+ */
+public class FilteredAggregationMaker extends MetricMaker {
+
+    protected final Filter filter;
+    protected final MetricDictionary metricDictionary;
+    protected final Aggregation aggregation;
+
+    /**
+     * Construct a metric maker for Filtered Aggregations.
+     *
+     * @param metricDictionary the metric dictionary
+     * @param aggregation the underlying aggregation
+     * @param filter the filter to filter the aggregation by
+     */
+    public FilteredAggregationMaker(MetricDictionary metricDictionary, Aggregation aggregation, Filter filter) {
+        super(metricDictionary);
+        this.aggregation = aggregation;
+        this.filter = filter;
+        this.metricDictionary = metricDictionary;
+    }
+
+    @Override
+    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+        FilteredAggregation filteredAggregation = new FilteredAggregation(
+                metricName,
+                aggregation.getFieldName(),
+                aggregation,
+                filter
+        );
+        return new LogicalMetric(
+                new TemplateDruidQuery(Collections.singleton(filteredAggregation), Collections.emptySet()),
+                new NoOpResultSetMapper(),
+                metricName
+        );
+    }
+
+    @Override
+    protected int getDependentMetricsRequired() {
+        return 0;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/MetricParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/MetricParser.java
@@ -1,0 +1,297 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser;
+
+import com.yahoo.bard.webservice.data.config.metric.parser.lexer.LexException;
+import com.yahoo.bard.webservice.data.config.metric.parser.lexer.Lexeme;
+import com.yahoo.bard.webservice.data.config.metric.parser.lexer.LexemeType;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.ConstantMetricNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.IdentifierNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.MetricNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand;
+import com.yahoo.bard.webservice.data.config.metric.parser.operator.ArithmeticOperator;
+import com.yahoo.bard.webservice.data.config.metric.parser.operator.BinaryFilterOperator;
+import com.yahoo.bard.webservice.data.config.metric.parser.operator.FilterOperator;
+import com.yahoo.bard.webservice.data.config.metric.parser.operator.FunctionOperator;
+import com.yahoo.bard.webservice.data.config.metric.parser.operator.Operator;
+import com.yahoo.bard.webservice.data.config.metric.parser.operator.Precedence;
+import com.yahoo.bard.webservice.data.config.metric.parser.operator.Sentinel;
+import com.yahoo.bard.webservice.data.config.provider.MakerDictionary;
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Queue;
+
+/**
+ * Metric parser.
+ */
+public class MetricParser {
+
+    private String name;
+
+    // All lookups happen here; this is where the metrics all end up
+    private final MetricDictionary dict;
+    private final MetricDictionary tempDict;
+
+    static int TEMP_IDENTIFIER = 0;
+    static String TEMP_BASE = "__temp_metric_";
+
+    private final Deque<Operator> operatorStack = new ArrayDeque<>();
+    private final Deque<Operand> operandStack = new ArrayDeque<>();
+
+    private final DimensionDictionary dimensionDictionary;
+    private final MakerDictionary makerDict;
+    private final String metricDefinition;
+
+    private Queue<Lexeme> items;
+
+    /**
+     * Parse a metric.
+     *
+     * @param metricName The metric name
+     * @param metricDefinition The metric definition, as a string
+     * @param dict the base metric dictionary
+     * @param tempDict the temporary scoped metric dictionary
+     * @param makerDict the metric maker dictionary
+     * @param dimensionDictionary the dimension dictionary
+     */
+    public MetricParser(
+            String metricName,
+            String metricDefinition,
+            MetricDictionary dict,
+            MetricDictionary tempDict,
+            MakerDictionary makerDict,
+            DimensionDictionary dimensionDictionary
+    ) {
+        this.name = metricName;
+        this.dict = dict;
+        this.tempDict = tempDict;
+        this.makerDict = makerDict;
+        this.dimensionDictionary = dimensionDictionary;
+        this.metricDefinition = metricDefinition;
+    }
+
+    /**
+     * Parses the metric def and returns a LogicalMetric; caller should add to dictionary.
+     *
+     * @return a logical metric
+     * @throws IOException when a lexing or parsing error occurs
+     */
+    public LogicalMetric parse() throws IOException {
+
+        try {
+            items = Lexeme.lex(metricDefinition);
+        } catch (LexException e) {
+            throw new ParsingException(
+                    "Error occurred while lexing metric " + name + " with definition " + metricDefinition,
+                    e
+            );
+        }
+
+        try {
+            MetricNode node = innerParse();
+            return node.make(name, tempDict);
+        } catch (ParsingException e) {
+            throw new ParsingException(
+                    "Error occurred while parsing metric " + name + " with definition " + metricDefinition,
+                    e
+            );
+        }
+    }
+
+    /**
+     * Parses the metric def and returns a MetricNode.
+     *
+     * @return a Metric Node
+     * @throws ParsingException when a parsing error occurs
+     */
+    protected MetricNode innerParse() throws ParsingException {
+        operatorStack.push(new Sentinel());
+        parseExpression();
+        Operand o = operandStack.peek();
+        return o.getMetricNode();
+    }
+
+    /**
+     * Parse an expression
+     *
+     * Uses the shunting yard algorithm ( https://www.engr.mun.ca/~theo/Misc/exp_parsing.htm#shunting_yard or wiki),
+     * with some minor changes to handle things like function calls.
+     *
+     * @throws ParsingException when a parsing error occurs
+     */
+    public void parseExpression() throws ParsingException {
+        consumeNext();
+
+        // Handle most operators; functions are handled inside consumeNext()
+        while (true) {
+            Lexeme current;
+            if ((current = peekPop(LexemeType.BINARY_OPERATOR)) != null) {
+                pushOperator(ArithmeticOperator.fromString(current.getToken()));
+                consumeNext();
+            } else if ((current = peekPop(LexemeType.FILTER_OPERATOR)) != null) {
+                pushOperator(BinaryFilterOperator.fromString(current.getToken()));
+                consumeNext();
+            } else if ((peekPop(LexemeType.PIPE)) != null) {
+                pushOperator(new FilterOperator());
+                consumeNext();
+            } else {
+                break;
+            }
+        }
+
+        while (operatorStack.peek().getPrecedence().greaterThan(Precedence.SENTINEL)) {
+            popOperator();
+        }
+    }
+
+    /**
+     * Consume and parse the next token/lexeme on the stack.
+     *
+     * @throws ParsingException when a parsing error occurs
+     */
+    private void consumeNext() throws ParsingException {
+        Lexeme current = items.remove();
+        LexemeType type = current.getType();
+
+        switch (type) {
+            case NUMBER:
+            case DOUBLE_QUOTED_STRING:
+            case SINGLE_QUOTED_STRING:
+                operandStack.push(new ConstantMetricNode(current.getToken()));
+                break;
+            case L_PAREN:
+                operatorStack.push(new Sentinel());
+                parseExpression();
+                expect(LexemeType.R_PAREN);
+                operatorStack.pop();
+                break;
+
+            case IDENTIFIER:
+                if (peekType(LexemeType.L_PAREN)) {
+                    expect(LexemeType.L_PAREN);
+                    int nArgs = parseFuncArgs();
+                    expect(LexemeType.R_PAREN);
+                    pushOperator(new FunctionOperator(makerDict.get(current.getToken()), nArgs));
+                } else {
+                    operandStack.push(new IdentifierNode(current.getToken(), dimensionDictionary, dict));
+                }
+                break;
+            default:
+                throw new ParsingException("Unexpected token:" + current.getToken());
+        }
+    }
+
+    /**
+     * Helper function to parse arguments to a function.
+     *
+     * @return the number of args parsed and placed onto the operand stack
+     * @throws ParsingException when a parsing error occurs
+     */
+    private int parseFuncArgs() throws ParsingException {
+        int argc = 0;
+
+        while (true) {
+            operatorStack.push(new Sentinel());
+            parseExpression();
+            argc += 1;
+            operatorStack.pop();
+
+            if (!peekType(LexemeType.COMMA)) {
+                break;
+            }
+            expect(LexemeType.COMMA);
+        }
+
+        return argc;
+    }
+
+    /**
+     * Get the next item on the top of the lexeme stack if it matches `type`, or throw an exception.
+     *
+     * @param type Lexeme type
+     * @return the item of the specified type
+     * @throws ParsingException when a parsing error occurs
+     */
+    private Lexeme expect(LexemeType type) throws ParsingException {
+        Lexeme current = items.remove();
+        if (!(current.getType() == type)) {
+            throw new ParsingException("Unexpected token type: found " + current.getType() + " but expected " + type);
+        }
+        return current;
+    }
+
+    /**
+     * Return true if the lexeme on the top of the stack equals the passed-in type.
+     *
+     * @param type lexeme type
+     * @return true if the top item matches, false otherwise
+     */
+    private boolean peekType(LexemeType type) {
+        return items.size() != 0 && (items.peek().getType() == type);
+    }
+
+    /**
+     * Return the next lexeme if it matches `type`, or null.
+     *
+     * @param type lexeme type
+     * @return item if the top item's type matches, null otherwise
+     * @throws ParsingException when a parsing error occurs
+     */
+    private Lexeme peekPop(LexemeType type) throws ParsingException {
+        if (peekType(type)) {
+            return expect(type);
+        }
+
+        return null;
+    }
+
+    /**
+     * Operator stack pop.
+     */
+    private void popOperator() {
+        if (operatorStack.peek().getPrecedence().greaterThan(Precedence.SENTINEL)) {
+            Operator operator = operatorStack.pop();
+            LinkedList<Operand> operands = new LinkedList<>();
+
+            for (int i = 0; i < operator.getNumOperands(); i++) {
+                operands.addFirst(operandStack.pop());
+            }
+
+            operandStack.push(operator.build(operands));
+        }
+    }
+
+    /**
+     * Operator stack push.
+     *
+     * @param op the operator to add to the stack
+     */
+    private void pushOperator(Operator op) {
+        while (true) {
+            if (operatorStack.peek().greaterThan(op)) {
+                popOperator();
+            } else {
+                break;
+            }
+        }
+        operatorStack.push(op);
+    }
+
+    /**
+     * Generate a globally unique new name.
+     * <p>
+     * Note: this assumes that we've chosen a sufficiently unique prefix.
+     *
+     * @return the new name
+     */
+    public synchronized static String getNewName() {
+        return TEMP_BASE + TEMP_IDENTIFIER++;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/MetricParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/MetricParser.java
@@ -39,8 +39,9 @@ public class MetricParser {
     private final MetricDictionary dict;
     private final MetricDictionary tempDict;
 
-    static int TEMP_IDENTIFIER = 0;
-    static String TEMP_BASE = "__temp_metric_";
+    // Yes, this will eventually roll over. No, this is certainly not the right way to do this.
+    private static long TEMP_IDENTIFIER = 0;
+    private static String TEMP_BASE = "__temp_metric_";
 
     private final Deque<Operator> operatorStack = new ArrayDeque<>();
     private final Deque<Operand> operandStack = new ArrayDeque<>();
@@ -221,7 +222,7 @@ public class MetricParser {
      */
     private Lexeme expect(LexemeType type) throws ParsingException {
         Lexeme current = items.remove();
-        if (!(current.getType() == type)) {
+        if (current.getType() != type) {
             throw new ParsingException("Unexpected token type: found " + current.getType() + " but expected " + type);
         }
         return current;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/MetricParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/MetricParser.java
@@ -22,7 +22,6 @@ import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -82,9 +81,9 @@ public class MetricParser {
      * Parses the metric def and returns a LogicalMetric; caller should add to dictionary.
      *
      * @return a logical metric
-     * @throws IOException when a lexing or parsing error occurs
+     * @throws ParsingException when a lexing or parsing error occurs
      */
-    public LogicalMetric parse() throws IOException {
+    public LogicalMetric parse() throws ParsingException {
 
         try {
             items = Lexeme.lex(metricDefinition);
@@ -255,8 +254,10 @@ public class MetricParser {
 
     /**
      * Operator stack pop.
+     *
+     * @throws ParsingException when an error occurs building
      */
-    private void popOperator() {
+    private void popOperator() throws ParsingException {
         if (operatorStack.peek().getPrecedence().greaterThan(Precedence.SENTINEL)) {
             Operator operator = operatorStack.pop();
             LinkedList<Operand> operands = new LinkedList<>();
@@ -273,8 +274,10 @@ public class MetricParser {
      * Operator stack push.
      *
      * @param op the operator to add to the stack
+     *
+     * @throws ParsingException when an error occurs building
      */
-    private void pushOperator(Operator op) {
+    private void pushOperator(Operator op) throws ParsingException {
         while (true) {
             if (operatorStack.peek().greaterThan(op)) {
                 popOperator();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/ParsingException.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/ParsingException.java
@@ -1,0 +1,31 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser;
+
+import java.io.IOException;
+
+/**
+ * Thrown when an error occurs while parsing.
+ */
+public class ParsingException extends IOException {
+
+    /**
+     * Construct a ParsingException with the given message.
+     *
+     * @param s message
+     */
+    public ParsingException(String s) {
+        super(s);
+    }
+
+    /**
+     * Construct a ParsingException with the given message and cause.
+     *
+     * @param s message
+     * @param e cause
+     */
+    public ParsingException(String s, Throwable e) {
+        super(s, e);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexException.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexException.java
@@ -1,0 +1,22 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.lexer;
+
+import java.io.IOException;
+
+/**
+ * A LexException may be thrown if errors are found when lexing the metric string.
+ */
+public class LexException extends IOException {
+
+    /**
+     * Exception that is thrown when lexing fails.
+     *
+     * @param message the error message
+     * @param current the current position while lexing
+     */
+    public LexException(String message, String current) {
+        super(message + "; (parsing failed beginning at: " + current + ")");
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/lexer/Lexeme.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/lexer/Lexeme.java
@@ -1,0 +1,146 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.lexer;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.Queue;
+
+/**
+ * A lexeme represents a single input token and contains the type of token and its content.
+ *
+ * This class also contains utility methods for producing lexemes for an entire string.
+ */
+public class Lexeme {
+
+    protected final String token;
+    protected final LexemeType type;
+    protected final int length;
+
+    /**
+     * Construct a new lexeme.
+     *
+     * @param type the type of lexeme
+     * @param token the content
+     */
+    public Lexeme(LexemeType type, String token) {
+        this(type, token, token.length());
+    }
+
+    /**
+     * Construct a new lexeme.
+     *
+     * @param type the type of lexeme
+     * @param token the content
+     * @param length the consumed length of the token
+     */
+    public Lexeme(LexemeType type, String token, int length) {
+        this.type = type;
+        this.token = token;
+        this.length = length;
+    }
+
+    /**
+     * Get the lexeme content.
+     *
+     * @return the content of this lexeme
+     */
+    public String getToken() {
+        return token;
+    }
+
+    /**
+     * Get the lexeme type.
+     *
+     * @return the LexemeType
+     */
+    public LexemeType getType() {
+        return type;
+    }
+
+    /**
+     * Get the consumed lexeme length.
+     *
+     * Typically equal to the size of the token, but in special cases may be longer.
+     * For example, 'foo' has a token of foo (no quotes) but length of 5.
+     *
+     * @return integer length
+     */
+    public int getConsumedLength() {
+        return length;
+    }
+
+    /**
+     * Return Lexemes parsed from the input string.
+     *
+     * @param input the input string to be lexed
+     * @return A queue of tokens/lexemes
+     * @throws LexException when an error occurs
+     */
+    public static Queue<Lexeme> lex(String input) throws LexException {
+        Queue<Lexeme> lexemes = new LinkedList<>();
+        int pos = 0;
+
+        // Read the entire input.
+        // We break out of loop when:
+        // - we get to the end of the line (get it?)
+        // - we reach a position at which there is no valid lexeme (exception thrown)
+        while (pos < input.length()) {
+            // All whitespace between lexemes is skipped
+            while (pos < input.length() && (input.charAt(pos) == '\t' || input.charAt(pos) == ' ')) {
+                pos++;
+            }
+            if (pos >= input.length()) {
+                break;
+            }
+
+            // Throws a LexException if no possible lexeme can be found
+            Lexeme lexeme = getNextLexeme(input.substring(pos));
+            lexemes.add(lexeme);
+            pos += lexeme.getConsumedLength();
+        }
+
+        return lexemes;
+    }
+
+    /**
+     * Get the next lexeme.
+     *
+     * @param inputString the input string
+     * @return The lexeme
+     * @throws LexException if a viable lexeme can not be created
+     */
+    protected static Lexeme getNextLexeme(String inputString) throws LexException {
+        return Arrays.stream(LexemeType.values())
+                .map(a -> a.buildLexeme(inputString))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(
+                        () -> new LexException("Viable option for lexing could not be found", inputString));
+    }
+
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof Lexeme)) {
+            return false;
+        }
+
+        Lexeme other = (Lexeme) obj;
+        return Objects.equals(token, other.token) &&
+                Objects.equals(type, other.type) &&
+                Objects.equals(length, other.length);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(token, type, length);
+    }
+
+    @Override
+    public String toString() {
+        return "Lexeme<type=" + type + " token=" + token + " length=" + length + ">";
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexemeBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexemeBuilder.java
@@ -1,0 +1,21 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.lexer;
+
+/**
+ * Given an input string, produce the Lexeme at the beginning of the string.
+ */
+public interface LexemeBuilder {
+
+    /**
+     * Build a lexeme.
+     *
+     * May only consume part of the input string; you must check
+     * Lexeme.getConsumedLength() to see how much of the string was consumed.
+     *
+     * @param inputString the string to consume a lexeme from
+     * @return a Lexeme
+     */
+    Lexeme build(String inputString);
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexemeType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexemeType.java
@@ -1,0 +1,125 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.lexer;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * Available token types.
+ *
+ * The order these are defined is the order that matching will be attempted.
+ */
+public enum LexemeType {
+
+    /**
+     * A binary arithmetic operator: +, -, *, /.
+     */
+    BINARY_OPERATOR("+", "-", "*", "/"),
+
+    /**
+     * A Druid filter operator: &amp;&amp;, ||, ==.
+     *
+     * Must be above PIPE since OR looks like two pipes.
+     */
+    FILTER_OPERATOR("&&", "||", "=="),
+
+    /**
+     * A pipe (filter-by).
+     */
+    PIPE("|"),
+
+    /**
+     * A "double quoted string" that can have slash-escaped double quotes in it.
+     */
+    DOUBLE_QUOTED_STRING(Pattern.compile("^\"((?:[^\"\\\\]*(?:\\\\.)?)*)\"")),
+
+    /**
+     * A 'single quoted string' that can have slash-escaped quotes in it.
+     */
+    SINGLE_QUOTED_STRING(Pattern.compile("^'((?:[^'\\\\]*(?:\\\\.)?)*)'")),
+
+    /**
+     * A comma.
+     */
+    COMMA(","),
+
+    /**
+     * A left paren.
+     */
+    L_PAREN("("),
+
+    /**
+     * A right paren.
+     */
+    R_PAREN(")"),
+
+    /**
+     * Any number (not including sign).
+     *
+     * Note that '100.' is a false positive here - it matches '100', but lexing will fail when you reach '.' as that
+     * character is invalid
+     */
+    NUMBER(Pattern.compile("^(([0-9]\\d*\\.\\d+)|(\\.\\d+)|([1-9][0-9]*))")),
+
+    /**
+     * Any string identifier.
+     */
+    IDENTIFIER(Pattern.compile("^([a-zA-Z_][a-zA-Z0-9_]*)"));
+
+    // An enum constant's LexemeBuilder can try to create a lexeme of its own type
+    protected final LexemeBuilder builder;
+
+    /**
+     * Lexeme type matched by a set of valid strings.
+     *
+     * @param validStrings valid strings
+     */
+    LexemeType(String... validStrings) {
+        this.builder = (inputString) -> Arrays.stream(validStrings)
+                .filter(inputString::startsWith)
+                .map(s -> new Lexeme(this, s))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Lexeme type matched by a regex.
+     *
+     * The regex should match the content it wants in group 1; the full length of the match
+     * will be used as the lexeme length.
+     *
+     * For example, for a single quoted string like 'foo', the consumed length is 5
+     * but the returned token is [foo] (unquoted).
+     *
+     * This removes a little complexity in the parser; it doesn't have to deal
+     * with quotes at all. It also means in the lexer we can discard insignificant
+     * whitespace, etc.
+     *
+     * @param pattern valid pattern
+     */
+    LexemeType(Pattern pattern) {
+        this.builder = (inputString) -> {
+            Matcher matcher = pattern.matcher(inputString);
+            if (matcher.find()) {
+                return new Lexeme(this, matcher.group(1), matcher.group(0).length());
+            }
+            return null;
+        };
+    }
+
+    /**
+     * Attempt to build a lexeme for the current LexemeType.
+     *
+     * Will return null if no match can be constructed.
+     *
+     * @param inputString the current input
+     * @return a Lexeme of the current type, or null if no Lexeme for the current type can be built
+     */
+    public Lexeme buildLexeme(String inputString) {
+        return builder.build(inputString);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/AndFilterNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/AndFilterNode.java
@@ -1,0 +1,33 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.druid.model.filter.AndFilter;
+import com.yahoo.bard.webservice.druid.model.filter.Filter;
+
+import java.util.Arrays;
+
+/**
+ * A filter representing AND.
+ */
+public class AndFilterNode extends FilterNode {
+    protected final FilterNode left;
+    protected final FilterNode right;
+
+    /**
+     * Construct a new AndFilter.
+     *
+     * @param left left operand
+     * @param right right operand
+     */
+    public AndFilterNode(FilterNode left, FilterNode right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public Filter buildFilter() {
+        return new AndFilter(Arrays.asList(left.buildFilter(), right.buildFilter()));
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/ArithmeticMetricNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/ArithmeticMetricNode.java
@@ -1,0 +1,53 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.data.config.metric.makers.ArithmeticMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker;
+import com.yahoo.bard.webservice.data.config.metric.parser.MetricParser;
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+import com.yahoo.bard.webservice.data.metric.mappers.NoOpResultSetMapper;
+import com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation;
+
+import java.util.Arrays;
+
+/**
+ * A binary arithmetic node.
+ */
+public class ArithmeticMetricNode implements MetricNode {
+
+    protected final ArithmeticPostAggregation.ArithmeticPostAggregationFunction func;
+    protected final MetricNode left;
+    protected final MetricNode right;
+
+    /**
+     * Create an arithmetic metric node.
+     *
+     * @param func the function to apply
+     * @param left the left operand
+     * @param right the right operand
+     */
+    public ArithmeticMetricNode(
+            ArithmeticPostAggregation.ArithmeticPostAggregationFunction func,
+            MetricNode left,
+            MetricNode right
+    ) {
+        this.func = func;
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public LogicalMetric make(String metricName, MetricDictionary dictionary) throws ParsingException {
+        LogicalMetric l = left.make(MetricParser.getNewName(), dictionary);
+        LogicalMetric r = right.make(MetricParser.getNewName(), dictionary);
+        MetricMaker maker = new ArithmeticMaker(dictionary, func, new NoOpResultSetMapper());
+
+        LogicalMetric result = maker.make(metricName, Arrays.asList(l.getName(), r.getName()));
+        dictionary.add(result);
+        return result;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/ConstantMetricNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/ConstantMetricNode.java
@@ -1,0 +1,43 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.data.config.metric.makers.ConstantMaker;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+import java.util.Collections;
+
+/**
+ * Node that handles constants.
+ */
+public class ConstantMetricNode implements MetricNode {
+
+    protected final String value;
+
+    /**
+     * Create a new ConstantMetricNode.
+     *
+     * @param value constant value
+     */
+    public ConstantMetricNode(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public LogicalMetric make(String metricName, MetricDictionary dictionary) {
+        LogicalMetric result = new ConstantMaker(dictionary).make(metricName, Collections.singletonList(value));
+        dictionary.add(result);
+        return result;
+    }
+
+    /**
+     * Get the constant node's value.
+     *
+     * @return the value
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/DimensionNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/DimensionNode.java
@@ -1,0 +1,18 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.data.dimension.Dimension;
+
+/**
+ * Node that contains a dimension name.
+ */
+public interface DimensionNode extends Operand {
+
+    /**
+     * Get the dimension.
+     * @return the dimension
+     */
+    Dimension getDimension();
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNode.java
@@ -1,0 +1,44 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.druid.model.filter.Filter;
+
+/**
+ * FilterNode represents a Druid filter condition.
+ *
+ * Note: Rick suggests taking advantage of the existing implementation; see:
+ * https://github.com/yahoo/fili/blob/master/fili-core/src/main/java/com/yahoo/bard/webservice/web/ApiFilter.java
+ */
+public abstract class FilterNode implements Operand {
+
+    /**
+     * Build a Bard filter object.
+     * @return the filter
+     */
+    abstract Filter buildFilter();
+
+    /**
+     * Create a new FilterNode.
+     *
+     * FIXME: We probably can add better error messages when the left/right are the wrong types
+     *
+     * @param filterType the type of filter to create
+     * @param left the left filter operand
+     * @param right the right filter operand
+     * @return a filter node
+     */
+    public static FilterNode create(Filter.DefaultFilterType filterType, Operand left, Operand right) {
+        switch (filterType) {
+            case OR:
+                return new OrFilterNode(left.getFilterNode(), right.getFilterNode());
+            case AND:
+                return new AndFilterNode(left.getFilterNode(), right.getFilterNode());
+            case SELECTOR:
+                return new SelectorFilterNode(left.getDimensionNode(), right.getConstantNode());
+            default:
+                throw new RuntimeException("Could not handle filter type " + filterType);
+        }
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNode.java
@@ -18,7 +18,7 @@ public abstract class FilterNode implements Operand {
      * Build a Bard filter object.
      * @return the filter
      */
-    abstract Filter buildFilter();
+    public abstract Filter buildFilter();
 
     /**
      * Create a new FilterNode.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNode.java
@@ -3,6 +3,7 @@
 
 package com.yahoo.bard.webservice.data.config.metric.parser.operand;
 
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
 import com.yahoo.bard.webservice.druid.model.filter.Filter;
 
 /**
@@ -28,8 +29,10 @@ public abstract class FilterNode implements Operand {
      * @param left the left filter operand
      * @param right the right filter operand
      * @return a filter node
+     * @throws ParsingException if an unsupported filter type is given
      */
-    public static FilterNode create(Filter.DefaultFilterType filterType, Operand left, Operand right) {
+    public static FilterNode create(Filter.DefaultFilterType filterType, Operand left, Operand right)
+            throws ParsingException {
         switch (filterType) {
             case OR:
                 return new OrFilterNode(left.getFilterNode(), right.getFilterNode());
@@ -38,7 +41,7 @@ public abstract class FilterNode implements Operand {
             case SELECTOR:
                 return new SelectorFilterNode(left.getDimensionNode(), right.getConstantNode());
             default:
-                throw new RuntimeException("Could not handle filter type " + filterType);
+                throw new ParsingException("Could not handle filter type: " + filterType);
         }
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilteredAggMetricNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilteredAggMetricNode.java
@@ -1,0 +1,56 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.data.config.metric.makers.FilteredAggregationMaker;
+import com.yahoo.bard.webservice.data.config.metric.parser.MetricParser;
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * A filtered aggregation.
+ */
+public class FilteredAggMetricNode implements MetricNode {
+
+    protected final IdentifierNode left;
+    protected final FilterNode right;
+
+    /**
+     * Create a new filtered aggregation metric node.
+     *
+     * @param left the left operand, an identifier node
+     * @param right the right operand, a filter node
+     */
+    public FilteredAggMetricNode(Operand left, Operand right) {
+        this.left = left.getIdentifierNode();
+        this.right = right.getFilterNode();
+    }
+
+
+    @Override
+    public LogicalMetric make(String metricName, MetricDictionary dictionary) throws ParsingException {
+
+        // FIXME: This seems...wrong? What if there is more than one aggregation in the left node?
+        LogicalMetric leftNode = left.getMetricNode().make(MetricParser.getNewName(), dictionary);
+        Set<Aggregation> aggregations = leftNode.getTemplateDruidQuery().getAggregations();
+        Aggregation aggregation;
+        if (aggregations != null && aggregations.size() >= 1) {
+            aggregation = aggregations.iterator().next(); // Java, why is there no "Give me some element from this set"?
+        } else {
+            throw new RuntimeException("Could not find an aggregation");
+        }
+        FilteredAggregationMaker
+                filteredAggregationMaker = new FilteredAggregationMaker(dictionary, aggregation, right.buildFilter());
+
+        LogicalMetric metric = filteredAggregationMaker.make(metricName, Collections.emptyList());
+        dictionary.put(metricName, metric);
+        // FIXME: Dependant metrics? I *think* we don't need any because we are already wrapping the other query.
+        return filteredAggregationMaker.make(metricName, Collections.emptyList());
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilteredAggMetricNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilteredAggMetricNode.java
@@ -43,7 +43,7 @@ public class FilteredAggMetricNode implements MetricNode {
         if (aggregations != null && aggregations.size() >= 1) {
             aggregation = aggregations.iterator().next(); // Java, why is there no "Give me some element from this set"?
         } else {
-            throw new RuntimeException("Could not find an aggregation");
+            throw new ParsingException("Filtered aggregation requires aggregation but could not find one");
         }
         FilteredAggregationMaker
                 filteredAggregationMaker = new FilteredAggregationMaker(dictionary, aggregation, right.buildFilter());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FunctionMetricNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/FunctionMetricNode.java
@@ -1,0 +1,58 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker;
+import com.yahoo.bard.webservice.data.config.metric.parser.MetricParser;
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A function node (e.g. longSum())
+ */
+public class FunctionMetricNode implements MetricNode {
+
+    protected final MetricMaker maker;
+    protected final List<Operand> operands;
+
+    /**
+     * Create a new function metric node.
+     *
+     * @param maker the metric maker that implements this function
+     * @param operands the operands passed to the function
+     */
+    public FunctionMetricNode(MetricMaker maker, List<Operand> operands) {
+        this.maker = maker;
+        this.operands = operands;
+    }
+
+    @Override
+    public LogicalMetric make(String metricName, MetricDictionary dictionary) throws ParsingException {
+        List<String> fields = new LinkedList<>();
+
+        for (Operand operand : operands) {
+            if (operand instanceof MetricNode) {
+                LogicalMetric metric = operand.getMetricNode().make(MetricParser.getNewName(), dictionary);
+
+                // FIXME: Not sure if all the logic here is right
+                if (metric != null) {
+                    fields.add(metric.getName());
+                } else if (operand instanceof IdentifierNode) {
+                    fields.add(((IdentifierNode) operand).name);
+                } else {
+                    throw new ParsingException("Unexpected node type: " + operand.toString());
+                }
+            } else {
+                throw new ParsingException("Unexpected node type: " + operand.toString());
+            }
+        }
+        LogicalMetric metric = maker.make(metricName, fields);
+        dictionary.add(metric);
+        return metric;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/IdentifierNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/IdentifierNode.java
@@ -1,0 +1,46 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.data.dimension.Dimension;
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+/**
+ * An IdentifierNode is special because it can be treated as a MetricNode *or* a DimensionNode.
+ */
+public class IdentifierNode implements Operand, MetricNode, DimensionNode {
+
+    protected final String name;
+    protected final DimensionDictionary dimensionDictionary;
+    protected final MetricDictionary metricDictionary;
+
+    /**
+     * Create a new node wrapping a name.
+     *
+     * @param name the dimension or metric name
+     * @param dimensionDictionary the dimension dictionary
+     * @param metricDictionary the metric dictionary
+     */
+    public IdentifierNode(String name, DimensionDictionary dimensionDictionary, MetricDictionary metricDictionary) {
+        this.name = name;
+        this.dimensionDictionary = dimensionDictionary;
+        this.metricDictionary = metricDictionary;
+    }
+
+    // Doesn't actually use the metricName parameter - may not be doing what I intend
+    @Override
+    public LogicalMetric make(String metricName, MetricDictionary dictionary) {
+        return metricDictionary.get(name);
+    }
+
+    // FIXME:
+    // This used to use findByDruidName(name), but that method was removed.
+    // I'm not entirely sure that this version actually works. You probably need to filter by the API name, though.
+    @Override
+    public Dimension getDimension() {
+        return dimensionDictionary.findByApiName(name);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/MetricNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/MetricNode.java
@@ -1,0 +1,24 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+/**
+ * Tree node that handles naming metrics and building dependant metrics.
+ */
+public interface MetricNode extends Operand {
+
+    /**
+     * Make and add to the dictionary by assigned name.
+     *
+     * @param metricName name of the metric to assign
+     * @param dictionary dictionary to add the metric to
+     * @return the LogicalMetric representing this metric
+     * @throws ParsingException when an error building the metric occurs
+     */
+    LogicalMetric make(String metricName, MetricDictionary dictionary) throws ParsingException;
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/Operand.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/Operand.java
@@ -1,0 +1,77 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+/**
+ * An operand is used as an argument to an Operator
+ *
+ * This interface seems silly. Surely there's a better way.
+ */
+public interface Operand {
+
+    /**
+     * Get this object as a FilterNode, or throw an exception.
+     *
+     * @return the filter node
+     */
+    default FilterNode getFilterNode() {
+        if (FilterNode.class.isAssignableFrom(this.getClass())) {
+            return (FilterNode) this;
+        }
+
+        throw new UnsupportedOperationException("Operation not yet implemented.");
+    }
+
+    /**
+     * Get this object as a MetricNode, or throw an exception.
+     *
+     * @return the metric node
+     */
+    default MetricNode getMetricNode() {
+        if (MetricNode.class.isAssignableFrom(this.getClass())) {
+            return (MetricNode) this;
+        }
+
+        throw new UnsupportedOperationException("Operation not yet implemented.");
+    }
+
+    /**
+     * Get this object as a ConstantMetricNode, or throw an exception.
+     *
+     * @return the constant node
+     */
+    default ConstantMetricNode getConstantNode() {
+        if (ConstantMetricNode.class.isAssignableFrom(this.getClass())) {
+            return (ConstantMetricNode) this;
+        }
+
+        throw new UnsupportedOperationException("Operation not yet implemented.");
+    }
+
+    /**
+     * Get this object as an IdentifierNode, or throw an exception.
+     *
+     * @return the identifier node
+     */
+    default IdentifierNode getIdentifierNode() {
+        if (IdentifierNode.class.isAssignableFrom(this.getClass())) {
+            return (IdentifierNode) this;
+        }
+
+        throw new UnsupportedOperationException("Operation not yet implemented.");
+    }
+
+    /**
+     * Get this object as a DimensionNode, or throw an exception.
+     *
+     * @return the dimension node
+     */
+    default DimensionNode getDimensionNode() {
+        if (DimensionNode.class.isAssignableFrom(this.getClass())) {
+            return (DimensionNode) this;
+        }
+
+        throw new UnsupportedOperationException("Operation not yet implemented.");
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/OrFilterNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/OrFilterNode.java
@@ -1,0 +1,40 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.druid.model.filter.Filter;
+import com.yahoo.bard.webservice.druid.model.filter.OrFilter;
+
+import java.util.Arrays;
+
+/**
+ * A filter representing OR.
+ *
+ * FIXME: Could support combining nested statements into a single filter so that:
+ *
+ *     a || b || c
+ *
+ *  produces one node, not two.
+ */
+public class OrFilterNode extends FilterNode {
+
+    protected final FilterNode left;
+    protected final FilterNode right;
+
+    /**
+     * Construct a new OrFilter.
+     *
+     * @param left left operand
+     * @param right right operand
+     */
+    public OrFilterNode(FilterNode left, FilterNode right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public Filter buildFilter() {
+        return new OrFilter(Arrays.asList(left.buildFilter(), right.buildFilter()));
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/SelectorFilterNode.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operand/SelectorFilterNode.java
@@ -1,0 +1,30 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand;
+
+import com.yahoo.bard.webservice.druid.model.filter.Filter;
+import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter;
+
+/**
+ * A filter representing SELECTOR.
+ */
+public class SelectorFilterNode extends FilterNode {
+    protected final DimensionNode dimension;
+    protected final ConstantMetricNode value;
+
+    /**
+     * Construct a new selector filter.
+     * @param dimension dimension to filter no
+     * @param value dimension value to filter by
+     */
+    public SelectorFilterNode(DimensionNode dimension, ConstantMetricNode value) {
+        this.dimension = dimension;
+        this.value = value;
+    }
+
+    @Override
+    public Filter buildFilter() {
+        return new SelectorFilter(dimension.getDimension(), value.getValue());
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/ArithmeticOperator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/ArithmeticOperator.java
@@ -1,0 +1,73 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator;
+
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.ArithmeticMetricNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.MetricNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand;
+import com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation;
+
+import java.util.List;
+
+/**
+ * Binary arithmetic operators (+, -, *, /) take two operands.
+ */
+public enum ArithmeticOperator implements Operator {
+    PLUS(ArithmeticPostAggregation.ArithmeticPostAggregationFunction.PLUS, Precedence.ADD_SUB),
+    MINUS(ArithmeticPostAggregation.ArithmeticPostAggregationFunction.MINUS, Precedence.ADD_SUB),
+    MULTIPLY(ArithmeticPostAggregation.ArithmeticPostAggregationFunction.MULTIPLY, Precedence.MUL_DIV),
+    DIVIDE(ArithmeticPostAggregation.ArithmeticPostAggregationFunction.DIVIDE, Precedence.MUL_DIV);
+
+    protected ArithmeticPostAggregation.ArithmeticPostAggregationFunction func;
+    protected Precedence precedence;
+
+    /**
+     * Create a new arithmetic operator with the given function and precedence.
+     *
+     * @param func an arithmetic function
+     * @param precedence the function's precedence
+     */
+    ArithmeticOperator(ArithmeticPostAggregation.ArithmeticPostAggregationFunction func, Precedence precedence) {
+        this.func = func;
+        this.precedence = precedence;
+    }
+
+    @Override
+    public Precedence getPrecedence() {
+        return precedence;
+    }
+
+    @Override
+    public int getNumOperands() {
+        return 2;
+    }
+
+    @Override
+    public MetricNode build(List<Operand> operands) {
+        return new ArithmeticMetricNode(func, operands.get(0).getMetricNode(), operands.get(1).getMetricNode());
+    }
+
+    /**
+     * Create a new arithmetic operator from the given string.
+     *
+     * @param op string representing an operation
+     * @return an ArithmeticOperator if string is valid
+     * @throws ParsingException if an invalid string was passed
+     */
+    public static ArithmeticOperator fromString(String op) throws ParsingException {
+        switch (op) {
+            case "+":
+                return PLUS;
+            case "-":
+                return MINUS;
+            case "*":
+                return MULTIPLY;
+            case "/":
+                return DIVIDE;
+            default:
+                throw new ParsingException("Got unsupported operator: " + op);
+        }
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/ArithmeticOperator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/ArithmeticOperator.java
@@ -45,7 +45,7 @@ public enum ArithmeticOperator implements Operator {
     }
 
     @Override
-    public MetricNode build(List<Operand> operands) {
+    public MetricNode build(List<Operand> operands) throws ParsingException {
         return new ArithmeticMetricNode(func, operands.get(0).getMetricNode(), operands.get(1).getMetricNode());
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/BinaryFilterOperator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/BinaryFilterOperator.java
@@ -1,0 +1,69 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator;
+
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.FilterNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand;
+import com.yahoo.bard.webservice.druid.model.filter.Filter;
+
+import java.util.List;
+
+/**
+ * Binary filter operators ( &amp;&amp;, ||, ==) take two operands.
+ */
+public enum BinaryFilterOperator implements Operator {
+    AND(Filter.DefaultFilterType.AND, Precedence.AND_OR),
+    OR(Filter.DefaultFilterType.OR, Precedence.AND_OR),
+    EQUALS(Filter.DefaultFilterType.SELECTOR, Precedence.EQUALITY);
+
+    protected Precedence precedence;
+    protected Filter.DefaultFilterType filterType;
+
+    /**
+     * Create a new binary filter operator.
+     *
+     * @param filterType the type of filter
+     * @param precedence the precedence of the operation
+     */
+    BinaryFilterOperator(Filter.DefaultFilterType filterType, Precedence precedence) {
+        this.filterType = filterType;
+        this.precedence = precedence;
+    }
+
+    @Override
+    public Precedence getPrecedence() {
+        return precedence;
+    }
+
+    @Override
+    public int getNumOperands() {
+        return 2;
+    }
+
+    @Override
+    public Operand build(List<Operand> operands) {
+        return FilterNode.create(this.filterType, operands.get(0), operands.get(1));
+    }
+
+    /**
+     * Create a new filter from the given string.
+     *
+     * @param op a string representing a filter
+     * @return a BinaryFilterOperator if the given string was valid
+     * @throws ParsingException an invalid string was passed
+     */
+    public static BinaryFilterOperator fromString(String op) throws ParsingException {
+        switch (op) {
+            case "&&":
+                return AND;
+            case "||":
+                return OR;
+            case "==":
+                return EQUALS;
+            default:
+                throw new ParsingException("Got unsupported operator: " + op);
+        }
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/BinaryFilterOperator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/BinaryFilterOperator.java
@@ -43,7 +43,7 @@ public enum BinaryFilterOperator implements Operator {
     }
 
     @Override
-    public Operand build(List<Operand> operands) {
+    public Operand build(List<Operand> operands) throws ParsingException {
         return FilterNode.create(this.filterType, operands.get(0), operands.get(1));
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/FilterOperator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/FilterOperator.java
@@ -1,0 +1,35 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator;
+
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.FilterNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.FilteredAggMetricNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.MetricNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand;
+
+import java.util.List;
+
+/**
+ * Filter operator (|).
+ */
+public class FilterOperator implements Operator {
+
+    @Override
+    public Precedence getPrecedence() {
+        return Precedence.FILTER;
+    }
+
+    @Override
+    public int getNumOperands() {
+        return 2;
+    }
+
+    @Override
+    public Operand build(List<Operand> operands) {
+        MetricNode left = operands.get(0).getMetricNode();
+        FilterNode right = operands.get(1).getFilterNode();
+
+        return new FilteredAggMetricNode(left, right);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/FilterOperator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/FilterOperator.java
@@ -3,6 +3,7 @@
 
 package com.yahoo.bard.webservice.data.config.metric.parser.operator;
 
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
 import com.yahoo.bard.webservice.data.config.metric.parser.operand.FilterNode;
 import com.yahoo.bard.webservice.data.config.metric.parser.operand.FilteredAggMetricNode;
 import com.yahoo.bard.webservice.data.config.metric.parser.operand.MetricNode;
@@ -26,7 +27,7 @@ public class FilterOperator implements Operator {
     }
 
     @Override
-    public Operand build(List<Operand> operands) {
+    public Operand build(List<Operand> operands) throws ParsingException {
         MetricNode left = operands.get(0).getMetricNode();
         FilterNode right = operands.get(1).getFilterNode();
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/FunctionOperator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/FunctionOperator.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.data.config.metric.parser.operator;
 
 
 import com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker;
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
 import com.yahoo.bard.webservice.data.config.metric.parser.operand.FunctionMetricNode;
 import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand;
 
@@ -43,7 +44,7 @@ public class FunctionOperator implements Operator {
     }
 
     @Override
-    public Operand build(List<Operand> operands) {
+    public Operand build(List<Operand> operands) throws ParsingException {
         return new FunctionMetricNode(maker, operands);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/FunctionOperator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/FunctionOperator.java
@@ -1,0 +1,49 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator;
+
+
+import com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.FunctionMetricNode;
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand;
+
+import java.util.List;
+
+/**
+ * A function operator.
+ *
+ * Are functions really operators? Mostly. And, it's a cleaner than
+ * implementing the alternative.
+ */
+public class FunctionOperator implements Operator {
+
+    protected final int numOperands;
+    protected final MetricMaker maker;
+
+    /**
+     * Construct a function operator for the given metric maker.
+     *
+     * @param maker metric maker to construct function from
+     * @param numOperands the number of operands the function accepts
+     */
+    public FunctionOperator(MetricMaker maker, int numOperands) {
+        this.numOperands = numOperands;
+        this.maker = maker;
+    }
+
+    @Override
+    public Precedence getPrecedence() {
+        return Precedence.FUNCTION;
+    }
+
+    @Override
+    public int getNumOperands() {
+        return numOperands;
+    }
+
+    @Override
+    public Operand build(List<Operand> operands) {
+        return new FunctionMetricNode(maker, operands);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/NegationOperator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/NegationOperator.java
@@ -1,0 +1,21 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator;
+
+/**
+ * Negation operator (-).
+ *
+ * Note: Not yet fully implemented
+ */
+public class NegationOperator implements Operator {
+
+    @Override
+    public Precedence getPrecedence() {
+        return Precedence.NEGATION;
+    }
+
+    public int getNumOperands() {
+        return 1;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/Operator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/Operator.java
@@ -3,6 +3,7 @@
 
 package com.yahoo.bard.webservice.data.config.metric.parser.operator;
 
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
 import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand;
 
 import java.util.List;
@@ -17,8 +18,9 @@ public interface Operator {
      *
      * @param operands Operator arguments
      * @return A MetricNode containing the expression
+     * @throws ParsingException when the operand cannot be built
      */
-    default Operand build(List<Operand> operands) {
+    default Operand build(List<Operand> operands) throws ParsingException {
         throw new UnsupportedOperationException("Operation not yet implemented.");
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/Operator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/Operator.java
@@ -1,0 +1,48 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator;
+
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand;
+
+import java.util.List;
+
+/**
+ * Interface representing operators in the metric definition language.
+ */
+public interface Operator {
+
+    /**
+     * Given a list of operands, build a MetricNode representing the computation operator(operands).
+     *
+     * @param operands Operator arguments
+     * @return A MetricNode containing the expression
+     */
+    default Operand build(List<Operand> operands) {
+        throw new UnsupportedOperationException("Operation not yet implemented.");
+    }
+
+    /**
+     * Get the precedence of the operator.
+     *
+     * @return the precedence of the operator
+     */
+    Precedence getPrecedence();
+
+    /**
+     * Get the number of operands that the operator requires.
+     *
+     * @return the number of operands
+     */
+    int getNumOperands();
+
+    /**
+     * Determine whether this object or other has greater precedence.
+     *
+     * @param other operator to compare to
+     * @return true if this object's precedence is higher; false otherwise
+     */
+    default boolean greaterThan(Operator other) {
+        return getPrecedence().compareTo(other.getPrecedence()) > 0;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/Precedence.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/Precedence.java
@@ -1,0 +1,29 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator;
+
+/**
+ * The precedence of a given operation.
+ */
+public enum Precedence {
+
+    SENTINEL,
+    ADD_SUB,
+    MUL_DIV,
+    FILTER,
+    AND_OR,
+    EQUALITY,
+    NEGATION,
+    FUNCTION;
+
+    /**
+     * Return true if this enum is greater than the other.
+     *
+     * @param other precedence to compare to
+     * @return true if this precedence is greater than the given precedence
+     */
+    public boolean greaterThan(Precedence other) {
+        return this.compareTo(other) > 0;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/Sentinel.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/operator/Sentinel.java
@@ -1,0 +1,21 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator;
+
+/**
+ * The sentinel has the lowest possible precedence, and doesn't
+ * represent an actual operator.
+ */
+public class Sentinel implements Operator {
+
+    @Override
+    public Precedence getPrecedence() {
+        return Precedence.SENTINEL;
+    }
+
+    @Override
+    public int getNumOperands() {
+        return 0;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigBinderFactory.java
@@ -46,7 +46,7 @@ public class ConfigBinderFactory extends AbstractBinderFactory {
         String className = SYSTEM_CONFIG.getStringProperty(CONF_TYPE);
 
         if (className == null) {
-            throw new RuntimeException("Unable to read class name property from config: " + CONF_TYPE);
+            throw new ConfigurationError("Unable to read class name property from config: " + CONF_TYPE);
         }
 
         try {
@@ -56,7 +56,7 @@ public class ConfigBinderFactory extends AbstractBinderFactory {
             Method build = providerClass.getDeclaredMethod("build", SystemConfig.class);
             provider = (ConfigProvider) build.invoke(null, SYSTEM_CONFIG);
         } catch (Exception e) {
-            throw new RuntimeException("Unable to construct config provider", e);
+            throw new ConfigurationError("Unable to construct config provider", e);
         }
 
         // Store the metric makers; should only be instantiated once.
@@ -64,7 +64,7 @@ public class ConfigBinderFactory extends AbstractBinderFactory {
         // can't really remember why...
         MakerDictionary.loadMetricMakers(tempDictionary, makerDictionary, provider.getCustomMakerConfig());
 
-        // FIXME: This doesn't seem like the right way to do this
+        // This is annoying
         provider.getDimensionConfig().values().forEach(
                 v -> dimensionDictionary.add(new KeyValueStoreDimension(v))
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigBinderFactory.java
@@ -1,0 +1,100 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider;
+
+import com.yahoo.bard.webservice.application.AbstractBinderFactory;
+import com.yahoo.bard.webservice.config.SystemConfig;
+import com.yahoo.bard.webservice.config.SystemConfigProvider;
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.metric.MetricLoader;
+import com.yahoo.bard.webservice.data.config.table.TableLoader;
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Config-driven AbstractBinderFactory.
+ */
+public class ConfigBinderFactory extends AbstractBinderFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(SystemConfigProvider.class);
+
+    private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
+    private static final String CONF_TYPE = SYSTEM_CONFIG.getPackageVariableName("config_binder_type");
+
+    private final ConfigProvider provider;
+
+    // FIXME: Can't remember why I did this this way. Probably needs to be cleaned up.
+    protected final MetricDictionary localDictionary = new MetricDictionary();
+    protected final MetricDictionary tempDictionary = localDictionary.getScope("tmp");
+
+    protected final MakerDictionary makerDictionary = new MakerDictionary();
+
+    protected final DimensionDictionary dimensionDictionary = new DimensionDictionary();
+
+    /**
+     * Construct a ConfigBinderFactory that instantiates a config provider via reflection.
+     */
+    public ConfigBinderFactory() {
+        String className = SYSTEM_CONFIG.getStringProperty(CONF_TYPE);
+
+        if (className == null) {
+            throw new RuntimeException("Unable to read class name property from config: " + CONF_TYPE);
+        }
+
+        try {
+            // oof
+            LOG.info("Loading ConfigBinderFactory for type: {}", className);
+            Class<? extends ConfigProvider> providerClass = (Class<? extends ConfigProvider>) Class.forName(className);
+            Method build = providerClass.getDeclaredMethod("build", SystemConfig.class);
+            provider = (ConfigProvider) build.invoke(null, SYSTEM_CONFIG);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to construct config provider", e);
+        }
+
+        // Store the metric makers; should only be instantiated once.
+        // The makers all use 'tempDictionary' under the hood, which seems important but I
+        // can't really remember why...
+        MakerDictionary.loadMetricMakers(tempDictionary, makerDictionary, provider.getCustomMakerConfig());
+
+        // FIXME: This doesn't seem like the right way to do this
+        provider.getDimensionConfig().values().forEach(
+                v -> dimensionDictionary.add(new KeyValueStoreDimension(v))
+        );
+    }
+
+    @Override
+    protected MetricLoader getMetricLoader() {
+        return new ConfiguredMetricLoader(
+                localDictionary,
+                tempDictionary,
+                provider.getBaseMetrics(),
+                provider.getDerivedMetrics(),
+                makerDictionary,
+                dimensionDictionary
+        );
+    }
+
+    @Override
+    protected Set<DimensionConfig> getDimensionConfigurations() {
+        return new LinkedHashSet<>(
+                provider.getDimensionConfig().values()
+        );
+    }
+
+    @Override
+    protected TableLoader getTableLoader() {
+        return new ConfiguredTableLoader(
+                provider.getLogicalTableConfig(),
+                provider.getPhysicalTableConfig(),
+                provider.getDimensionConfig()
+        );
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigProvider.java
@@ -1,0 +1,60 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider;
+
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+
+/**
+ * A ConfigProvider defines a programmatic source for configuring Fili.
+ *
+ * An instance of ConfigProvider provides access to configuration of:
+ *  - Physical tables
+ *  - Logical tables
+ *  - Dimensions
+ *  - Metrics, both base and derived
+ *  - Custom metric makers
+ */
+public interface ConfigProvider {
+
+    /**
+     * Return the actual physical tables in Druid.
+     *
+     * @return a mapping of physical table names to their configurations
+     */
+    ConfigurationDictionary<PhysicalTableConfiguration> getPhysicalTableConfig();
+
+    /**
+     * Return the logical tables you'd like to expose.
+     *
+     * @return a mapping of logical table names to their configurations
+     */
+    ConfigurationDictionary<LogicalTableConfiguration> getLogicalTableConfig();
+
+    /**
+     * Return any custom metric makers used in metrics.
+     *
+     * @return a mapping of custom metric maker names to their definitions
+     */
+    ConfigurationDictionary<MakerConfiguration> getCustomMakerConfig();
+
+    /**
+     * Return the dimension config.
+     *
+     * @return a mapping of dimension names to their definition
+     */
+    ConfigurationDictionary<DimensionConfig> getDimensionConfig();
+
+    /**
+     * Get the base metrics.
+     *
+     * @return a mapping of base metric names to their definitions
+     */
+    ConfigurationDictionary<MetricConfiguration> getBaseMetrics();
+
+    /**
+     * Get the derived / computed metrics.
+     *
+     * @return a mapping of derived metric names to their definitions
+     */
+    ConfigurationDictionary<MetricConfiguration> getDerivedMetrics();
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigurationDictionary.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigurationDictionary.java
@@ -1,0 +1,14 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider;
+
+import java.util.LinkedHashMap;
+
+/**
+ * A ConfigurationDictionary is just a LinkedHashMap of String to some value type T.
+ *
+ * @param <T> the value type in the dictionary
+ */
+public class ConfigurationDictionary<T> extends LinkedHashMap<String, T> {
+    private static final long serialVersionUID = 7763131056859622560L;
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigurationError.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfigurationError.java
@@ -1,0 +1,29 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider;
+
+/**
+ * Exception that occurs during configuration.
+ */
+public class ConfigurationError extends Error {
+
+    /**
+     * Construct a new configuration exception with the given message.
+     *
+     * @param message exception message
+     */
+    public ConfigurationError(String message) {
+        super(message);
+    }
+
+    /**
+     * Construct a new configuration exception with the given message and cause.
+     *
+     * @param message exception message
+     * @param cause exception cause
+     */
+    public ConfigurationError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfiguredMetricLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfiguredMetricLoader.java
@@ -1,0 +1,75 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider;
+
+import com.yahoo.bard.webservice.data.config.metric.MetricLoader;
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A config-driven MetricLoader.
+ */
+public class ConfiguredMetricLoader implements MetricLoader {
+
+    private final MetricDictionary localDictionary;
+    private final MetricDictionary tempDictionary;
+    private final MakerDictionary makerDictionary;
+    private final DimensionDictionary dimensionDictionary;
+    private final ConfigurationDictionary<MetricConfiguration> baseMetrics;
+    private final ConfigurationDictionary<MetricConfiguration> derivedMetrics;
+
+    /**
+     * Construct a new MetricLoader with the given configuration.
+     *
+     * @param localDictionary the local metric dictionary
+     * @param tempDictionary the temporary metric dictionary
+     * @param baseMetrics the configured base metrics
+     * @param derivedMetrics the configured derived metrics
+     * @param makerDictionary the metric maker dictionary
+     * @param dimensionDictionary the dimension dictionary
+     */
+    public ConfiguredMetricLoader(
+            MetricDictionary localDictionary, MetricDictionary tempDictionary,
+            ConfigurationDictionary<MetricConfiguration> baseMetrics,
+            ConfigurationDictionary<MetricConfiguration> derivedMetrics,
+            MakerDictionary makerDictionary, DimensionDictionary dimensionDictionary
+    ) {
+        this.localDictionary = localDictionary;
+        this.tempDictionary = tempDictionary;
+        this.dimensionDictionary = dimensionDictionary;
+        this.makerDictionary = makerDictionary;
+        this.baseMetrics = baseMetrics;
+        this.derivedMetrics = derivedMetrics;
+    }
+
+    @Override
+    public void loadMetricDictionary(MetricDictionary metricDictionary) {
+        localDictionary.clearLocal();
+
+        try {
+            for (Map.Entry<String, MetricConfiguration> entry : baseMetrics.entrySet()) {
+                String name = entry.getKey();
+                MetricConfiguration metric = entry.getValue();
+                localDictionary
+                        .add(metric.build(name, localDictionary, tempDictionary, makerDictionary, dimensionDictionary));
+                tempDictionary.clearLocal();
+            }
+
+            for (Map.Entry<String, MetricConfiguration> entry : derivedMetrics.entrySet()) {
+                String name = entry.getKey();
+                MetricConfiguration metric = entry.getValue();
+                localDictionary
+                        .add(metric.build(name, localDictionary, tempDictionary, makerDictionary, dimensionDictionary));
+                tempDictionary.clearLocal();
+            }
+        } catch (IOException ex) {
+            // this needs to be cleaned up
+            throw new RuntimeException(ex);
+        }
+
+        localDictionary.forEach((k, v) -> metricDictionary.add(v));
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfiguredMetricLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfiguredMetricLoader.java
@@ -6,7 +6,6 @@ import com.yahoo.bard.webservice.data.config.metric.MetricLoader;
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -49,25 +48,21 @@ public class ConfiguredMetricLoader implements MetricLoader {
     public void loadMetricDictionary(MetricDictionary metricDictionary) {
         localDictionary.clearLocal();
 
-        try {
-            for (Map.Entry<String, MetricConfiguration> entry : baseMetrics.entrySet()) {
-                String name = entry.getKey();
-                MetricConfiguration metric = entry.getValue();
-                localDictionary
-                        .add(metric.build(name, localDictionary, tempDictionary, makerDictionary, dimensionDictionary));
-                tempDictionary.clearLocal();
-            }
+        // Note: will throw ConfigurationError if metric cannot be parsed
+        for (Map.Entry<String, MetricConfiguration> entry : baseMetrics.entrySet()) {
+            String name = entry.getKey();
+            MetricConfiguration metric = entry.getValue();
+            localDictionary
+                    .add(metric.build(name, localDictionary, tempDictionary, makerDictionary, dimensionDictionary));
+            tempDictionary.clearLocal();
+        }
 
-            for (Map.Entry<String, MetricConfiguration> entry : derivedMetrics.entrySet()) {
-                String name = entry.getKey();
-                MetricConfiguration metric = entry.getValue();
-                localDictionary
-                        .add(metric.build(name, localDictionary, tempDictionary, makerDictionary, dimensionDictionary));
-                tempDictionary.clearLocal();
-            }
-        } catch (IOException ex) {
-            // this needs to be cleaned up
-            throw new RuntimeException(ex);
+        for (Map.Entry<String, MetricConfiguration> entry : derivedMetrics.entrySet()) {
+            String name = entry.getKey();
+            MetricConfiguration metric = entry.getValue();
+            localDictionary
+                    .add(metric.build(name, localDictionary, tempDictionary, makerDictionary, dimensionDictionary));
+            tempDictionary.clearLocal();
         }
 
         localDictionary.forEach((k, v) -> metricDictionary.add(v));

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfiguredTableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/ConfiguredTableLoader.java
@@ -1,0 +1,111 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider;
+
+import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
+import com.yahoo.bard.webservice.data.config.names.FieldName;
+import com.yahoo.bard.webservice.data.config.table.BaseTableLoader;
+import com.yahoo.bard.webservice.data.config.table.PhysicalTableDefinition;
+import com.yahoo.bard.webservice.data.time.TimeGrain;
+import com.yahoo.bard.webservice.table.TableGroup;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A TableLoader from configuration.
+ */
+public class ConfiguredTableLoader extends BaseTableLoader {
+
+    protected final ConfigurationDictionary<LogicalTableConfiguration> logicalTables;
+    protected final ConfigurationDictionary<PhysicalTableConfiguration> physicalTables;
+    protected final ConfigurationDictionary<DimensionConfig> dimensions;
+
+    /**
+     * Construct a table loader from configuration.
+     *
+     * @param logicalTables the logical tables
+     * @param physicalTables the physical tables
+     * @param dimensions the dimensions
+     */
+    public ConfiguredTableLoader(
+            ConfigurationDictionary<LogicalTableConfiguration> logicalTables,
+            ConfigurationDictionary<PhysicalTableConfiguration> physicalTables,
+            ConfigurationDictionary<DimensionConfig> dimensions
+    ) {
+        this.logicalTables = logicalTables;
+        this.physicalTables = physicalTables;
+        this.dimensions = dimensions;
+    }
+
+    @Override
+    public void loadTableDictionary(ResourceDictionaries dictionaries) {
+
+        for (Map.Entry<String, LogicalTableConfiguration> entry : logicalTables.entrySet()) {
+            LogicalTableConfiguration logicalTable = entry.getValue();
+            String tableName = entry.getKey();
+
+            // Compute the set of all physical fields on this logical table's physical tables
+            Set<FieldName> physicalFields = logicalTable
+                    .getPhysicalTables()
+                    .stream()
+                    .map(physicalTable -> physicalTables.get(physicalTable).getMetrics())
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+
+            // Build the actual physical tables for this logical table
+            Set<PhysicalTableDefinition> physicalTableDefs = logicalTable
+                    .getPhysicalTables()
+                    .stream()
+                    .map(physicalTable -> physicalTables.get(physicalTable).buildPhysicalTable(dimensions))
+                    .collect(Collectors.toSet());
+
+            // Get the smallest granularity for this table
+            // TimeGrain smallestGrain = Collections.min(entry.getValue().timeGrains);
+
+            // Fixme: We should use 'apiName' vs 'asName' as intended
+            // FIXME: should be possible to override grains valid for?
+            Set<ApiMetricName> apiMetricNames = new HashSet<>();
+            for (String metric : logicalTable.getMetrics()) {
+                apiMetricNames.add(new ApiMetricName() {
+                    @Override
+                    public boolean isValidFor(TimeGrain grain) {
+                        return logicalTable.getTimeGrains()
+                                .stream()
+                                .anyMatch(grain::satisfiedBy);
+                    }
+
+                    @Override
+                    public String getApiName() {
+                        return metric;
+                    }
+
+                    @Override
+                    public String asName() {
+                        return metric;
+                    }
+                });
+            }
+
+            TableGroup tableGroup = buildTableGroup(
+                    tableName,
+                    apiMetricNames,
+                    physicalFields,
+                    physicalTableDefs,
+                    dictionaries
+            );
+
+            loadLogicalTableWithGranularities(
+                    entry.getKey(),
+                    tableGroup,
+                    new HashSet<>(entry.getValue().getTimeGrains()),
+                    dictionaries
+            );
+        }
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/LogicalTableConfiguration.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/LogicalTableConfiguration.java
@@ -1,0 +1,36 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider;
+
+import com.yahoo.bard.webservice.data.time.TimeGrain;
+
+import java.util.Set;
+
+/**
+ * A LogicalTableConfiguration defines configuration for a LogicalTable
+ *
+ * FIXME: should getTimeGrains() deal with time grains or granularities?
+ */
+public interface LogicalTableConfiguration {
+
+    /**
+     * Get the time grains for this logical table.
+     *
+     * @return set of time grains
+     */
+    Set<TimeGrain> getTimeGrains();
+
+    /**
+     * Get the physical tables backing this logical table.
+     *
+     * @return set of physical table names
+     */
+    Set<String> getPhysicalTables();
+
+    /**
+     * Get the list of metrics this logical table provides.
+     *
+     * @return set of metric names
+     */
+    Set<String> getMetrics();
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MakerConfiguration.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MakerConfiguration.java
@@ -1,0 +1,41 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider;
+
+import com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker;
+
+/**
+ * A MakerConfiguration provides a means to register custom MetricMakers.
+ */
+public interface MakerConfiguration {
+
+    /**
+     * The class name of the metric maker.
+     *
+     * @return the class name
+     */
+    String getClassName();
+
+    /**
+     * The arguments to construct the custom metric maker.
+     *
+     * @return the constructor arguments
+     */
+    Object[] getArguments();
+
+    /**
+     * The class of the metric maker.
+     *
+     * FIXME: Clean up exception type
+     *
+     * @return the metric maker class
+     */
+    default Class<? extends MetricMaker> getMakerClass() {
+        try {
+            // Unchecked cast
+            return (Class<? extends MetricMaker>) Class.forName(getClassName());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MakerConfiguration.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MakerConfiguration.java
@@ -26,16 +26,13 @@ public interface MakerConfiguration {
     /**
      * The class of the metric maker.
      *
-     * FIXME: Clean up exception type
-     *
      * @return the metric maker class
      */
     default Class<? extends MetricMaker> getMakerClass() {
         try {
-            // Unchecked cast
             return (Class<? extends MetricMaker>) Class.forName(getClassName());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } catch (ClassNotFoundException e) {
+            throw new ConfigurationError("Unable to instantiate class " + getClassName(), e);
         }
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MakerDictionary.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MakerDictionary.java
@@ -1,0 +1,278 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider;
+
+import com.yahoo.bard.webservice.data.config.metric.makers.ConstantMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.CountMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.DoubleMaxMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.DoubleMinMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.DoubleSumMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.LongMaxMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.LongMinMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.LongSumMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.RowNumMaker;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Dictionary of MetricMakers
+ *
+ * In The Future, this could be an interface that can easily be changed
+ *
+ * For now, a bunch of yucky reflection code lives in here.
+ */
+public class MakerDictionary extends LinkedHashMap<String, MetricMaker> {
+    private static final long serialVersionUID = 4296501494537995054L;
+
+    // The package name
+    private static final String MAKER_PACKAGE_NAME = MetricMaker.class.getPackage().getName();
+
+    // List of 'built-in' metric makers
+    // This used to use Reflections, but that seems like overkill
+    private static final Set<Class<? extends MetricMaker>> BUILTIN_METRIC_MAKERS = Collections.unmodifiableSet(
+            new HashSet<>(
+                    Arrays.asList(
+                            ConstantMaker.class,
+                            CountMaker.class,
+                            DoubleMaxMaker.class,
+                            DoubleMinMaker.class,
+                            DoubleSumMaker.class,
+                            LongMaxMaker.class,
+                            LongMinMaker.class,
+                            LongSumMaker.class,
+                            RowNumMaker.class
+
+                            // These (and a few others) are built in but require some arguments
+                            // So, you'll have to list them as custom makers with their parameters
+                            // AggregationAverageMaker.class,
+                            // CardinalityMaker.class,
+                    )
+            )
+    );
+
+    // Cache of default metric makers
+    private static MakerDictionary defaultMakers;
+
+    /**
+     * Get a map of name -&gt; makers for the default (built-in) MetricMakers.
+     *
+     * Makers included by default:
+     *
+     * 1. Are in the same package as MetricMaker
+     * 2. Have a constructor that takes a single MetricDictionary
+     *
+     * @param dict metric dictionary to use for built-in makers
+     * @return the dictionary of MetricMakers
+     */
+    public static MakerDictionary getDefaultMakers(MetricDictionary dict) {
+        if (defaultMakers == null) {
+            defaultMakers = new MakerDictionary();
+            for (Class<? extends MetricMaker> cls : BUILTIN_METRIC_MAKERS) {
+                // LongSumMaker => longSum
+                String makerName = lowerFirst(cls.getSimpleName()).replaceFirst("Maker", "");
+                MetricMaker actualMaker = instantiateObjectFromArgs(cls, dict);
+                if (actualMaker != null) {
+                    defaultMakers.put(makerName, actualMaker);
+                } else {
+                    throw new RuntimeException("Unable to instantiate built-in metric maker " + cls);
+                }
+            }
+        }
+
+        return defaultMakers;
+    }
+
+    /**
+     * Initialize the metric makers, custom and built-in.
+     *
+     * @param dict MetricDictionary to use for every maker
+     * @param mDict Dictionary of function name to MetricMaker
+     * @param makers user-defined config listing custom MetricMakers
+     */
+    public static void loadMetricMakers(
+            MetricDictionary dict,
+            MakerDictionary mDict,
+            Map<String, MakerConfiguration> makers
+    ) {
+        loadMetricMakers(dict, mDict, makers, false);
+    }
+
+    /**
+     * Initialize the metric makers, custom and optionally built-in.
+     *
+     * Eventually, 'skipDefault' will be an option in the YAML config.
+     *
+     * @param dict MetricDictionary to use for every maker
+     * @param mDict Dictionary of function name to MetricMaker
+     * @param makers user-defined config listing custom MetricMakers
+     * @param skipDefault true to skip loading built-in metrics
+     */
+    public static void loadMetricMakers(
+            MetricDictionary dict,
+            MakerDictionary mDict,
+            Map<String, MakerConfiguration> makers,
+            boolean skipDefault
+    ) {
+
+        if (!skipDefault) {
+            mDict.putAll(getDefaultMakers(dict));
+        }
+
+        if (makers != null) {
+            Map<String, MetricMaker> customMakers = makers.entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            v -> buildCustomMaker(v.getKey(),
+                                    v.getValue().getClassName(),
+                                    v.getValue().getArguments(),
+                                    dict
+                            )
+                    ));
+
+            mDict.putAll(customMakers);
+        }
+    }
+
+    /**
+     * Find the full package + class name for a maker.
+     *
+     * The class name chosen for the custom maker is one of:
+     *
+     * 1. The full package + class name specified in the className field
+     * 2. The name specified in the className field inside the MetricMaker package
+     * 3. If no className given, the Maker name specified (longSum), turned into a Maker class name
+     *    (LongSumMaker), inside the MetricMaker package
+     *
+     * @param suppliedMakerName The maker name the user specified
+     * @param suppliedClassName The class name the user provided
+     * @return The resolved class name
+     */
+    protected static String getClassName(String suppliedMakerName, String suppliedClassName) {
+        if (suppliedClassName == null || suppliedClassName.isEmpty()) {
+            return MAKER_PACKAGE_NAME + "." + suppliedMakerName.substring(0, 1)
+                    .toUpperCase(Locale.ENGLISH) + suppliedMakerName.substring(1) + "Maker";
+        } else if (suppliedClassName.contains(".")) {
+            return suppliedClassName;
+        } else {
+            return MAKER_PACKAGE_NAME + "." + suppliedClassName;
+        }
+    }
+
+    /**
+     * Construct a custom MetricMaker given its class name and arguments.
+     *
+     * @param name The pretty name ("longSum")
+     * @param className The class name for the maker
+     * @param args Arguments to the maker constructor
+     * @param dict Metric dictionary
+     * @return A metric maker
+     */
+    protected static MetricMaker buildCustomMaker(String name, String className, Object[] args, MetricDictionary dict) {
+        Class cls;
+        try {
+            cls = Class.forName(getClassName(name, className));
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Error loading metric maker `" + name + "`: Could not find `" + className + "`" +
+                    " in classpath");
+        }
+
+        if (!MetricMaker.class.isAssignableFrom(cls)) {
+            throw new RuntimeException("Error loading metric maker `" + name + "`: Could not instantiate " +
+                    className + "; seems to not inherit from MetricMaker");
+        } else {
+
+            Object[] instArgs = new Object[args.length + 1];
+            instArgs[0] = dict;
+            System.arraycopy(args, 0, instArgs, 1, args.length);
+
+            MetricMaker m = (MetricMaker) instantiateObjectFromArgs(cls, instArgs);
+
+            if (m == null) {
+                throw new RuntimeException("Could not instantiate " + className + "; no suitable constructor found");
+            }
+
+            return m;
+        }
+    }
+
+    /**
+     * Instantiate an object from a class name and parameters.
+     *
+     * @param type the class to instantiate
+     * @param args the constructor arguments
+     * @param <T> the type of object to return
+     * @return an instantiated object, or null
+     */
+    public static <T> T instantiateObjectFromArgs(Class<? extends T> type, Object... args) {
+
+        if (type == null || Modifier.isAbstract(type.getModifiers()) || !Modifier.isPublic(type.getModifiers()) ||
+                args == null) {
+            return null;
+        }
+
+        // Find a valid constructor and build an instance
+        Constructor<?>[] constructors = type.getConstructors();
+        for (Constructor<?> ctor : constructors) {
+            if (ctor.getParameterCount() == args.length) {
+                int argc = 0;
+                boolean success = true;
+
+                for (Class<?> pType : ctor.getParameterTypes()) {
+                    Object arg = args[argc];
+
+                    // Ugh. This is not an exhaustive list;
+                    // the problem is that int.class is not isAssignableFrom Integer.class.
+                    if ((pType == int.class && arg.getClass() == Integer.class) || (pType == Integer.class && arg
+                            .getClass() == int.class)) {
+                        // OK...
+                    } else if ((pType == long.class && arg.getClass() == Long.class) || (pType == Long.class && arg
+                            .getClass() == long.class)) {
+                        // OK...
+
+                        // Note that this allows null arguments; that may not be what we want.
+                    } else if (arg != null && !pType.isAssignableFrom(arg.getClass())) {
+                        success = false;
+                        break;
+                    }
+                    argc += 1;
+                }
+
+                if (success) {
+                    try {
+                        return (T) ctor.newInstance(args);
+                    } catch (Exception e) {
+                        throw new RuntimeException("Could not construct metricMaker " + type, e);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Make the first letter of the input string lowercase.
+     *
+     * @param input any string
+     * @return a new copy of the input string with the first letter lower-cased
+     */
+    protected static String lowerFirst(String input) {
+        if (input == null || input.length() == 0) {
+            return input;
+        } else {
+            return input.substring(0, 1).toLowerCase(Locale.ENGLISH) + input.substring(1);
+        }
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MetricConfiguration.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MetricConfiguration.java
@@ -6,8 +6,6 @@ import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 
-import java.io.IOException;
-
 /**
  * A metric with a definition, description, and flag to exclude from external API
  *
@@ -47,7 +45,6 @@ public interface MetricConfiguration {
      * @param makerDict the metric maker dictionary
      * @param dimensionDictionary the dimension dictionary
      * @return a logical metric
-     * @throws IOException if the metric could not be built
      */
     LogicalMetric build(
             String metricName,
@@ -55,5 +52,5 @@ public interface MetricConfiguration {
             MetricDictionary tempDict,
             MakerDictionary makerDict,
             DimensionDictionary dimensionDictionary
-    ) throws IOException;
+    );
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MetricConfiguration.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/MetricConfiguration.java
@@ -1,0 +1,59 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider;
+
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+import java.io.IOException;
+
+/**
+ * A metric with a definition, description, and flag to exclude from external API
+ *
+ * FIXME: The isExcluded() flag is currently unused.
+ */
+public interface MetricConfiguration {
+
+    /**
+     * Get the metric's definition.
+     *
+     * @return the definition
+     */
+    String getDefinition();
+
+    /**
+     * Get the metric's description.
+     *
+     * @return the description
+     */
+    String getDescription();
+
+    /**
+     * Return true if the metric shouldn't be exposed in the api.
+     *
+     * @return true if the metric should be excluded
+     */
+    Boolean isExcluded();
+
+    /**
+     * Build the LogicalMetric for this metric.
+     *
+     * Yes, the signature is a little nasty and some of these things should be changed around a bit.
+     *
+     * @param metricName the name of the metric to build
+     * @param dict the local metric dictionary
+     * @param tempDict the temporary metric dictionary
+     * @param makerDict the metric maker dictionary
+     * @param dimensionDictionary the dimension dictionary
+     * @return a logical metric
+     * @throws IOException if the metric could not be built
+     */
+    LogicalMetric build(
+            String metricName,
+            MetricDictionary dict,
+            MetricDictionary tempDict,
+            MakerDictionary makerDict,
+            DimensionDictionary dimensionDictionary
+    ) throws IOException;
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/PhysicalTableConfiguration.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/PhysicalTableConfiguration.java
@@ -1,0 +1,31 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider;
+
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.names.FieldName;
+import com.yahoo.bard.webservice.data.config.table.PhysicalTableDefinition;
+
+import java.util.Set;
+
+/**
+ * A PhysicalTableConfiguration can create its PhysicalTableDefinition, given a dimension configuration.
+ */
+public interface PhysicalTableConfiguration {
+
+    /**
+     * Build a physical table, given dimensions.
+     *
+     * @param dimensionMap the dimension configuration
+     * @return a PhysicalTableDefinition
+     */
+    PhysicalTableDefinition buildPhysicalTable(ConfigurationDictionary<DimensionConfig> dimensionMap);
+
+    /**
+     * Return the metrics of the physical table.
+     *
+     * @return the set of FieldNames
+     */
+    Set<FieldName> getMetrics();
+
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlConfigProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlConfigProvider.java
@@ -1,0 +1,209 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml;
+
+import com.yahoo.bard.webservice.config.SystemConfig;
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.provider.ConfigProvider;
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationDictionary;
+import com.yahoo.bard.webservice.data.config.provider.LogicalTableConfiguration;
+import com.yahoo.bard.webservice.data.config.provider.MakerConfiguration;
+import com.yahoo.bard.webservice.data.config.provider.MetricConfiguration;
+import com.yahoo.bard.webservice.data.config.provider.PhysicalTableConfiguration;
+import com.yahoo.bard.webservice.data.config.provider.yaml.serde.YamlDimensionConfigDeserializer;
+import com.yahoo.bard.webservice.data.config.provider.yaml.serde.YamlDimensionFieldConfigDeserializer;
+import com.yahoo.bard.webservice.data.config.provider.yaml.serde.YamlPhysicalTableConfigDeserializer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * YAML-based configuration.
+ */
+public class YamlConfigProvider implements ConfigProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(YamlConfigProvider.class);
+    public static final String CONF_YAML_PATH = "config_binder_yaml_path";
+    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+
+    protected ConfigurationDictionary<PhysicalTableConfiguration> physicalTables;
+    protected ConfigurationDictionary<MakerConfiguration> makers;
+    protected ConfigurationDictionary<LogicalTableConfiguration> logicalTables;
+    protected ConfigurationDictionary<DimensionConfig> dimensions;
+    protected ConfigurationDictionary<MetricConfiguration> baseMetrics;
+    protected ConfigurationDictionary<MetricConfiguration> derivedMetrics;
+
+    /**
+     * Instantiate the yaml-based configuration.
+     *
+     * @param physicalTables the physical table configuration
+     * @param logicalTables the logical table configuration
+     * @param dimensions the dimension configuration
+     * @param dimensionFields the dimension field configuration
+     * @param baseMetrics the base (Druid) metric configuration
+     * @param derivedMetrics the derived metric configuration
+     * @param makers the metric makers
+     */
+    @JsonCreator
+    public YamlConfigProvider(
+            @JsonProperty("physical_tables")
+            @JsonDeserialize(using = YamlPhysicalTableConfigDeserializer.class)
+                    ConfigurationDictionary<PhysicalTableConfiguration> physicalTables,
+
+            @JsonProperty("logical_tables")
+            @JsonDeserialize(contentAs = YamlLogicalTableConfig.class)
+                    ConfigurationDictionary<LogicalTableConfiguration> logicalTables,
+
+            @JsonProperty("dimensions")
+            @JsonDeserialize(using = YamlDimensionConfigDeserializer.class, contentAs = YamlDimensionConfig.class)
+                    ConfigurationDictionary<DimensionConfig> dimensions,
+
+            // Don't need a 'nice' type here, since not exposed
+            @JsonProperty("dimension_fields")
+            @JsonDeserialize(using = YamlDimensionFieldConfigDeserializer.class)
+                    ConfigurationDictionary<YamlDimensionFieldConfig> dimensionFields,
+
+            @JsonProperty("base_metrics")
+            @JsonDeserialize(contentAs = YamlMetricConfiguration.class)
+                    ConfigurationDictionary<MetricConfiguration> baseMetrics,
+
+            @JsonProperty("derived_metrics")
+            @JsonDeserialize(contentAs = YamlMetricConfiguration.class)
+                    ConfigurationDictionary<MetricConfiguration> derivedMetrics,
+
+            // Any custom metric makers
+            @JsonProperty("makers")
+            @JsonDeserialize(contentAs = YamlMakerConfiguration.class)
+                    ConfigurationDictionary<MakerConfiguration> makers
+
+    ) {
+        this.physicalTables = physicalTables;
+        this.logicalTables = logicalTables;
+        this.dimensions = dimensions;
+        this.baseMetrics = baseMetrics;
+        this.derivedMetrics = derivedMetrics;
+        this.makers = makers;
+
+        // Physical tables are required
+        if (physicalTables == null) {
+            throw new RuntimeException("Error: No physical tables configured.");
+        }
+
+        // Logical tables are required
+        if (logicalTables == null) {
+            throw new RuntimeException("Error: No logical tables configured.");
+        }
+
+        // Dimensions are required
+        if (dimensions == null) {
+            throw new RuntimeException("Error: No dimensions configured.");
+        }
+
+        // Dimension fields are required
+        if (dimensionFields == null) {
+            throw new RuntimeException("Error: No dimension fields configured.");
+        }
+
+        // Base metrics are required
+        if (baseMetrics == null) {
+            throw new RuntimeException("Error: No base metrics configured.");
+        }
+
+        // Derived metrics are not required
+        if (derivedMetrics == null) {
+            LOG.info("No derived metrics found.");
+            this.derivedMetrics = new ConfigurationDictionary<>();
+        }
+
+        // Custom makers are not required
+        if (makers == null) {
+            LOG.info("No custom metric makers found.");
+            this.makers = new ConfigurationDictionary<>();
+        }
+
+        // Dimensions must know their fields.
+        dimensions.values().forEach(
+                v -> ((YamlDimensionConfig) v).setAvailableDimensionFields(dimensionFields)
+        );
+    }
+
+    @Override
+    public ConfigurationDictionary<PhysicalTableConfiguration> getPhysicalTableConfig() {
+        return physicalTables;
+    }
+
+    @Override
+    public ConfigurationDictionary<LogicalTableConfiguration> getLogicalTableConfig() {
+        return logicalTables;
+    }
+
+    @Override
+    public ConfigurationDictionary<DimensionConfig> getDimensionConfig() {
+        return dimensions;
+    }
+
+    @Override
+    public ConfigurationDictionary<MetricConfiguration> getBaseMetrics() {
+        return baseMetrics;
+    }
+
+    @Override
+    public ConfigurationDictionary<MetricConfiguration> getDerivedMetrics() {
+        return derivedMetrics;
+    }
+
+    @Override
+    public ConfigurationDictionary<MakerConfiguration> getCustomMakerConfig() {
+        return makers;
+    }
+
+    /**
+     * Build self from yaml file.
+     *
+     * @param systemConfig the system configuration
+     * @return a ConfigProvider
+     *
+     * @see com.yahoo.bard.webservice.data.config.provider.ConfigBinderFactory
+     */
+    public static ConfigProvider build(SystemConfig systemConfig) {
+        String path = systemConfig.getStringProperty(
+                systemConfig.getPackageVariableName(CONF_YAML_PATH)
+        );
+
+        if (path == null) {
+            throw new RuntimeException("Could not read path variable: " + CONF_YAML_PATH);
+        }
+
+        File f = new File(path);
+        if (!f.exists() || !f.canRead()) {
+            throw new RuntimeException("Could not read path: " + path + ". Please ensure it exists and is readable.");
+        }
+
+        try {
+            LOG.info("Loading YAML configuration from path: {}", path);
+            return build(f);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not parse path: " + path, e);
+        }
+    }
+
+    /**
+     * Build self from yaml file.
+     *
+     * @param file the YAML file to read
+     * @return a ConfigProvider
+     * @throws IOException when the file cannot be parsed
+     * @see com.yahoo.bard.webservice.data.config.provider.ConfigBinderFactory
+     */
+    public static ConfigProvider build(File file) throws IOException {
+        return MAPPER.readValue(file, YamlConfigProvider.class);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionConfig.java
@@ -1,0 +1,320 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml;
+
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.dimension.DimensionField;
+import com.yahoo.bard.webservice.data.dimension.KeyValueStore;
+import com.yahoo.bard.webservice.data.dimension.MapStoreManager;
+import com.yahoo.bard.webservice.data.dimension.SearchProvider;
+import com.yahoo.bard.webservice.data.dimension.impl.NoOpSearchProviderManager;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Dimension configuration.
+ *
+ * FIXME: Need to implement the following methods:
+ *  * getKeyValueStore
+ *  * getSearchProvider
+ *  * getType
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class YamlDimensionConfig implements DimensionConfig {
+
+    private static final Logger LOG = LoggerFactory.getLogger(YamlDimensionConfig.class);
+
+    protected String dimensionName;
+    protected String apiName;
+    protected String physicalName;
+    protected String longName;
+    protected String category;
+    protected String description;
+
+    protected List<String> dimensionFieldNames = null;
+    protected List<String> defaultDimensionFieldNames = null;
+    protected LinkedHashSet<DimensionField> allDimensionFields = null;
+    protected LinkedHashSet<DimensionField> defaultDimensionFields = null;
+    protected KeyValueStore keyValueStore;
+    protected SearchProvider searchProvider;
+    protected Boolean aggregatable = true;
+
+    /**
+     * Construct the dimension configuration.
+     *
+     * @param physicalName the physical name
+     * @param longName the long name
+     * @param category the category
+     * @param description the description
+     * @param dimensionFields the dimension fields
+     * @param defaultDimensionFields the default dimension fields
+     * @param keyValueStore the keyvalue store
+     * @param searchProvider the search provider
+     * @param aggregatable true if the dimension is aggregatable
+     */
+    @JsonCreator
+    public YamlDimensionConfig(
+            @JsonProperty("physical_name") String physicalName,
+            @JsonProperty("long_name") String longName,
+            @JsonProperty("category") String category,
+            @JsonProperty("description") String description,
+            @JsonProperty("fields") String[] dimensionFields,
+            @JsonProperty("default_fields") String[] defaultDimensionFields,
+            @JsonProperty("key_value_store") String keyValueStore,
+            @JsonProperty("search_provider") String searchProvider,
+            @JsonProperty("aggregatable") Boolean aggregatable
+    ) {
+        this.physicalName = physicalName;
+        this.longName = longName;
+        this.category = category;
+        this.description = description;
+
+        // Set and validate dimension fields
+        if (dimensionFields != null && dimensionFields.length > 0) {
+            dimensionFieldNames = Arrays.asList(dimensionFields);
+            if (!isUniqueList(dimensionFieldNames)) {
+                throw new RuntimeException("Error: must provide unique list of dimension fields. Found: " + Arrays
+                        .toString(
+                        dimensionFields));
+            }
+        } else {
+            LOG.info("No fields configured for dimension " + physicalName + "; will use defaults.");
+        }
+
+        // Set and validate default dimension fields
+        if (defaultDimensionFields != null && defaultDimensionFields.length > 0) {
+            defaultDimensionFieldNames = Arrays.asList(defaultDimensionFields);
+            if (!isUniqueList(defaultDimensionFieldNames)) {
+                throw new RuntimeException("Error: must provide unique list of default dimension fields. Found: " +
+                        Arrays
+                        .toString(defaultDimensionFields));
+            }
+        } else {
+            LOG.info("No default fields configured for dimension " + physicalName + "; will use defaults.");
+        }
+
+        this.aggregatable = (aggregatable != null ? aggregatable : this.aggregatable);
+    }
+
+    /**
+     * Set the API name.
+     *
+     * Intended to be used by Jackson deserializer
+     *
+     * @param apiName the API name
+     */
+    public void setApiName(String apiName) {
+        this.apiName = apiName;
+
+        // Set defaults, too
+        if (this.physicalName == null) {
+            this.physicalName = apiName;
+        }
+        if (this.longName == null) {
+            this.longName = apiName;
+        }
+
+        if (this.description == null) {
+            this.description = apiName;
+        }
+    }
+
+    /**
+     * Set the available dimension fields.
+     *
+     * There is a global list of dimension fields; this tells the dimensions about them.
+     *
+     * @param availableFields configured available dimension fields
+     */
+    public void setAvailableDimensionFields(Map<String, YamlDimensionFieldConfig> availableFields) {
+
+        LinkedHashSet<String> allDimensionFieldNames = new LinkedHashSet<>();
+
+        // If no dimension fields were specified, make all globally defined fields available.
+        // Otherwise, use just the ones specified.
+        if (dimensionFieldNames == null) {
+            allDimensionFields = new LinkedHashSet<>(availableFields.values());
+            allDimensionFieldNames.addAll(availableFields.keySet());
+        } else {
+
+            // You can't ask for a dimension field that doesn't exist in the global config
+            if (!dimensionFieldNames.stream().allMatch(availableFields::containsKey)) {
+                throw new RuntimeException("Asked for unconfigured dimension field; requested fields: " +
+                        Arrays.toString(dimensionFieldNames.toArray()) +
+                        "; available fields: " +
+                        Arrays.toString(availableFields.keySet().toArray()));
+            }
+
+            allDimensionFieldNames.addAll(dimensionFieldNames);
+            allDimensionFields = dimensionFieldNames
+                    .stream()
+                    .map(availableFields::get)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+
+        // If no default fields were specified, use the default included fields from those
+        // that are available for this dimension.
+        // Otherwise, use the defaults that were specified.
+        if (defaultDimensionFieldNames == null) {
+            defaultDimensionFields = allDimensionFields
+                    .stream()
+                    .filter(d -> ((YamlDimensionFieldConfig) d).includedByDefault())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+        } else {
+
+            // You can't ask for a default dimension field that isn't available, either
+            if (!defaultDimensionFieldNames.stream().allMatch(allDimensionFieldNames::contains)) {
+                throw new RuntimeException("Asked for unconfigured default dimension field; requested fields: " +
+                        Arrays.toString(dimensionFieldNames.toArray()) +
+                        "; available fields: " +
+                        Arrays.toString(allDimensionFieldNames.toArray()));
+            }
+
+            defaultDimensionFields = defaultDimensionFieldNames
+                    .stream()
+                    .filter(availableFields::containsKey)
+                    .map(availableFields::get)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+    }
+
+    @Override
+    public String getApiName() {
+        return apiName;
+    }
+
+    @Override
+    public String getLongName() {
+        return longName;
+    }
+
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Return all dimension fields.
+     *
+     * @return the dimension fields
+     */
+    @Override
+    public LinkedHashSet<DimensionField> getFields() {
+
+        if (allDimensionFields == null) {
+            throw new RuntimeException("Dimension fields not available from configuration.");
+        }
+
+        return allDimensionFields;
+    }
+
+    /**
+     * Return the default dimension fields.
+     *
+     * @return the default dimension fields
+     */
+    @Override
+    public LinkedHashSet<DimensionField> getDefaultDimensionFields() {
+        if (defaultDimensionFields == null) {
+            throw new RuntimeException("Dimension fields not available from configuration.");
+        }
+
+        return defaultDimensionFields;
+    }
+
+    @Override
+    public boolean isAggregatable() {
+        return aggregatable;
+    }
+
+    @Override
+    public String getPhysicalName() {
+        return physicalName;
+    }
+
+    @Override
+    public KeyValueStore getKeyValueStore() {
+        // return keyValueStore;
+        // Not really implemented yet
+        return MapStoreManager.getInstance(apiName);
+    }
+
+    // FIXME: not implemented yet
+    @Override
+    public SearchProvider getSearchProvider() {
+        // return searchProvider;
+        // Not really implemented yet
+        return NoOpSearchProviderManager.getInstance(apiName);
+    }
+
+    /**
+     * Return true if the passed list contains a unique collection of elements.
+     *
+     * @param elements array of elements
+     * @param <E> type of element
+     * @return true if the list has no duplicate elements
+     */
+    public static <E> boolean isUniqueList(List<E> elements) {
+        return elements.size() == new HashSet<>(elements).size();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null || !(other instanceof YamlDimensionConfig)) {
+            return false;
+        }
+
+        YamlDimensionConfig conf = (YamlDimensionConfig) other;
+
+        return Objects.equals(dimensionName, conf.dimensionName) &&
+                Objects.equals(apiName, conf.apiName) &&
+                Objects.equals(physicalName, conf.physicalName) &&
+                Objects.equals(longName, conf.longName) &&
+                Objects.equals(category, conf.category) &&
+                Objects.equals(description, conf.description) &&
+                Objects.equals(dimensionFieldNames, conf.dimensionFieldNames) &&
+                Objects.equals(defaultDimensionFieldNames, conf.defaultDimensionFieldNames) &&
+                Objects.equals(allDimensionFields, conf.allDimensionFields) &&
+                Objects.equals(defaultDimensionFields, conf.defaultDimensionFields) &&
+                Objects.equals(keyValueStore, conf.keyValueStore) &&
+                Objects.equals(searchProvider, conf.searchProvider) &&
+                Objects.equals(aggregatable, conf.aggregatable);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                dimensionName,
+                apiName,
+                physicalName,
+                longName,
+                category,
+                description,
+                dimensionFieldNames,
+                defaultDimensionFieldNames,
+                allDimensionFields,
+                defaultDimensionFields,
+                keyValueStore,
+                searchProvider,
+                aggregatable
+        );
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionConfig.java
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.data.config.provider.yaml;
 
 import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationError;
 import com.yahoo.bard.webservice.data.dimension.DimensionField;
 import com.yahoo.bard.webservice.data.dimension.KeyValueStore;
 import com.yahoo.bard.webservice.data.dimension.MapStoreManager;
@@ -48,8 +49,6 @@ public class YamlDimensionConfig implements DimensionConfig {
     protected List<String> defaultDimensionFieldNames = null;
     protected LinkedHashSet<DimensionField> allDimensionFields = null;
     protected LinkedHashSet<DimensionField> defaultDimensionFields = null;
-    protected KeyValueStore keyValueStore;
-    protected SearchProvider searchProvider;
     protected Boolean aggregatable = true;
 
     /**
@@ -61,8 +60,6 @@ public class YamlDimensionConfig implements DimensionConfig {
      * @param description the description
      * @param dimensionFields the dimension fields
      * @param defaultDimensionFields the default dimension fields
-     * @param keyValueStore the keyvalue store
-     * @param searchProvider the search provider
      * @param aggregatable true if the dimension is aggregatable
      */
     @JsonCreator
@@ -73,8 +70,8 @@ public class YamlDimensionConfig implements DimensionConfig {
             @JsonProperty("description") String description,
             @JsonProperty("fields") String[] dimensionFields,
             @JsonProperty("default_fields") String[] defaultDimensionFields,
-            @JsonProperty("key_value_store") String keyValueStore,
-            @JsonProperty("search_provider") String searchProvider,
+            // @JsonProperty("key_value_store") String keyValueStore,
+            // @JsonProperty("search_provider") String searchProvider,
             @JsonProperty("aggregatable") Boolean aggregatable
     ) {
         this.physicalName = physicalName;
@@ -86,7 +83,7 @@ public class YamlDimensionConfig implements DimensionConfig {
         if (dimensionFields != null && dimensionFields.length > 0) {
             dimensionFieldNames = Arrays.asList(dimensionFields);
             if (!isUniqueList(dimensionFieldNames)) {
-                throw new RuntimeException("Error: must provide unique list of dimension fields. Found: " + Arrays
+                throw new ConfigurationError("Error: must provide unique list of dimension fields. Found: " + Arrays
                         .toString(
                         dimensionFields));
             }
@@ -98,7 +95,7 @@ public class YamlDimensionConfig implements DimensionConfig {
         if (defaultDimensionFields != null && defaultDimensionFields.length > 0) {
             defaultDimensionFieldNames = Arrays.asList(defaultDimensionFields);
             if (!isUniqueList(defaultDimensionFieldNames)) {
-                throw new RuntimeException("Error: must provide unique list of default dimension fields. Found: " +
+                throw new ConfigurationError("Error: must provide unique list of default dimension fields. Found: " +
                         Arrays
                         .toString(defaultDimensionFields));
             }
@@ -152,7 +149,7 @@ public class YamlDimensionConfig implements DimensionConfig {
 
             // You can't ask for a dimension field that doesn't exist in the global config
             if (!dimensionFieldNames.stream().allMatch(availableFields::containsKey)) {
-                throw new RuntimeException("Asked for unconfigured dimension field; requested fields: " +
+                throw new ConfigurationError("Asked for unconfigured dimension field; requested fields: " +
                         Arrays.toString(dimensionFieldNames.toArray()) +
                         "; available fields: " +
                         Arrays.toString(availableFields.keySet().toArray()));
@@ -177,7 +174,7 @@ public class YamlDimensionConfig implements DimensionConfig {
 
             // You can't ask for a default dimension field that isn't available, either
             if (!defaultDimensionFieldNames.stream().allMatch(allDimensionFieldNames::contains)) {
-                throw new RuntimeException("Asked for unconfigured default dimension field; requested fields: " +
+                throw new ConfigurationError("Asked for unconfigured default dimension field; requested fields: " +
                         Arrays.toString(dimensionFieldNames.toArray()) +
                         "; available fields: " +
                         Arrays.toString(allDimensionFieldNames.toArray()));
@@ -220,7 +217,7 @@ public class YamlDimensionConfig implements DimensionConfig {
     public LinkedHashSet<DimensionField> getFields() {
 
         if (allDimensionFields == null) {
-            throw new RuntimeException("Dimension fields not available from configuration.");
+            throw new ConfigurationError("Dimension fields not available from configuration.");
         }
 
         return allDimensionFields;
@@ -234,7 +231,7 @@ public class YamlDimensionConfig implements DimensionConfig {
     @Override
     public LinkedHashSet<DimensionField> getDefaultDimensionFields() {
         if (defaultDimensionFields == null) {
-            throw new RuntimeException("Dimension fields not available from configuration.");
+            throw new ConfigurationError("Dimension fields not available from configuration.");
         }
 
         return defaultDimensionFields;
@@ -294,8 +291,6 @@ public class YamlDimensionConfig implements DimensionConfig {
                 Objects.equals(defaultDimensionFieldNames, conf.defaultDimensionFieldNames) &&
                 Objects.equals(allDimensionFields, conf.allDimensionFields) &&
                 Objects.equals(defaultDimensionFields, conf.defaultDimensionFields) &&
-                Objects.equals(keyValueStore, conf.keyValueStore) &&
-                Objects.equals(searchProvider, conf.searchProvider) &&
                 Objects.equals(aggregatable, conf.aggregatable);
     }
 
@@ -312,8 +307,6 @@ public class YamlDimensionConfig implements DimensionConfig {
                 defaultDimensionFieldNames,
                 allDimensionFields,
                 defaultDimensionFields,
-                keyValueStore,
-                searchProvider,
                 aggregatable
         );
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionFieldConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionFieldConfig.java
@@ -1,0 +1,91 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml;
+
+import com.yahoo.bard.webservice.data.dimension.DimensionField;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Pojo for deserializing yaml configuration of dimension fields.
+ */
+public class YamlDimensionFieldConfig implements DimensionField {
+
+    protected String name;
+    protected String description;
+    protected Boolean defaultInclude;
+
+    /**
+     * Construct the dimension field configuration.
+     *
+     * @param description field description
+     * @param defaultInclude true if field is included by default
+     */
+    @JsonCreator
+    public YamlDimensionFieldConfig(
+            @JsonProperty("description") String description,
+            @JsonProperty("default_include") Boolean defaultInclude
+    ) {
+        this.description = description;
+        if (defaultInclude != null) {
+            this.defaultInclude = defaultInclude;
+        } else {
+            this.defaultInclude = false;
+        }
+    }
+
+    /**
+     * Set the dimension field name.
+     *
+     * Intended to be called by Jackson deserialization
+     *
+     * @param name the dimension field name
+     */
+    public void setName(String name) {
+        this.name = name;
+
+        // Default the description to the name
+        if (this.description == null) {
+            this.description = name;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Return true if the dimension field should be included in results by default.
+     *
+     * @return true if included by default, false otherwise
+     */
+    public Boolean includedByDefault() {
+        return defaultInclude;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null || !(other instanceof YamlDimensionFieldConfig)) {
+            return false;
+        }
+
+        YamlDimensionFieldConfig conf = (YamlDimensionFieldConfig) other;
+        return Objects.equals(name, conf.name) &&
+                Objects.equals(description, conf.description) &&
+                Objects.equals(defaultInclude, conf.defaultInclude);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, defaultInclude);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlLogicalTableConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlLogicalTableConfig.java
@@ -1,0 +1,93 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml;
+
+import com.yahoo.bard.webservice.data.config.provider.LogicalTableConfiguration;
+import com.yahoo.bard.webservice.data.config.provider.yaml.serde.GranularityDeserializer;
+import com.yahoo.bard.webservice.data.time.TimeGrain;
+import com.yahoo.bard.webservice.druid.model.query.Granularity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * YAML configuration for a single LogicalTable.
+ *
+ * FIXME: Handle non-default time grains; should maybe be Set of Granularity instead?
+ *
+ */
+public class YamlLogicalTableConfig implements LogicalTableConfiguration {
+
+    protected Set<TimeGrain> timeGrains;
+    protected Set<String> physicalTables;
+    protected Set<String> metrics;
+
+    /**
+     * Construct the logical table configuration object.
+     *
+     * @param timeGrains the logical table time grains
+     * @param physicalTables the physical tables backing the logical table
+     * @param metrics the logical table metrics
+     */
+    @JsonCreator
+    public YamlLogicalTableConfig(
+            @NotNull @JsonProperty("granularities") @JsonDeserialize(contentUsing = GranularityDeserializer.class)
+                    Granularity[] timeGrains,
+            @NotNull @JsonProperty("physical_tables") String[] physicalTables,
+            @NotNull @JsonProperty("metrics") String[] metrics
+    ) {
+        this.timeGrains = new HashSet<>();
+        for (Granularity granularity : timeGrains) {
+            if (!(granularity instanceof TimeGrain)) {
+                throw new RuntimeException("Must construct logical table with only TimeGrains; found: " + granularity);
+            }
+            this.timeGrains.add((TimeGrain) granularity);
+        }
+        this.physicalTables = new HashSet<>(Arrays.asList(physicalTables));
+        this.metrics = new HashSet<>(Arrays.asList(metrics));
+    }
+
+    @Override
+    public Set<TimeGrain> getTimeGrains() {
+        return timeGrains;
+    }
+
+    @Override
+    public Set<String> getPhysicalTables() {
+        return physicalTables;
+    }
+
+    @Override
+    public Set<String> getMetrics() {
+        return metrics;
+    }
+
+    // FIXME: I wanted to implement .equals and .hashCode on these objects but
+    // couldn't convince the ClassScannerSpec to pass because it can't construct
+    // valid objects out of thin air.
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null || !(other instanceof YamlLogicalTableConfig)) {
+            return false;
+        }
+
+        YamlLogicalTableConfig conf = (YamlLogicalTableConfig) other;
+        return Objects.equals(timeGrains, conf.timeGrains) &&
+                Objects.equals(physicalTables, conf.physicalTables) &&
+                Objects.equals(metrics, conf.metrics);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timeGrains, physicalTables, metrics);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlLogicalTableConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlLogicalTableConfig.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.provider.yaml;
 
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationError;
 import com.yahoo.bard.webservice.data.config.provider.LogicalTableConfiguration;
 import com.yahoo.bard.webservice.data.config.provider.yaml.serde.GranularityDeserializer;
 import com.yahoo.bard.webservice.data.time.TimeGrain;
@@ -22,7 +23,6 @@ import javax.validation.constraints.NotNull;
  * YAML configuration for a single LogicalTable.
  *
  * FIXME: Handle non-default time grains; should maybe be Set of Granularity instead?
- *
  */
 public class YamlLogicalTableConfig implements LogicalTableConfiguration {
 
@@ -47,7 +47,8 @@ public class YamlLogicalTableConfig implements LogicalTableConfiguration {
         this.timeGrains = new HashSet<>();
         for (Granularity granularity : timeGrains) {
             if (!(granularity instanceof TimeGrain)) {
-                throw new RuntimeException("Must construct logical table with only TimeGrains; found: " + granularity);
+                throw new ConfigurationError("Must construct logical table with only TimeGrains; found: " +
+                        granularity);
             }
             this.timeGrains.add((TimeGrain) granularity);
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlMakerConfiguration.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlMakerConfiguration.java
@@ -1,0 +1,51 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml;
+
+import com.yahoo.bard.webservice.data.config.provider.MakerConfiguration;
+import com.yahoo.bard.webservice.data.config.provider.yaml.serde.YamlArgDeserializer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.util.Objects;
+
+/**
+ * Configuration for metric makers.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class YamlMakerConfiguration implements MakerConfiguration {
+    @JsonProperty("class")
+    public String cls;
+
+    @JsonProperty("args")
+    @JsonDeserialize(using = YamlArgDeserializer.class)
+    public Object[] args;
+
+    @Override
+    public String getClassName() {
+        return cls;
+    }
+
+    @Override
+    public Object[] getArguments() {
+        return args;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null || !(other instanceof YamlMakerConfiguration)) {
+            return false;
+        }
+
+        YamlMakerConfiguration conf = (YamlMakerConfiguration) other;
+        return Objects.equals(cls, conf.cls) &&
+                Objects.equals(args, conf.args);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cls, args);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlMetricConfiguration.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlMetricConfiguration.java
@@ -3,6 +3,8 @@
 package com.yahoo.bard.webservice.data.config.provider.yaml;
 
 import com.yahoo.bard.webservice.data.config.metric.parser.MetricParser;
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException;
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationError;
 import com.yahoo.bard.webservice.data.config.provider.MakerDictionary;
 import com.yahoo.bard.webservice.data.config.provider.MetricConfiguration;
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
@@ -12,7 +14,6 @@ import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -68,9 +69,13 @@ public class YamlMetricConfiguration implements MetricConfiguration {
             MetricDictionary tempDict,
             MakerDictionary makerDict,
             DimensionDictionary dimensionDictionary
-    ) throws IOException {
+    ) {
         MetricParser p = new MetricParser(metricName, definition, dict, tempDict, makerDict, dimensionDictionary);
-        return p.parse();
+        try {
+            return p.parse();
+        } catch (ParsingException e) {
+            throw new ConfigurationError("Could not parse metric", e);
+        }
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlMetricConfiguration.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlMetricConfiguration.java
@@ -1,0 +1,92 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml;
+
+import com.yahoo.bard.webservice.data.config.metric.parser.MetricParser;
+import com.yahoo.bard.webservice.data.config.provider.MakerDictionary;
+import com.yahoo.bard.webservice.data.config.provider.MetricConfiguration;
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Yaml-configured metric.
+ *
+ * Definition is parsed using the built-in metrics parser.
+ *
+ * @see com.yahoo.bard.webservice.data.config.metric.parser.MetricParser
+ */
+public class YamlMetricConfiguration implements MetricConfiguration {
+
+    protected String definition;
+    protected String description;
+    protected Boolean exclude;
+
+    /**
+     * Construct the YAML metric configuration.
+     *
+     * @param description metric description
+     * @param definition metric definition
+     * @param exclude true if metric is excluded from API (not yet implemented)
+     */
+    @JsonCreator
+    public YamlMetricConfiguration(
+            @JsonProperty("description") String description,
+            @JsonProperty("def") String definition,
+            @JsonProperty("exclude") Boolean exclude
+    ) {
+        this.description = description;
+        this.definition = definition;
+        this.exclude = exclude;
+    }
+
+    @Override
+    public String getDefinition() {
+        return definition;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public Boolean isExcluded() {
+        return exclude;
+    }
+
+    @Override
+    public LogicalMetric build(
+            String metricName,
+            MetricDictionary dict,
+            MetricDictionary tempDict,
+            MakerDictionary makerDict,
+            DimensionDictionary dimensionDictionary
+    ) throws IOException {
+        MetricParser p = new MetricParser(metricName, definition, dict, tempDict, makerDict, dimensionDictionary);
+        return p.parse();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == null || !(object instanceof YamlMetricConfiguration)) {
+            return false;
+        }
+
+        YamlMetricConfiguration other = (YamlMetricConfiguration) object;
+        return Objects.equals(definition, other.definition) &&
+                Objects.equals(description, other.definition) &&
+                Objects.equals(exclude, other.exclude);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(definition, description, exclude);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlPhysicalTableConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlPhysicalTableConfig.java
@@ -1,0 +1,135 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml;
+
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.names.FieldName;
+import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationDictionary;
+import com.yahoo.bard.webservice.data.config.provider.PhysicalTableConfiguration;
+import com.yahoo.bard.webservice.data.config.provider.yaml.serde.GranularityDeserializer;
+import com.yahoo.bard.webservice.data.config.table.PhysicalTableDefinition;
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
+import com.yahoo.bard.webservice.data.time.ZonelessTimeGrain;
+import com.yahoo.bard.webservice.druid.model.query.Granularity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.joda.time.DateTimeZone;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * YAML configuration for physical table.
+ *
+ * FIXME: Timegrain has changed since I wrote originally; probably needs configurable time zone
+ */
+public class YamlPhysicalTableConfig implements PhysicalTableConfiguration {
+
+    protected TableName name;
+    protected ZonedTimeGrain grain;
+    protected List<String> dimensions;
+    protected List<String> metrics;
+
+    /**
+     * Create the physical table configuration.
+     * @param grain the table time grain
+     * @param dimensions the table dimensions
+     * @param metrics the table metrics
+     */
+    @JsonCreator
+    public YamlPhysicalTableConfig(
+            @JsonProperty("granularity") @JsonDeserialize(using = GranularityDeserializer.class) Granularity grain,
+            @JsonProperty("dimensions") String[] dimensions,
+            @JsonProperty("metrics") String[] metrics
+    ) {
+
+        if (!(grain instanceof ZonelessTimeGrain)) {
+            throw new RuntimeException("ZonelessTimeGrain required; found " + grain);
+        }
+        if (dimensions == null || dimensions.length == 0) {
+            throw new RuntimeException("Physical table must be configured with dimensions; found null.");
+        }
+
+        if (metrics == null || metrics.length == 0) {
+            throw new RuntimeException("Physical table must be configured with metrics; found null.");
+        }
+
+        this.grain = new ZonedTimeGrain((ZonelessTimeGrain) grain, DateTimeZone.UTC);
+        this.dimensions = Arrays.asList(dimensions);
+        this.metrics = Arrays.asList(metrics);
+    }
+
+    /**
+     * Set the table name.
+     *
+     * Not intended for public use; called from Jackson deserialization code on construction
+     *
+     * @param tableName the table name
+     */
+    public void setTableName(String tableName) {
+        this.name = new YamlTableName(tableName);
+    }
+
+    @Override
+    public PhysicalTableDefinition buildPhysicalTable(ConfigurationDictionary<DimensionConfig> dimensionMap) {
+
+        Set<DimensionConfig> dimSet = dimensions
+                .stream()
+                .filter(dimensionMap::containsKey)
+                .map(dimensionMap::get)
+                .collect(Collectors.toSet());
+
+        return new PhysicalTableDefinition(name, grain, dimSet);
+    }
+
+    @Override
+    public Set<FieldName> getMetrics() {
+        return metrics.stream().map(YamlFieldName::new).collect(Collectors.toSet());
+    }
+
+    /**
+     * A FieldName.
+     *
+     * Was this, but problems with creating a set of them (.equals doesn't work):
+     *
+     *   return stream.map(f -&gt; (FieldName) () -&gt; f).collect(Collectors.toSet());
+     */
+    public static class YamlFieldName implements FieldName {
+        protected String name;
+
+        /**
+         * Construct a new name.
+         *
+         * @param name the field name
+         */
+        public YamlFieldName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String asName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == null || !(other instanceof YamlFieldName)) {
+                return false;
+            } else {
+                return Objects.equals(this.name, ((YamlFieldName) other).name);
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.name);
+        }
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlPhysicalTableConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlPhysicalTableConfig.java
@@ -6,6 +6,7 @@ import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
 import com.yahoo.bard.webservice.data.config.names.FieldName;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.config.provider.ConfigurationDictionary;
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationError;
 import com.yahoo.bard.webservice.data.config.provider.PhysicalTableConfiguration;
 import com.yahoo.bard.webservice.data.config.provider.yaml.serde.GranularityDeserializer;
 import com.yahoo.bard.webservice.data.config.table.PhysicalTableDefinition;
@@ -51,14 +52,14 @@ public class YamlPhysicalTableConfig implements PhysicalTableConfiguration {
     ) {
 
         if (!(grain instanceof ZonelessTimeGrain)) {
-            throw new RuntimeException("ZonelessTimeGrain required; found " + grain);
+            throw new ConfigurationError("ZonelessTimeGrain required; found " + grain);
         }
         if (dimensions == null || dimensions.length == 0) {
-            throw new RuntimeException("Physical table must be configured with dimensions; found null.");
+            throw new ConfigurationError("Physical table must be configured with dimensions; found null.");
         }
 
         if (metrics == null || metrics.length == 0) {
-            throw new RuntimeException("Physical table must be configured with metrics; found null.");
+            throw new ConfigurationError("Physical table must be configured with metrics; found null.");
         }
 
         this.grain = new ZonedTimeGrain((ZonelessTimeGrain) grain, DateTimeZone.UTC);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlTableName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/YamlTableName.java
@@ -1,0 +1,44 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml;
+
+import com.yahoo.bard.webservice.data.config.names.TableName;
+
+import java.util.Objects;
+
+/**
+ * YAML configuration for TableName.
+ */
+public class YamlTableName implements TableName {
+
+    protected String name;
+
+    /**
+     * Construct a new table name.
+     *
+     * @param name the table name
+     */
+    public YamlTableName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String asName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == null || !(object instanceof YamlTableName)) {
+            return false;
+        }
+
+        YamlTableName other = (YamlTableName) object;
+        return Objects.equals(name, other.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return 1 + Objects.hash(name);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/GranularityDeserializer.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/GranularityDeserializer.java
@@ -1,0 +1,46 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde;
+
+import com.yahoo.bard.webservice.data.time.GranularityDictionary;
+import com.yahoo.bard.webservice.data.time.StandardGranularityParser;
+import com.yahoo.bard.webservice.druid.model.query.Granularity;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * Deserialize a granularity string into an object, e.g. 'minute'
+ *
+ * FIXME: Currently only parses built-in granularities; probably should be extensible
+ *
+ * @see com.yahoo.bard.webservice.data.time.StandardGranularityParser
+ */
+public class GranularityDeserializer extends JsonDeserializer<Granularity> {
+
+    protected static final GranularityDictionary DICTIONARY = StandardGranularityParser.getDefaultGrainMap();
+
+    @Override
+    public Granularity deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException, JsonProcessingException {
+        JsonLocation currentLocation = jsonParser.getCurrentLocation();
+
+        String granularityString = jsonParser.getValueAsString().toLowerCase(Locale.ENGLISH);
+        Granularity granularity = DICTIONARY.get(granularityString);
+
+        if (granularity == null) {
+            throw new JsonParseException("Unable to parse granularity. Found: [" + granularityString + "]; available:" +
+                    " " + DICTIONARY
+                    .toString(), currentLocation);
+        }
+
+        return granularity;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlArgDeserializer.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlArgDeserializer.java
@@ -1,0 +1,33 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+
+/**
+ * Deserialize a list of arguments into Java objects
+ *
+ * If any of them look like they're annotated with YAML types, try to interpret them.
+ */
+public class YamlArgDeserializer extends JsonDeserializer<Object[]> {
+    @Override
+    public Object[] deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        Object[] args = p.readValueAs(Object[].class);
+
+        int i;
+        for (i = 0; i < args.length; i++) {
+            if (args[i] != null && args[i] instanceof String && ((String) args[i]).startsWith("!!")) {
+                Yaml yaml = new Yaml();
+                args[i] = yaml.load((String) args[i]);
+            }
+        }
+
+        return args;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlDimensionConfigDeserializer.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlDimensionConfigDeserializer.java
@@ -1,0 +1,37 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde;
+
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationDictionary;
+import com.yahoo.bard.webservice.data.config.provider.yaml.YamlDimensionConfig;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Deserializer for dimension configuration.
+ */
+public class YamlDimensionConfigDeserializer
+        extends JsonDeserializer<ConfigurationDictionary<? extends DimensionConfig>> {
+
+    protected static final TypeReference<ConfigurationDictionary<YamlDimensionConfig>> TYPE = new
+            TypeReference<ConfigurationDictionary<YamlDimensionConfig>>() { };
+
+    @Override
+    public ConfigurationDictionary<? extends DimensionConfig> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        ConfigurationDictionary<YamlDimensionConfig> map = p.readValueAs(TYPE);
+
+        for (Map.Entry<String, YamlDimensionConfig> entry : map.entrySet()) {
+            entry.getValue().setApiName(entry.getKey());
+        }
+        return map;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlDimensionFieldConfigDeserializer.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlDimensionFieldConfigDeserializer.java
@@ -1,0 +1,37 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde;
+
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationDictionary;
+import com.yahoo.bard.webservice.data.config.provider.yaml.YamlDimensionFieldConfig;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Deserializer for dimension field configuration.
+ */
+public class YamlDimensionFieldConfigDeserializer
+        extends JsonDeserializer<ConfigurationDictionary<YamlDimensionFieldConfig>> {
+    protected static final TypeReference<ConfigurationDictionary<YamlDimensionFieldConfig>> TYPE = new
+            TypeReference<ConfigurationDictionary<YamlDimensionFieldConfig>>() {
+    };
+
+    @Override
+    public ConfigurationDictionary<YamlDimensionFieldConfig> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        ConfigurationDictionary<YamlDimensionFieldConfig> dimensionFields = p.readValueAs(TYPE);
+
+        for (Map.Entry<String, YamlDimensionFieldConfig> entry : dimensionFields.entrySet()) {
+            entry.getValue().setName(entry.getKey());
+        }
+
+        return dimensionFields;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlPhysicalTableConfigDeserializer.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlPhysicalTableConfigDeserializer.java
@@ -1,0 +1,37 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde;
+
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationDictionary;
+import com.yahoo.bard.webservice.data.config.provider.yaml.YamlPhysicalTableConfig;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Deserializer for physical table configuration.
+ */
+public class YamlPhysicalTableConfigDeserializer
+        extends JsonDeserializer<ConfigurationDictionary<YamlPhysicalTableConfig>> {
+    protected static final TypeReference<ConfigurationDictionary<YamlPhysicalTableConfig>> TYPE = new
+            TypeReference<ConfigurationDictionary<YamlPhysicalTableConfig>>() { };
+
+    @Override
+    public ConfigurationDictionary<YamlPhysicalTableConfig> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        ConfigurationDictionary<YamlPhysicalTableConfig> result = p.readValueAs(TYPE);
+
+        // Set the table name to the map key
+        for (Map.Entry<String, YamlPhysicalTableConfig> entry : result.entrySet()) {
+            entry.getValue().setTableName(entry.getKey());
+        }
+
+        return result;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/metadata/ShardSpecMixIn.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/metadata/ShardSpecMixIn.java
@@ -13,6 +13,7 @@ import io.druid.timeline.partition.NoneShardSpec;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = NumberedShardSpec.class, name = "hashed"),
+        @JsonSubTypes.Type(value = NumberedShardSpec.class, name = "linear"),
         @JsonSubTypes.Type(value = NoneShardSpec.class, name = "none")
 })
 public abstract class ShardSpecMixIn { }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoader.java
@@ -42,8 +42,16 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
     private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
 
     public static final String DATASOURCE_METADATA_QUERY_FORMAT = "/datasources/%s?full";
+
+    /**
+     * The period of the segment metadata loader, in milliseconds.
+     */
     public static final String DRUID_SEG_LOADER_TIMER_DURATION_KEY =
             SYSTEM_CONFIG.getPackageVariableName("druid_seg_loader_timer_duration");
+
+    /**
+     * The initial delay before the first instance of the segment metadata loader, in milliseconds.
+     */
     public static final String DRUID_SEG_LOADER_TIMER_DELAY_KEY =
             SYSTEM_CONFIG.getPackageVariableName("druid_seg_loader_timer_delay");
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMakerSpec.groovy
@@ -1,0 +1,44 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.makers
+
+import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.data.dimension.DimensionField
+import com.yahoo.bard.webservice.data.dimension.KeyValueStore
+import com.yahoo.bard.webservice.data.dimension.SearchProvider
+import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
+import com.yahoo.bard.webservice.data.metric.LogicalMetric
+import com.yahoo.bard.webservice.data.metric.MetricDictionary
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
+import com.yahoo.bard.webservice.data.metric.mappers.NoOpResultSetMapper
+import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
+import com.yahoo.bard.webservice.druid.model.aggregation.FilteredAggregation
+import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
+import com.yahoo.bard.webservice.druid.model.filter.Filter
+import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter
+import spock.lang.Specification
+
+public class FilteredAggregationMakerSpec extends Specification{
+
+    private static final String DEPENDENT_METRIC_NAME = "totalPageViews"
+    private static final String FILT_METRIC_NAME = "filteredPageViews"
+
+    def "A filtered aggregation logical metric is made correctly"(){
+
+        given: "The name of the metric the maker depends on, and the maker itself"
+
+        Aggregation sumAggregation = new LongSumAggregation("tmp_metric", DEPENDENT_METRIC_NAME)
+        Dimension dim = new KeyValueStoreDimension("d", "des", new LinkedHashSet<DimensionField>(), Mock(KeyValueStore), Mock(SearchProvider))
+        Filter filter = new SelectorFilter(dim, "1")
+        MetricMaker maker = new FilteredAggregationMaker(new MetricDictionary(), sumAggregation, filter)
+
+        and: "The expected metric"
+
+        Aggregation expectedAgg = new FilteredAggregation(FILT_METRIC_NAME, DEPENDENT_METRIC_NAME, sumAggregation, filter);
+        LogicalMetric expectedMetric = new LogicalMetric(new TemplateDruidQuery([expectedAgg], [] as Set), new NoOpResultSetMapper(), FILT_METRIC_NAME)
+
+        expect:
+        maker.make(FILT_METRIC_NAME, []) == expectedMetric
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexemeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexemeSpec.groovy
@@ -1,0 +1,71 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.lexer
+
+import spock.lang.Specification
+
+public class LexemeSpec extends Specification {
+    def "lexeme should know its length"() {
+        setup:
+        def lexeme = new Lexeme(LexemeType.IDENTIFIER, "foo")
+
+        expect:
+        lexeme.getConsumedLength() == "foo".length()
+    }
+
+    def "lexing a simple input should work"() {
+        setup:
+        def lexemes = Lexeme.lex("3 + 4").collect()
+
+        expect:
+        lexemes == [
+                new Lexeme(LexemeType.NUMBER, "3"),
+                new Lexeme(LexemeType.BINARY_OPERATOR, "+"),
+                new Lexeme(LexemeType.NUMBER, "4"),
+        ]
+    }
+
+    def "lexing an invalid input should fail"() {
+        when:
+        Lexeme.lex("3 ? 4")
+
+        then:
+        LexException ex = thrown()
+        ex.message =~ /Viable option for lexing could not be found.*/
+    }
+
+    def "lexing a more complex input should work"() {
+        setup:
+        def lexemes = Lexeme.lex("3 * 4 + (9/5) - impressions + foo(bar, bat) | a == 'one' && c == \"two\"").collect()
+        expect:
+        lexemes == [
+                new Lexeme(LexemeType.NUMBER, "3"),
+                new Lexeme(LexemeType.BINARY_OPERATOR, "*"),
+                new Lexeme(LexemeType.NUMBER, "4"),
+                new Lexeme(LexemeType.BINARY_OPERATOR, "+"),
+                new Lexeme(LexemeType.L_PAREN, "("),
+                new Lexeme(LexemeType.NUMBER, "9"),
+                new Lexeme(LexemeType.BINARY_OPERATOR, "/"),
+                new Lexeme(LexemeType.NUMBER, "5"),
+                new Lexeme(LexemeType.R_PAREN, ")"),
+                new Lexeme(LexemeType.BINARY_OPERATOR, "-"),
+                new Lexeme(LexemeType.IDENTIFIER, "impressions"),
+                new Lexeme(LexemeType.BINARY_OPERATOR, "+"),
+                new Lexeme(LexemeType.IDENTIFIER, "foo"),
+                new Lexeme(LexemeType.L_PAREN, "("),
+                new Lexeme(LexemeType.IDENTIFIER, "bar"),
+                new Lexeme(LexemeType.COMMA, ","),
+                new Lexeme(LexemeType.IDENTIFIER, "bat"),
+                new Lexeme(LexemeType.R_PAREN, ")"),
+                new Lexeme(LexemeType.PIPE, "|"),
+                new Lexeme(LexemeType.IDENTIFIER, "a"),
+                new Lexeme(LexemeType.FILTER_OPERATOR, "=="),
+                new Lexeme(LexemeType.SINGLE_QUOTED_STRING, "one", 5),
+                new Lexeme(LexemeType.FILTER_OPERATOR, "&&"),
+                new Lexeme(LexemeType.IDENTIFIER, "c"),
+                new Lexeme(LexemeType.FILTER_OPERATOR, "=="),
+                new Lexeme(LexemeType.DOUBLE_QUOTED_STRING, "two", 5),
+        ]
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexemeTypeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/lexer/LexemeTypeSpec.groovy
@@ -1,0 +1,88 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.lexer
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+public class LexemeTypeSpec extends Specification {
+
+    @Unroll
+    def "LexemeTypes should build correct lexemes"(String lexString, LexemeType type) {
+        setup:
+        def lexeme = type.buildLexeme(lexString)
+        expect:
+        lexeme.equals(new Lexeme(type, lexString))
+        lexeme.getConsumedLength() == lexString.length()
+
+        where:
+        lexString | type
+        "+"       | LexemeType.BINARY_OPERATOR
+        "-"       | LexemeType.BINARY_OPERATOR
+        "*"       | LexemeType.BINARY_OPERATOR
+        "/"       | LexemeType.BINARY_OPERATOR
+
+        "&&"      | LexemeType.FILTER_OPERATOR
+        "||"      | LexemeType.FILTER_OPERATOR
+        "=="      | LexemeType.FILTER_OPERATOR
+
+        "|"       | LexemeType.PIPE
+
+        ","       | LexemeType.COMMA
+        "("       | LexemeType.L_PAREN
+        ")"       | LexemeType.R_PAREN
+
+        "3"       | LexemeType.NUMBER
+        "3.14"    | LexemeType.NUMBER
+        ".14"     | LexemeType.NUMBER
+        "0.14"    | LexemeType.NUMBER
+
+        "FOO"     | LexemeType.IDENTIFIER
+        "Foo"     | LexemeType.IDENTIFIER
+    }
+
+    def "Double quoted strings should include quotes in length but not in content"() {
+        setup:
+        def lexeme = LexemeType.DOUBLE_QUOTED_STRING.buildLexeme('"foo"')
+        expect:
+
+        lexeme.getConsumedLength() == 5
+        lexeme.getType() == LexemeType.DOUBLE_QUOTED_STRING
+        lexeme.getToken() == "foo"
+    }
+
+    def "Single quoted strings should include quotes in length but not in content"() {
+        setup:
+        def lexeme = LexemeType.SINGLE_QUOTED_STRING.buildLexeme("'foo'")
+        expect:
+
+        lexeme.getConsumedLength() == 5
+        lexeme.getType() == LexemeType.SINGLE_QUOTED_STRING
+        lexeme.getToken() == "foo"
+    }
+
+    def "Null should be returned for non-matching string"() {
+        setup:
+        def result = LexemeType.BINARY_OPERATOR.buildLexeme("not a binary operator")
+
+        expect:
+        result == null
+    }
+
+    def "Null should be returned for non-matching pattern"() {
+        setup:
+        def result = LexemeType.IDENTIFIER.buildLexeme("+ is not a valid identifier")
+
+        expect:
+        result == null
+    }
+
+    def "Pattern should build lexeme with only matching part of pattern"() {
+        setup:
+        def result = LexemeType.IDENTIFIER.buildLexeme("foo + bar")
+
+        expect:
+        result.equals(new Lexeme(LexemeType.IDENTIFIER, "foo"))
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/AndFilterNodeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/AndFilterNodeSpec.groovy
@@ -1,0 +1,30 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand
+
+import com.yahoo.bard.webservice.druid.model.filter.AndFilter
+import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter
+
+import spock.lang.Specification
+
+public class AndFilterNodeSpec extends Specification {
+
+    def "AndFilterNode should correctly build an AndFilter"() {
+        setup:
+        def left = Mock(SelectorFilter)
+        def right = Mock(SelectorFilter)
+        def leftNode = Mock(FilterNode)
+        def rightNode = Mock(FilterNode)
+
+        // Expected interactions
+        1 * leftNode.buildFilter() >> left
+        1 * rightNode.buildFilter() >> right
+
+        def filter = new AndFilterNode(leftNode, rightNode).buildFilter()
+
+        expect:
+        filter == new AndFilter([left, right])
+    }
+}
+

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/ArithmeticMetricNodeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/ArithmeticMetricNodeSpec.groovy
@@ -1,0 +1,71 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand
+
+import com.yahoo.bard.webservice.data.config.provider.FuzzyQueryMatcher
+import com.yahoo.bard.webservice.data.metric.LogicalMetric
+import com.yahoo.bard.webservice.data.metric.MetricDictionary
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
+import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.ConstantPostAggregation
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+public class ArithmeticMetricNodeSpec extends Specification {
+
+    @Unroll
+    def "All types of arithmetic should be supported"(ArithmeticPostAggregation.ArithmeticPostAggregationFunction func) {
+        setup:
+        def arithNode = new ArithmeticMetricNode(func, new ConstantMetricNode("3"), new ConstantMetricNode("5"))
+        def metric = arithNode.make("result", new MetricDictionary())
+
+        expect:
+        // Checks the names of top level fields, but not inner field names
+        FuzzyQueryMatcher.matches(
+                metric.getTemplateDruidQuery(),
+                new TemplateDruidQuery(
+                        [],
+                        [new ArithmeticPostAggregation("result", func, [new ConstantPostAggregation("three", 3), new ConstantPostAggregation("five", 5)]) ]
+                )
+        )
+
+        where:
+        func << ArithmeticPostAggregation.ArithmeticPostAggregationFunction.values()
+    }
+
+    def "ArithmeticNode should make() inner metrics and add self to dictionary"() {
+        setup:
+        def dict = new MetricDictionary()
+
+        def leftNode = Mock(MetricNode)
+        def rightNode = Mock(MetricNode)
+
+        def leftMetric = Mock(LogicalMetric)
+        leftMetric.getTemplateDruidQuery() >> new TemplateDruidQuery([new LongSumAggregation("left", "left")], [])
+        leftMetric.getName() >> "left"
+
+        def rightMetric = Mock(LogicalMetric)
+        rightMetric.getTemplateDruidQuery() >> new TemplateDruidQuery([new LongSumAggregation("right", "right")], [])
+        rightMetric.getName() >> "right"
+
+        dict.put("left", leftMetric)
+        dict.put("right", rightMetric)
+
+        def arithNode = new ArithmeticMetricNode(ArithmeticPostAggregation.ArithmeticPostAggregationFunction.PLUS, leftNode, rightNode)
+
+        when:
+        def metric = arithNode.make("result", dict)
+
+        then:
+        // The inner nodes should be made
+        1 * leftNode.make(_, dict) >> leftMetric
+        1 * rightNode.make(_, dict) >> rightMetric
+        // The
+        metric.getName() == "result"
+        dict.containsKey("result")
+    }
+}
+

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/ConstantMetricNodeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/ConstantMetricNodeSpec.groovy
@@ -1,0 +1,35 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand
+
+import com.yahoo.bard.webservice.data.metric.LogicalMetric
+import com.yahoo.bard.webservice.data.metric.MetricDictionary
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
+import com.yahoo.bard.webservice.data.metric.mappers.NoOpResultSetMapper
+import com.yahoo.bard.webservice.druid.model.postaggregation.ConstantPostAggregation
+
+import spock.lang.Specification
+
+public class ConstantMetricNodeSpec extends Specification {
+
+    def "ConstantMetricNode should correctly add a constant to metric dictionary"() {
+        setup:
+        def node = new ConstantMetricNode("3.14")
+        def dict = new MetricDictionary()
+        def actual = node.make("pi", dict)
+
+        def expected = new LogicalMetric(
+                new TemplateDruidQuery([], [new ConstantPostAggregation("pi", 3.14)]),
+                new NoOpResultSetMapper(),
+                "pi"
+        )
+
+        expect:
+        node.getValue() == "3.14"
+        actual == expected
+        dict.get("pi") == expected
+        dict.containsKey("pi")
+    }
+}
+

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNodeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNodeSpec.groovy
@@ -3,6 +3,7 @@
 
 package com.yahoo.bard.webservice.data.config.metric.parser.operand
 
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException
 import com.yahoo.bard.webservice.druid.model.filter.Filter
 
 import spock.lang.Specification
@@ -62,7 +63,7 @@ public class FilterNodeSpec extends Specification {
         FilterNode.create(Filter.DefaultFilterType.NOT, left, right)
 
         then:
-        RuntimeException ex = thrown()
-        ex.message =~ /Could not handle filter type .*/
+        ParsingException ex = thrown()
+        ex.message =~ /Could not handle filter type:.*/
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNodeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilterNodeSpec.groovy
@@ -1,0 +1,68 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand
+
+import com.yahoo.bard.webservice.druid.model.filter.Filter
+
+import spock.lang.Specification
+
+public class FilterNodeSpec extends Specification {
+    def "should construct and filter"() {
+        setup:
+        def left = Mock(FilterNode)
+        def right = Mock(FilterNode)
+
+        when:
+        def actual = FilterNode.create(Filter.DefaultFilterType.AND, left, right)
+
+        then:
+        1 * left.getFilterNode() >> left
+        1 * right.getFilterNode() >> right
+
+        actual instanceof AndFilterNode
+    }
+
+    def "should construct or filter"() {
+        setup:
+        def left = Mock(FilterNode)
+        def right = Mock(FilterNode)
+
+        when:
+        def actual = FilterNode.create(Filter.DefaultFilterType.OR, left, right)
+
+        then:
+        1 * left.getFilterNode() >> left
+        1 * right.getFilterNode() >> right
+
+        actual instanceof OrFilterNode
+    }
+
+    def "should construct selector filter"() {
+        setup:
+        def left = Mock(DimensionNode)
+        def right = Mock(ConstantMetricNode)
+
+        when:
+        def actual = FilterNode.create(Filter.DefaultFilterType.SELECTOR, left, right)
+
+        then:
+        1 * left.getDimensionNode() >> left
+        1 * right.getConstantNode() >> right
+
+        actual instanceof SelectorFilterNode
+    }
+
+    def "should throw exception for fields that aren't implemented yet"() {
+        setup:
+        def left = Mock(FilterNode)
+        def right = Mock(DimensionNode)
+
+        when:
+        FilterNode.create(Filter.DefaultFilterType.NOT, left, right)
+
+        then:
+        RuntimeException ex = thrown()
+        ex.message =~ /Could not handle filter type .*/
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilteredAggMetricNodeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/FilteredAggMetricNodeSpec.groovy
@@ -1,0 +1,50 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand
+
+import com.yahoo.bard.webservice.data.config.metric.makers.LongSumMaker
+import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.data.metric.LogicalMetric
+import com.yahoo.bard.webservice.data.metric.MetricDictionary
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
+import com.yahoo.bard.webservice.druid.model.aggregation.FilteredAggregation
+import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
+import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter
+
+import spock.lang.Specification
+
+public class FilteredAggMetricNodeSpec extends Specification {
+
+    def "should correctly construct a filtered aggregate"() {
+        setup:
+        MetricDictionary metricDictionary = new MetricDictionary()
+
+        LogicalMetric metric = new LongSumMaker(metricDictionary).make("impressions", "impressions")
+        def selectedDimension = Mock(Dimension)
+        def expectedFilter = new SelectorFilter(selectedDimension, "3")
+
+        // The filter
+        def filter = Mock(SelectorFilterNode, {
+            getFilterNode() >> it
+            buildFilter() >> expectedFilter
+        })
+
+        def identifier = Mock(IdentifierNode, {
+            getIdentifierNode() >> it
+            getMetricNode() >> it
+            make(_, metricDictionary) >> metric
+        })
+
+        def expectedQuery = new TemplateDruidQuery(
+                [new FilteredAggregation("filteredImpressions", "impressions", new LongSumAggregation("impressions", "impressions"), expectedFilter)],
+                []
+        )
+
+        def filteredAgg = new FilteredAggMetricNode(identifier, filter)
+        def logicalMetric = filteredAgg.make("filteredImpressions", metricDictionary)
+
+        expect:
+        logicalMetric.getTemplateDruidQuery() == expectedQuery
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/FunctionMetricNodeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/FunctionMetricNodeSpec.groovy
@@ -1,0 +1,72 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand
+
+import com.yahoo.bard.webservice.data.config.metric.makers.LongSumMaker
+import com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException
+import com.yahoo.bard.webservice.data.config.provider.FuzzyQueryMatcher
+import com.yahoo.bard.webservice.data.metric.LogicalMetric
+import com.yahoo.bard.webservice.data.metric.MetricDictionary
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
+import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
+
+import spock.lang.Specification
+
+public class FunctionMetricNodeSpec extends Specification {
+    def "FunctionMetricNode should properly construct aggregators"() {
+        setup:
+        def dict = new MetricDictionary()
+        def f = new FunctionMetricNode(new LongSumMaker(dict), [new IdentifierNode("metric", null, dict)])
+        def result = f.make("new_metric", dict)
+
+        expect:
+        dict.containsKey("new_metric")
+        FuzzyQueryMatcher.matches(
+                result.getTemplateDruidQuery(),
+                new TemplateDruidQuery([new LongSumAggregation("new_metric", "metric")], [])
+        )
+    }
+
+    def "Error should be thrown on bad operand"() {
+        setup:
+        def dict = new MetricDictionary()
+        def f = new FunctionMetricNode(new LongSumMaker(dict), [Mock(FilterNode)])
+
+        when:
+        f.make("new_metric", dict)
+
+        then:
+        ParsingException ex = thrown()
+        ex.message =~ /Unexpected node type.*/
+    }
+
+    def "Interactions with operands and maker should be correct"() {
+        setup:
+
+        // mock all the things
+        def maker = Mock(MetricMaker)
+
+        def makerMetric = Mock(LogicalMetric, { getName() >> "new_metric" })
+
+        def op1 = Mock(MetricNode, { getMetricNode() >> it })
+        def met1 = Mock(LogicalMetric, { getName() >> "metric1" })
+
+        def op2 = Mock(MetricNode, { getMetricNode() >> it })
+        def met2 = Mock(LogicalMetric, { getName() >> "metric2" })
+
+        def dict = new MetricDictionary()
+        def f = new FunctionMetricNode(maker, [op1, op2])
+
+        when:
+        def metric = f.make("new_metric", dict)
+
+        then:
+        1 * op1.make(_, _) >> met1
+        1 * op2.make(_, _) >> met2
+        1 * maker.make("new_metric", ["metric1", "metric2"]) >> makerMetric
+
+        metric == makerMetric
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/IdentifierNodeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/IdentifierNodeSpec.groovy
@@ -1,0 +1,44 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand
+
+import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
+import com.yahoo.bard.webservice.data.metric.LogicalMetric
+import com.yahoo.bard.webservice.data.metric.MetricDictionary
+
+import spock.lang.Specification
+
+public class IdentifierNodeSpec extends Specification {
+    def "should be able to get identifier as metric"() {
+        setup:
+        def dict = new MetricDictionary()
+        def expected = Mock(LogicalMetric)
+        dict.put("node", expected)
+        def node = new IdentifierNode("node", Mock(DimensionDictionary), dict)
+
+        when:
+        def actual = node.getMetricNode().make("some metric", dict)
+
+        then:
+        actual == expected
+    }
+
+    def "should be able to get identifier as dimension"() {
+
+        setup:
+        def dict = new DimensionDictionary()
+        def expected = Mock(Dimension)
+        expected.getApiName() >> "node"
+        dict.add(expected)
+        def node = new IdentifierNode("node", dict, Mock(MetricDictionary))
+
+        when:
+        def actual = node.getDimensionNode().getDimension()
+
+        then:
+        actual == expected
+    }
+
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/OrFilterNodeSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/OrFilterNodeSpec.groovy
@@ -1,0 +1,29 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand
+
+import com.yahoo.bard.webservice.druid.model.filter.OrFilter
+import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter
+
+import spock.lang.Specification
+
+public class OrFilterNodeSpec extends Specification {
+
+    def "OrFilterNode should correctly build an OrFilter"() {
+        setup:
+        def left = Mock(SelectorFilter)
+        def right = Mock(SelectorFilter)
+        def leftNode = Mock(FilterNode)
+        def rightNode = Mock(FilterNode)
+
+        // Expected interactions
+        1 * leftNode.buildFilter() >> left
+        1 * rightNode.buildFilter() >> right
+
+        def filter = new OrFilterNode(leftNode, rightNode).buildFilter()
+
+        expect:
+        filter == new OrFilter([left, right])
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/SelectorFilterNodeTest.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operand/SelectorFilterNodeTest.groovy
@@ -1,0 +1,28 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operand
+
+import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter
+
+import spock.lang.Specification
+
+public class SelectorFilterNodeTest extends Specification {
+
+    def "SelectorFilterNode should correctly build an SelectorFilter"() {
+        setup:
+        def dim = Mock(Dimension)
+        def dimNode = Mock(DimensionNode)
+        def constNode = Mock(ConstantMetricNode)
+
+        // Expected interactions
+        1 * dimNode.getDimension() >> dim
+        1 * constNode.getValue() >> "1.0"
+
+        def filter = new SelectorFilterNode(dimNode, constNode).buildFilter()
+
+        expect:
+        filter == new SelectorFilter(dim, "1.0")
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/ArithmeticOperatorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/ArithmeticOperatorSpec.groovy
@@ -1,0 +1,38 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator
+
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+public class ArithmeticOperatorSpec extends Specification {
+
+    @Unroll
+    def "All operations should behave correctly"(String operatorString, Precedence precedence) {
+        setup:
+        ArithmeticOperator operator = ArithmeticOperator.fromString(operatorString)
+        def left = Mock(Operand)
+        def right = Mock(Operand)
+
+        when:
+        operator.build([left, right])
+
+        then:
+        1 * left.getMetricNode()
+        1 * right.getMetricNode()
+        operator.greaterThan(new Sentinel())
+        operator.getPrecedence() == precedence
+        operator.getNumOperands() == 2
+
+        where:
+        operatorString | precedence
+        "+" | Precedence.ADD_SUB
+        "-" | Precedence.ADD_SUB
+        "*" | Precedence.MUL_DIV
+        "/" | Precedence.MUL_DIV
+
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/BinaryFilterOperatorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/BinaryFilterOperatorSpec.groovy
@@ -1,0 +1,54 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator
+
+import com.yahoo.bard.webservice.data.config.metric.parser.ParsingException
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.AndFilterNode
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.OrFilterNode
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.SelectorFilterNode
+
+import spock.lang.Specification
+
+public class BinaryFilterOperatorSpec extends Specification {
+
+    def "Equals should produce a SelectorFilter"() {
+        setup:
+        def operator = BinaryFilterOperator.fromString("==")
+        def filterNode = operator.build([Mock(Operand), Mock(Operand)])
+
+        expect:
+        operator.greaterThan(new Sentinel())
+        filterNode instanceof SelectorFilterNode
+    }
+
+    def "And should produce an AndFilter"() {
+        setup:
+        def operator = BinaryFilterOperator.fromString("&&")
+        def filterNode = operator.build([Mock(Operand), Mock(Operand)])
+
+        expect:
+        operator.greaterThan(new Sentinel())
+        filterNode instanceof AndFilterNode
+    }
+
+    def "Or should produce an OrFilter"() {
+        setup:
+        def operator = BinaryFilterOperator.fromString("||")
+        def filterNode = operator.build([Mock(Operand), Mock(Operand)])
+
+        expect:
+        operator.greaterThan(new Sentinel())
+        filterNode instanceof OrFilterNode
+    }
+
+    def "invalid should throw an exception"() {
+        when:
+        BinaryFilterOperator.fromString("?")
+
+        then:
+        ParsingException ex = thrown()
+        ex.message =~ /.*unsupported.*/
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/FilterOperatorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/FilterOperatorSpec.groovy
@@ -1,0 +1,35 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator
+
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.FilteredAggMetricNode
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.IdentifierNode
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.SelectorFilterNode
+
+import spock.lang.Specification
+
+public class FilterOperatorSpec extends Specification {
+    def "FilterOperator should behave correctly"() {
+        setup:
+        def operator = new FilterOperator();
+
+        def metricNode = Mock(IdentifierNode, {
+            getMetricNode() >> it
+            getIdentifierNode() >> it
+        })
+        def filterNode = Mock(SelectorFilterNode, {
+            getFilterNode() >> it
+        })
+
+        FilteredAggMetricNode builtMetricNode = operator.build([metricNode, filterNode])
+
+        expect:
+        operator.getNumOperands() == 2
+        operator.greaterThan(new Sentinel())
+
+        // .equals() isn't implemented on everything
+        builtMetricNode.left == metricNode
+        builtMetricNode.right == filterNode
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/FunctionOperatorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/FunctionOperatorSpec.groovy
@@ -1,0 +1,26 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator
+
+import com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.FunctionMetricNode
+import com.yahoo.bard.webservice.data.config.metric.parser.operand.Operand
+
+import spock.lang.Specification
+
+public class FunctionOperatorSpec extends Specification {
+    def "FunctionOperator should return a FunctionMetricNode and know its operand count"() {
+        setup:
+        def mockOperands = [Mock(Operand)]
+        def mockMaker = Mock(MetricMaker)
+        def operator = new FunctionOperator(mockMaker, 7)
+        FunctionMetricNode result = operator.build(mockOperands)
+
+        expect:
+        operator.getNumOperands() == 7
+        operator.greaterThan(new Sentinel())
+        result.operands == mockOperands
+        result.maker == mockMaker
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/PrecedenceSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/PrecedenceSpec.groovy
@@ -1,0 +1,15 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator
+
+import spock.lang.Specification
+
+public class PrecedenceSpec extends Specification {
+    def "the greaterThan operator should work"() {
+        expect:
+        !Precedence.SENTINEL.greaterThan(Precedence.SENTINEL)
+        !Precedence.SENTINEL.greaterThan(Precedence.ADD_SUB)
+        Precedence.ADD_SUB.greaterThan(Precedence.SENTINEL)
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/SentinelSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/parser/operator/SentinelSpec.groovy
@@ -1,0 +1,24 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.metric.parser.operator
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+public class SentinelSpec extends Specification {
+
+    // The sole purpose of the sentinel is to have a lower precedence than everything else
+
+    @Unroll
+    def "sentinel must have lowest precedence"(Precedence other) {
+        setup:
+        def sentinel = new Sentinel()
+
+        expect:
+        other.greaterThan(sentinel.getPrecedence())
+
+        where:
+        other << Arrays.stream(Precedence.values()).filter({a -> a != Precedence.SENTINEL})
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/ConfigBinderFactorySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/ConfigBinderFactorySpec.groovy
@@ -1,0 +1,121 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider
+
+import com.yahoo.bard.webservice.config.SystemConfig
+import com.yahoo.bard.webservice.config.SystemConfigProvider
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig
+import com.yahoo.bard.webservice.data.config.provider.yaml.YamlConfigProvider
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
+import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.ConstantPostAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.FieldAccessorPostAggregation
+import spock.lang.Specification
+
+public class ConfigBinderFactorySpec extends Specification {
+    private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
+    private static final String CONF_TYPE = SYSTEM_CONFIG.getPackageVariableName("config_binder_type");
+
+    public static class StubProvider implements ConfigProvider {
+        @Override
+        ConfigurationDictionary<PhysicalTableConfiguration> getPhysicalTableConfig() {
+            return new ConfigurationDictionary<PhysicalTableConfiguration>()
+        }
+
+        @Override
+        ConfigurationDictionary<LogicalTableConfiguration> getLogicalTableConfig() {
+            return new ConfigurationDictionary<LogicalTableConfiguration>()
+        }
+
+        @Override
+        ConfigurationDictionary<MakerConfiguration> getCustomMakerConfig() {
+            return new ConfigurationDictionary<MakerConfiguration>()
+        }
+
+        @Override
+        ConfigurationDictionary<DimensionConfig> getDimensionConfig() {
+            return new ConfigurationDictionary<DimensionConfig>()
+        }
+
+        @Override
+        ConfigurationDictionary<MetricConfiguration> getBaseMetrics() {
+            return new ConfigurationDictionary<MetricConfiguration>()
+        }
+
+        @Override
+        ConfigurationDictionary<MetricConfiguration> getDerivedMetrics() {
+            return new ConfigurationDictionary<MetricConfiguration>()
+        }
+
+        /**
+         *
+         * @return
+         */
+        public static ConfigProvider build(SystemConfig systemConfig) {
+            return new StubProvider();
+        }
+    }
+
+    def "test that class can be instantiated"() {
+
+        setup:
+        SYSTEM_CONFIG.setProperty(CONF_TYPE, StubProvider.class.getName())
+        // This should instantiate the above stub class
+        def factory = new ConfigBinderFactory()
+        def loader = factory.buildConfigurationLoader()
+        loader.load()
+
+        expect:
+        factory.provider instanceof StubProvider
+    }
+
+    def "Exception should be thrown when no class exists"() {
+
+        setup:
+        SYSTEM_CONFIG.setProperty(CONF_TYPE, "this.is.not.a.class")
+        // This should instantiate the above stub class
+        when:
+        new ConfigBinderFactory()
+
+        then:
+        RuntimeException ex = thrown()
+        ex.message =~ /.*Unable to construct config provider.*/
+        ex.cause instanceof ClassNotFoundException
+    }
+
+    def "We should be able to load a YAML configuration"() {
+
+        setup:
+        SYSTEM_CONFIG.setProperty(CONF_TYPE, YamlConfigProvider.class.getName())
+        String path = ConfigBinderFactory.class.getResource("/yaml/exampleConfiguration.yaml").getPath()
+        SYSTEM_CONFIG.setProperty(SYSTEM_CONFIG.getPackageVariableName(YamlConfigProvider.CONF_YAML_PATH), path)
+        when:
+        ConfigBinderFactory factory = new ConfigBinderFactory()
+        def loader = factory.buildConfigurationLoader()
+        loader.load()
+
+        def expectedAgg = new LongSumAggregation("impressions", "impressions")
+
+        then:
+
+        loader.metricDictionary.containsKey("impressions")
+        def q = loader.metricDictionary.get("incremented_impressions").getTemplateDruidQuery()
+
+        FuzzyQueryMatcher.matches(
+                loader.metricDictionary.get("impressions").getTemplateDruidQuery(),
+                new TemplateDruidQuery([expectedAgg], [])
+        );
+
+        FuzzyQueryMatcher.matches(q,
+                new TemplateDruidQuery(
+                        [expectedAgg],
+                        [new ArithmeticPostAggregation(
+                                "incremented_impressions",
+                                ArithmeticPostAggregation.ArithmeticPostAggregationFunction.PLUS,
+                                [new FieldAccessorPostAggregation(expectedAgg), new ConstantPostAggregation("some_name", 1.0)]
+                        )]));
+    }
+
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/ConfigBinderFactorySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/ConfigBinderFactorySpec.groovy
@@ -80,7 +80,7 @@ public class ConfigBinderFactorySpec extends Specification {
         new ConfigBinderFactory()
 
         then:
-        RuntimeException ex = thrown()
+        ConfigurationError ex = thrown()
         ex.message =~ /.*Unable to construct config provider.*/
         ex.cause instanceof ClassNotFoundException
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/FuzzyQueryMatcher.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/FuzzyQueryMatcher.groovy
@@ -1,0 +1,135 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider
+
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
+import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.ConstantPostAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.FieldAccessorPostAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation
+
+/**
+ * Utility class to validate that TemplateDruidQueries have the same structure and values.
+ *
+ * It's ok if inner objects don't always have the same names.
+ */
+public class FuzzyQueryMatcher {
+
+    /**
+     * Throws a hopefully-helpful exception if the two queries do not look alike.
+     *
+     * @param actual the actual output
+     * @param fuzzy the expected query
+     */
+    public static void matches(TemplateDruidQuery actual, TemplateDruidQuery expected) {
+        Map<String, Aggregation> expectedAggs = expected.aggregations.collectEntries { [(it.getName()): it] }
+
+        // The number of aggregations should match
+        if (actual.aggregations.size() != expectedAggs.size()) {
+            throw new RuntimeException("Different agg sizes: expected" + expected.aggregations + "; actual: " + actual.aggregations);
+        }
+
+        // Validate that the actual aggregations match
+        for (Aggregation actualAggregation : actual.aggregations) {
+            if (!expectedAggs.containsKey(actualAggregation.getName())) {
+                throw new RuntimeException("Expected to find " + actualAggregation.getName() + "but did not find in expected query");
+            }
+
+            validateAggregation(actualAggregation, expectedAggs.get(actualAggregation.getName()));
+        }
+
+        Map<String, PostAggregation> expectedPostAggs = expected.postAggregations.collectEntries { [(it.getName()): it] }
+
+        // The number of postAggs should match
+        if (actual.postAggregations.size() != expectedPostAggs.size()) {
+            throw new RuntimeException("Different postAgg sizes: expected" + expected.postAggregations + "; actual: " + actual.postAggregations);
+        }
+
+        for (PostAggregation actualPostAgg : actual.postAggregations) {
+            if (!expectedPostAggs.containsKey(actualPostAgg.getName())) {
+                throw new RuntimeException("Expected to find " + actualPostAgg.getName() + "but did not find in fuzzy query");
+            }
+
+            validatePostAgg(actualPostAgg, expectedPostAggs.get(actualPostAgg.getName()));
+        }
+    }
+
+    /**
+     * Validate that two aggregations are equal
+     * @param actual
+     * @param expected
+     */
+    public static void validateAggregation(Aggregation actual, Aggregation expected) {
+        if (!(actual.equals(expected))) {
+            throw new RuntimeException("Unequal aggregations: expected " + expected + "; actual: " + actual);
+        }
+    }
+
+
+    /**
+     * Validate that two post aggregations are equal
+     * @param actual
+     * @param expected
+     */
+    public static void validatePostAgg(PostAggregation actual, PostAggregation expected) {
+
+        if (actual.getClass() != expected.getClass()) {
+            throw new RuntimeException("Expected to find class " + expected.getClass() + "but found " + expected.getClass());
+        }
+
+        if (actual instanceof ArithmeticPostAggregation) {
+            // Throws exception if don't match
+            validateArithmetic((ArithmeticPostAggregation) actual, (ArithmeticPostAggregation) expected);
+        } else if (actual instanceof ConstantPostAggregation) {
+            validateConstant((ConstantPostAggregation) actual, (ConstantPostAggregation) expected);
+        } else if (actual instanceof FieldAccessorPostAggregation) {
+            validateFieldAccessor((FieldAccessorPostAggregation) actual,(FieldAccessorPostAggregation) expected);
+        }
+
+    }
+
+    /**
+     * Validate that two field accessors are equal
+     * @param actual
+     * @param expected
+     */
+    public static void validateFieldAccessor(FieldAccessorPostAggregation actual, FieldAccessorPostAggregation expected) {
+        if (actual.getFieldName() != expected.getFieldName()) {
+            throw new RuntimeException("FieldAccessor field names did not match. Expected: " + expected + "; actual: " + actual);
+        }
+
+        validateAggregation(actual.aggregation, expected.aggregation);
+    }
+
+    /**
+     * Validate that constants are equal
+     * @param actual
+     * @param expected
+     */
+    public static void validateConstant(ConstantPostAggregation actual, ConstantPostAggregation expected) {
+        if (actual.value != expected.value) {
+            throw new RuntimeException("Expected constant=$expected with value=${expected.getValue()}; actual=$actual with value=${actual.getValue()}");
+        }
+    }
+
+    /**
+     * Validate that arithmetic aggregations are equal
+     * @param actual
+     * @param expected
+     */
+    public static void validateArithmetic(ArithmeticPostAggregation actual, ArithmeticPostAggregation expected) {
+        if (actual.getFn() != expected.getFn()) {
+            throw new RuntimeException("Functions do not match; found " + actual.getFn() + "; expected: " + expected.getFn());
+        }
+
+        if (!(actual.fields.size() == expected.fields.size())) {
+            throw new RuntimeException("Fields do not match in size; found " + actual + "; expected: " + expected);
+        }
+
+        for (int i = 0; i < actual.fields.size(); i++) {
+            validatePostAgg(actual.fields.get(i), expected.fields.get(i));
+        }
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/FuzzyQueryMatcherSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/FuzzyQueryMatcherSpec.groovy
@@ -1,0 +1,77 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider
+
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
+import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.ConstantPostAggregation
+import com.yahoo.bard.webservice.druid.model.postaggregation.FieldAccessorPostAggregation
+
+import static com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation.ArithmeticPostAggregationFunction.PLUS
+import spock.lang.Specification
+
+public class FuzzyQueryMatcherSpec extends Specification {
+    def "identical empty TemplateDruidQueries should match"() {
+        def actual = new TemplateDruidQuery(
+                [],
+                []
+        )
+        expect:
+        FuzzyQueryMatcher.matches(actual, actual)
+    }
+
+    def "identical non-empty TemplateDruidQueries should match"() {
+        def agg1 = new LongSumAggregation("longsum1", "field1")
+        def actual = new TemplateDruidQuery(
+                [agg1, new LongSumAggregation("longsum2", "field2")],
+                [new ConstantPostAggregation("constant1", 3.5), new FieldAccessorPostAggregation(agg1)]
+        )
+        expect:
+        FuzzyQueryMatcher.matches(actual, actual)
+    }
+
+    def "not-quite identical TemplateDruidQueries should match"() {
+        def agg1 = new LongSumAggregation("longsum1", "field1")
+        def actual = new TemplateDruidQuery(
+                [agg1],
+                [new ConstantPostAggregation("constant1", 3.5),
+                 new ArithmeticPostAggregation("some-arithmetic", PLUS, [new ConstantPostAggregation("35", 3.5), new ConstantPostAggregation("45", 4.5)])
+                ]
+        )
+        def expected = new TemplateDruidQuery(
+                [agg1],
+                [new ConstantPostAggregation("constant1", 3.5),
+                 new ArithmeticPostAggregation("some-arithmetic", PLUS, [new ConstantPostAggregation("35_2", 3.5), new ConstantPostAggregation("45_2", 4.5)])
+                ]
+        )
+        expect:
+        FuzzyQueryMatcher.matches(actual, expected)
+    }
+
+    def "no match if values differ"() {
+        def agg1 = new LongSumAggregation("longsum1", "field1")
+        def actual = new TemplateDruidQuery(
+                [agg1],
+                [new ConstantPostAggregation("constant1", 3.5),
+                 new ArithmeticPostAggregation("some-arithmetic", PLUS, [new ConstantPostAggregation("35", 3.5), new ConstantPostAggregation("45", 4.5)])
+                ]
+        )
+
+        def expected = new TemplateDruidQuery(
+                [agg1],
+                [new ConstantPostAggregation("constant1", 3.5),
+                 new ArithmeticPostAggregation("some-arithmetic", PLUS, [new ConstantPostAggregation("35_2", 3.3), new ConstantPostAggregation("45_2", 4.5)])
+                ]
+        )
+
+
+        when:
+        FuzzyQueryMatcher.matches(actual, expected)
+
+        then:
+        RuntimeException ex = thrown()
+        ex.message =~ /Expected.*3\.3.*actual.*3\.5/
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/MakerConfigurationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/MakerConfigurationSpec.groovy
@@ -1,0 +1,31 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider
+
+import com.yahoo.bard.webservice.data.config.metric.makers.ConstantMaker
+import spock.lang.Specification
+
+public class MakerConfigurationSpec extends Specification {
+
+    static class MakerConfigurationImpl implements MakerConfiguration {
+        @Override
+        String getClassName() {
+            return ConstantMaker.class.name
+        }
+
+        @Override
+        Object[] getArguments() {
+            return new Object[0]
+        }
+    }
+
+    def "MakerConfiguration can construct a new class"() {
+        setup:
+        def conf = new MakerConfigurationImpl()
+
+        expect:
+        conf.getMakerClass() == ConstantMaker.class
+    }
+
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/MakerDictionarySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/MakerDictionarySpec.groovy
@@ -1,0 +1,40 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider
+
+import com.yahoo.bard.webservice.data.config.metric.makers.ThetaSketchMaker
+import com.yahoo.bard.webservice.data.metric.MetricDictionary
+import spock.lang.Specification
+
+public class MakerDictionarySpec extends Specification {
+    def "should construct default makers without error"(){
+        setup:
+        MakerDictionary dictionary = MakerDictionary.getDefaultMakers(new MetricDictionary())
+
+        expect:
+        dictionary.containsKey("longSum")
+    }
+
+    def "Should construct configured makers correctly"(){
+        setup:
+         def maker = MakerDictionary.buildCustomMaker("thetaMaker", ThetaSketchMaker.getName(), [1] as Object[], new MetricDictionary())
+
+        expect:
+        maker instanceof ThetaSketchMaker
+    }
+
+    def "Should construct configured makers correctly and include defaults"(){
+        setup:
+        def makerDict = new MakerDictionary()
+        MakerDictionary.loadMetricMakers(new MetricDictionary(), makerDict, ["thetaMaker": new MakerConfiguration() {
+            String getClassName() { return ThetaSketchMaker.getName(); }
+            Object[] getArguments() { return [1] as Object[]; }
+        } ])
+
+        expect:
+        makerDict.containsKey("longSum")
+        makerDict.containsKey("thetaMaker")
+    }
+
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlConfigProviderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlConfigProviderSpec.groovy
@@ -7,11 +7,12 @@ import com.yahoo.bard.webservice.config.SystemConfig
 import com.yahoo.bard.webservice.config.SystemConfigException
 import com.yahoo.bard.webservice.config.SystemConfigProvider
 import com.yahoo.bard.webservice.data.config.metric.makers.ThetaSketchSetOperationMaker
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationError
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationPostAggFunction
 import spock.lang.Specification
 
-public class YamlConfigSpec extends Specification {
+public class YamlConfigProviderSpec extends Specification {
     static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance()
 
 
@@ -30,13 +31,13 @@ public class YamlConfigSpec extends Specification {
         when:
         YamlConfigProvider.build(SYSTEM_CONFIG)
         then:
-        RuntimeException ex = thrown()
+        ConfigurationError ex = thrown()
         ex.message =~ /Could not read path.*/
     }
 
     def "Test loading of config file"() {
         setup:
-        String path = YamlConfigSpec.class.getResource("/yaml/exampleConfiguration.yaml").getPath()
+        String path = YamlConfigProviderSpec.class.getResource("/yaml/exampleConfiguration.yaml").getPath()
         SYSTEM_CONFIG.setProperty(SYSTEM_CONFIG.getPackageVariableName(YamlConfigProvider.CONF_YAML_PATH), path)
 
         when:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlConfigSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlConfigSpec.groovy
@@ -1,0 +1,72 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml
+
+import com.yahoo.bard.webservice.config.SystemConfig
+import com.yahoo.bard.webservice.config.SystemConfigException
+import com.yahoo.bard.webservice.config.SystemConfigProvider
+import com.yahoo.bard.webservice.data.config.metric.makers.ThetaSketchSetOperationMaker
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
+import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationPostAggFunction
+import spock.lang.Specification
+
+public class YamlConfigSpec extends Specification {
+    static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance()
+
+
+    def "test missing setting"() {
+        setup:
+        SYSTEM_CONFIG.resetProperty(SYSTEM_CONFIG.getPackageVariableName(YamlConfigProvider.CONF_YAML_PATH), null)
+        when:
+        YamlConfigProvider.build(SYSTEM_CONFIG)
+        then:
+        SystemConfigException ex = thrown()
+    }
+
+    def "test setting that doesn't point to file"() {
+        setup:
+        SYSTEM_CONFIG.setProperty(SYSTEM_CONFIG.getPackageVariableName(YamlConfigProvider.CONF_YAML_PATH), "/hopefully/not/a/file")
+        when:
+        YamlConfigProvider.build(SYSTEM_CONFIG)
+        then:
+        RuntimeException ex = thrown()
+        ex.message =~ /Could not read path.*/
+    }
+
+    def "Test loading of config file"() {
+        setup:
+        String path = YamlConfigSpec.class.getResource("/yaml/exampleConfiguration.yaml").getPath()
+        SYSTEM_CONFIG.setProperty(SYSTEM_CONFIG.getPackageVariableName(YamlConfigProvider.CONF_YAML_PATH), path)
+
+        when:
+        def conf = YamlConfigProvider.build(SYSTEM_CONFIG)
+
+        then:
+        // Metric configs should exist
+        conf.getBaseMetrics().containsKey("impressions")
+        conf.getDerivedMetrics().containsKey("incremented_impressions")
+
+        // Dimension configs should exist with correct fields
+        conf.getDimensionConfig().get("tld").getDefaultDimensionFields().collect({a -> a.getName()}) == ["id"]
+        conf.getDimensionConfig().get("tld").getFields().collect({a -> a.getName()}) == ["id", "description"]
+        conf.getDimensionConfig().get("platform").getDefaultDimensionFields().collect({a -> a.getName()}) == ["id"]
+        conf.getDimensionConfig().get("platform").getFields().collect({a -> a.getName()}) == ["id"]
+
+        // physical table configs should exist
+        conf.getPhysicalTableConfig().size() == 2
+        conf.getPhysicalTableConfig().get("physical_table_1").getMetrics().collect({a -> a.asName()}) == ["impressions"]
+        conf.getPhysicalTableConfig().get("physical_table_2").getMetrics().collect({a -> a.asName()}) == ["impressions"]
+
+        // logical table configs should exist
+        conf.getLogicalTableConfig().size() == 1
+        conf.getLogicalTableConfig().get("logical_table_1").getMetrics() == ["impressions", "incremented_impressions"] as Set
+        conf.getLogicalTableConfig().get("logical_table_1").getPhysicalTables() == ["physical_table_1", "physical_table_2"] as Set
+        conf.getLogicalTableConfig().get("logical_table_1").getTimeGrains() == [DefaultTimeGrain.DAY, DefaultTimeGrain.HOUR, DefaultTimeGrain.MINUTE] as Set
+
+        // custom maker configs should exist
+        conf.getCustomMakerConfig().get("sketch").getMakerClass() == ThetaSketchSetOperationMaker.class
+        conf.getCustomMakerConfig().get("sketch").getArguments()[0] == SketchSetOperationPostAggFunction.NOT
+
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionConfigSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionConfigSpec.groovy
@@ -3,6 +3,8 @@
 
 package com.yahoo.bard.webservice.data.config.provider.yaml
 
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationError
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import spock.lang.Specification
@@ -36,7 +38,7 @@ public class YamlDimensionConfigSpec extends Specification {
 
     def "Setting the API name should set missing fields"() {
         setup:
-        def dim =  new YamlDimensionConfig(null, null, null, null, null, null, null, null, true)
+        def dim =  new YamlDimensionConfig(null, null, null, null, null, null, true)
         dim.setApiName("the_api_name")
 
         expect:
@@ -48,26 +50,26 @@ public class YamlDimensionConfigSpec extends Specification {
 
     def "Duplicate fields should throw an error"() {
         when:
-        new YamlDimensionConfig(null, null, null, null, ["f1", "f2", "f2"] as String[], null, null, null, true)
+        new YamlDimensionConfig(null, null, null, null, ["f1", "f2", "f2"] as String[], null, true)
 
         then:
-        RuntimeException ex = thrown()
+        ConfigurationError ex = thrown()
         ex.message ==~ /.*unique list of dimension fields.*/
     }
 
     def "Duplicate default fields should throw an error"() {
         when:
-        new YamlDimensionConfig(null, null, null, null, null, ["f1", "f2", "f2"] as String[], null, null, true)
+        new YamlDimensionConfig(null, null, null, null, null, ["f1", "f2", "f2"] as String[], true)
 
         then:
-        RuntimeException ex = thrown()
+        ConfigurationError ex = thrown()
         ex.message ==~ /.*unique list of default dimension fields.*/
     }
 
     def "Dimension fields works correctly"() {
         setup:
 
-        def dim =  new YamlDimensionConfig(null, null, null, null, ["f1", "f2"] as String[], ["f1"] as String[], null, null, true)
+        def dim =  new YamlDimensionConfig(null, null, null, null, ["f1", "f2"] as String[], ["f1"] as String[], true)
 
         // Normally called by deserializer
         def availableFields = ["f1": Mock(YamlDimensionFieldConfig), "f2": Mock(YamlDimensionFieldConfig)]
@@ -82,7 +84,7 @@ public class YamlDimensionConfigSpec extends Specification {
 
     def "Dimension fields works correctly to set defaults"() {
         setup:
-        def dim =  new YamlDimensionConfig(null, null, null, null, null, null, null, null, true)
+        def dim =  new YamlDimensionConfig(null, null, null, null, null, null, true)
 
         // Normally called by deserializer
         def availableFields = ["f1": Mock(YamlDimensionFieldConfig), "f2": Mock(YamlDimensionFieldConfig), "f3": Mock(YamlDimensionFieldConfig)]

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionConfigSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionConfigSpec.groovy
@@ -1,0 +1,100 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import spock.lang.Specification
+
+public class YamlDimensionConfigSpec extends Specification {
+
+    static ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+    def "Can deserialize from yaml correctly"() {
+        setup:
+        String conf = """
+                     |physical_name: physicalName
+                     |long_name: Longer Name
+                     |category: some_category
+                     |description: some description
+                     |fields: [f1, f2]
+                     |default_fields: [f1]
+                     |aggregatable: false
+                     |""".stripMargin()
+        def dim = mapper.readValue(conf, YamlDimensionConfig.class)
+
+        expect:
+        dim.isAggregatable() == false
+        dim.getPhysicalName() == "physicalName"
+        dim.getLongName() == "Longer Name"
+        dim.getCategory() == "some_category"
+        dim.getDescription() == "some description"
+        dim.dimensionFieldNames == ["f1", "f2"]
+        dim.defaultDimensionFieldNames == ["f1"]
+    }
+
+    def "Setting the API name should set missing fields"() {
+        setup:
+        def dim =  new YamlDimensionConfig(null, null, null, null, null, null, null, null, true)
+        dim.setApiName("the_api_name")
+
+        expect:
+        dim.getPhysicalName() == "the_api_name"
+        dim.getApiName() == "the_api_name"
+        dim.getLongName() == "the_api_name"
+        dim.getDescription() == "the_api_name"
+    }
+
+    def "Duplicate fields should throw an error"() {
+        when:
+        new YamlDimensionConfig(null, null, null, null, ["f1", "f2", "f2"] as String[], null, null, null, true)
+
+        then:
+        RuntimeException ex = thrown()
+        ex.message ==~ /.*unique list of dimension fields.*/
+    }
+
+    def "Duplicate default fields should throw an error"() {
+        when:
+        new YamlDimensionConfig(null, null, null, null, null, ["f1", "f2", "f2"] as String[], null, null, true)
+
+        then:
+        RuntimeException ex = thrown()
+        ex.message ==~ /.*unique list of default dimension fields.*/
+    }
+
+    def "Dimension fields works correctly"() {
+        setup:
+
+        def dim =  new YamlDimensionConfig(null, null, null, null, ["f1", "f2"] as String[], ["f1"] as String[], null, null, true)
+
+        // Normally called by deserializer
+        def availableFields = ["f1": Mock(YamlDimensionFieldConfig), "f2": Mock(YamlDimensionFieldConfig)]
+        dim.setAvailableDimensionFields(availableFields)
+
+        expect:
+        dim.getDefaultDimensionFields().size() == 1
+        dim.getDefaultDimensionFields().contains(availableFields.f1)
+        dim.getFields().size() == 2
+        dim.getFields().containsAll(availableFields.values())
+    }
+
+    def "Dimension fields works correctly to set defaults"() {
+        setup:
+        def dim =  new YamlDimensionConfig(null, null, null, null, null, null, null, null, true)
+
+        // Normally called by deserializer
+        def availableFields = ["f1": Mock(YamlDimensionFieldConfig), "f2": Mock(YamlDimensionFieldConfig), "f3": Mock(YamlDimensionFieldConfig)]
+        availableFields.f1.includedByDefault() >> true
+        availableFields.f2.includedByDefault() >> false
+        availableFields.f3.includedByDefault() >> true
+        dim.setAvailableDimensionFields(availableFields)
+
+        expect:
+        dim.getDefaultDimensionFields().size() == 2
+        dim.getDefaultDimensionFields().containsAll(availableFields.f1, availableFields.f3)
+        dim.getFields().size() == 3
+        dim.getFields().containsAll(availableFields.values())
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionFieldConfigSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlDimensionFieldConfigSpec.groovy
@@ -1,0 +1,20 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml
+
+import spock.lang.Specification
+
+public class YamlDimensionFieldConfigSpec extends Specification {
+
+    def "Defaults set correctly by name"() {
+        setup:
+        def dim =  new YamlDimensionFieldConfig(null, false);
+        dim.setName("some name")
+
+        expect:
+        dim.includedByDefault() == false
+        dim.getDescription() == "some name"
+        dim.getName() == "some name"
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlPhysicalTableConfigSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlPhysicalTableConfigSpec.groovy
@@ -1,0 +1,47 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml
+
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationDictionary
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
+import spock.lang.Specification
+
+public class YamlPhysicalTableConfigSpec extends Specification {
+
+    def "Basic constructor works"() {
+        setup:
+        def t =  new YamlPhysicalTableConfig(DefaultTimeGrain.HOUR, ["dim1"] as String[], ["m1"] as String[])
+        t.setTableName("table")
+
+        expect:
+        t.getMetrics().collect({a -> a.asName()}) == ["m1"]
+        // not checking result, but shouldn't fail
+        t.buildPhysicalTable(new ConfigurationDictionary<DimensionConfig>())
+    }
+
+    def "TimeGrain required"() {
+        when:
+        new YamlPhysicalTableConfig(null, ["dim1"] as String[], ["m1"] as String[])
+        then:
+        RuntimeException ex = thrown()
+        ex.message =~ /ZonelessTimeGrain required.*/
+    }
+
+    def "Dimensions required"() {
+        when:
+        new YamlPhysicalTableConfig(DefaultTimeGrain.HOUR, null, ["m1"] as String[])
+        then:
+        RuntimeException ex = thrown()
+        ex.message =~ /.*with dimensions.*/
+    }
+
+    def "Metrics required"() {
+        when:
+        new YamlPhysicalTableConfig(DefaultTimeGrain.HOUR, ["dim1"] as String[], null)
+        then:
+        RuntimeException ex = thrown()
+        ex.message =~ /.*with metrics.*/
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlPhysicalTableConfigSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/YamlPhysicalTableConfigSpec.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.data.config.provider.yaml
 
 import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig
 import com.yahoo.bard.webservice.data.config.provider.ConfigurationDictionary
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationError
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import spock.lang.Specification
 
@@ -25,7 +26,7 @@ public class YamlPhysicalTableConfigSpec extends Specification {
         when:
         new YamlPhysicalTableConfig(null, ["dim1"] as String[], ["m1"] as String[])
         then:
-        RuntimeException ex = thrown()
+        ConfigurationError ex = thrown()
         ex.message =~ /ZonelessTimeGrain required.*/
     }
 
@@ -33,7 +34,7 @@ public class YamlPhysicalTableConfigSpec extends Specification {
         when:
         new YamlPhysicalTableConfig(DefaultTimeGrain.HOUR, null, ["m1"] as String[])
         then:
-        RuntimeException ex = thrown()
+        ConfigurationError ex = thrown()
         ex.message =~ /.*with dimensions.*/
     }
 
@@ -41,7 +42,7 @@ public class YamlPhysicalTableConfigSpec extends Specification {
         when:
         new YamlPhysicalTableConfig(DefaultTimeGrain.HOUR, ["dim1"] as String[], null)
         then:
-        RuntimeException ex = thrown()
+        ConfigurationError ex = thrown()
         ex.message =~ /.*with metrics.*/
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/GranularityDeserializerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/GranularityDeserializerSpec.groovy
@@ -1,0 +1,47 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
+import com.yahoo.bard.webservice.druid.model.query.AllGranularity
+import com.yahoo.bard.webservice.druid.model.query.Granularity
+import spock.lang.Specification
+import spock.lang.Unroll
+
+public class GranularityDeserializerSpec extends Specification {
+
+    def "Invalid granularity should throw exception"() {
+        setup:
+        ObjectMapper mapper = DeserializationHelper.getMapper(Granularity, new GranularityDeserializer())
+        when:
+        mapper.readValue('"something bad"', Granularity)
+        then:
+
+        JsonParseException ex = thrown()
+        ex.message =~ /Unable to parse granularity.*something bad.*/
+    }
+
+    def "Deserializing all granularity should return the correct value"() {
+        setup:
+        ObjectMapper mapper = DeserializationHelper.getMapper(Granularity, new GranularityDeserializer())
+        def gran = mapper.readValue('"all"', Granularity)
+        expect:
+        gran == AllGranularity.INSTANCE
+    }
+
+    @Unroll
+    def "Deserializing default granularities should work"(Granularity expected, String name) {
+        setup:
+        ObjectMapper mapper = DeserializationHelper.getMapper(Granularity, new GranularityDeserializer())
+        def gran = mapper.readValue("\"${name}\"", Granularity)
+
+        expect:
+        gran == expected
+
+        where:
+        [expected, name] << Arrays.stream(DefaultTimeGrain.values()).map( { a -> [a, a.toString()]})
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlArgDeserializerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlArgDeserializerSpec.groovy
@@ -1,0 +1,56 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationPostAggFunction
+import spock.lang.Specification
+
+public class YamlArgDeserializerSpec extends Specification {
+
+    public static class ArgTest {
+        @JsonDeserialize(using = YamlArgDeserializer.class)
+        public Object[] args;
+    }
+
+    def "Parsing basic arguments should work correctly"() {
+        setup:
+        ObjectMapper mapper = new ObjectMapper();
+        def resp = mapper.readValue('{"args": [1, 2, 3]}', ArgTest.class)
+
+        expect:
+        Arrays.equals(resp.args, [1,2,3] as Object[])
+    }
+
+    def "Parsing complex arguments should work correctly"() {
+        setup:
+        ObjectMapper mapper = new ObjectMapper();
+        def resp = mapper.readValue('{"args": [1, "foo", 3]}', ArgTest.class)
+
+        expect:
+        Arrays.equals(resp.args, [1,"foo",3] as Object[])
+    }
+
+    def "Parsing arguments that instantiate classes should work correctly"() {
+        setup:
+        ObjectMapper mapper = new ObjectMapper();
+        def resp = mapper.readValue('{"args": [1, "!!com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationPostAggFunction \'NOT\'", 3]}', ArgTest.class)
+
+        expect:
+        Arrays.equals(resp.args, [1, SketchSetOperationPostAggFunction.NOT, 3] as Object[])
+    }
+
+    def "Exception should be thrown on failure"() {
+        setup:
+        ObjectMapper mapper = new ObjectMapper();
+        when:
+        mapper.readValue('{"args": [1, "!!no.class.here", 3]}', ArgTest.class)
+
+        then:
+        JsonMappingException ex = thrown()
+        ex.message =~ /Can't construct a java object.*no.class.here/
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlDimensionConfigDeserializerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlDimensionConfigDeserializerSpec.groovy
@@ -1,0 +1,21 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde
+
+import spock.lang.Specification
+
+import static com.yahoo.bard.webservice.data.config.provider.yaml.serde.DeserializationHelper.deserialize
+
+
+public class YamlDimensionConfigDeserializerSpec extends Specification {
+
+    def "Parsing should populate api name"() {
+        setup:
+        def result = deserialize('{"dim1": {"description": "some_desc"}}', new YamlDimensionConfigDeserializer())
+        expect:
+        result.size() == 1
+        result.containsKey("dim1")
+        result.get("dim1").getApiName() == "dim1"
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlDimensionFieldConfigDeserializerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlDimensionFieldConfigDeserializerSpec.groovy
@@ -1,0 +1,19 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde
+
+import spock.lang.Specification
+
+import static com.yahoo.bard.webservice.data.config.provider.yaml.serde.DeserializationHelper.deserialize
+
+public class YamlDimensionFieldConfigDeserializerSpec extends Specification {
+    def "Parsing should populate name"() {
+        setup:
+        def result = deserialize('{"field1": {"description": "some_desc"}}', new YamlDimensionFieldConfigDeserializer())
+        expect:
+        result.size() == 1
+        result.containsKey("field1")
+        result.get("field1").getName() == "field1"
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlPhysicalTableConfigDeserializerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/provider/yaml/serde/YamlPhysicalTableConfigDeserializerSpec.groovy
@@ -1,0 +1,27 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde
+
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig
+import com.yahoo.bard.webservice.data.config.provider.ConfigurationDictionary
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain
+import org.joda.time.DateTimeZone
+import spock.lang.Specification
+
+import static com.yahoo.bard.webservice.data.config.provider.yaml.serde.DeserializationHelper.deserialize
+
+public class YamlPhysicalTableConfigDeserializerSpec extends Specification {
+
+    def "Parsing should populate table name"() {
+        setup:
+        def result = deserialize('{"table1": {"dimensions": ["dim1"], "metrics": ["m1"], "granularity": "MINUTE"}}', new YamlPhysicalTableConfigDeserializer())
+        def physicalTable = result.get("table1").buildPhysicalTable(new ConfigurationDictionary<DimensionConfig>())
+
+        expect:
+        result.size() == 1
+        physicalTable.getName().asName() == "table1"
+        physicalTable.getGrain() == new ZonedTimeGrain(DefaultTimeGrain.MINUTE, DateTimeZone.UTC)
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
@@ -98,6 +98,12 @@ class ClassScannerSpec extends Specification {
     }
 
     /**
+     * This tests the 'equals' method across all methods that have implemented it (see getClassesDeclaring).
+     *
+     * If this test fails for you you may need to update ClassScanner to handle your special argument types,
+     * add values to the class scanner value cache above, or add your class to the ignored list in
+     * getClassesDeclaring.
+     *
      * This method is ignored if no declaring classes will trigger the where block.
      * This is an issue because downstream developers may want to defensively deploy subclasses of this class to
      * ensure that any legitimate class scanner targets are picked up when discovered and appropriate.

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/DeserializationHelper.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/provider/yaml/serde/DeserializationHelper.java
@@ -1,0 +1,49 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+package com.yahoo.bard.webservice.data.config.provider.yaml.serde;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+/**
+ * Utility functions to test deserializers.
+ */
+public class DeserializationHelper {
+
+    /**
+     * Get an object mapper that deserializes using the specified deserializer.
+     *
+     * @param asClass target class
+     * @param deserializer deserializer
+     * @return object mapper that uses deserializer to turn json into the target class
+     */
+    public static ObjectMapper getMapper(Class asClass, JsonDeserializer deserializer) {
+        ObjectMapper mapper = new ObjectMapper();
+        HashMap<Class<?>, JsonDeserializer<?>> map = new HashMap<>();
+        map.put(asClass, deserializer);
+        mapper.registerModule(new SimpleModule("module", new Version(1, 1, 1, ""), map));
+        return mapper;
+    }
+
+    /**
+     * Deserialize json using given deserializer.
+     *
+     * @param json the json string to deserialize
+     * @param deserializer deserializer to use
+     * @param <T> class to return
+     * @return deserialized object
+     * @throws IOException when object could not be deserialized
+     */
+    public static <T> T deserialize(String json, JsonDeserializer<T> deserializer) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonParser parser = mapper.getFactory().createParser(json);
+        return deserializer.deserialize(parser, null);
+    }
+}

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.net.URL;
@@ -214,6 +215,7 @@ public class ClassScanner {
                     if (annotation.annotationType().isAssignableFrom(NotNull.class)) {
                         argMode = Args.VALUES;
                         notnull = true;
+                        break;
                     }
                 }
 
@@ -275,6 +277,11 @@ public class ClassScanner {
             arg = cachedValue;
         } else if (cls == Object[].class) {
             arg = (T) new Object[0];
+
+        } else if (cls.isArray()) {
+            Object arrayElement = constructArg(cls.getComponentType(), mode, stack);
+            arg = (T) Array.newInstance(cls.getComponentType(), 1);
+            Array.set(arg, 0, arrayElement);
         } else if (Modifier.isAbstract(cls.getModifiers())) {
             arg = constructSubclass(cls, mode, stack);
         } else {

--- a/fili-core/src/test/resources/yaml/exampleConfiguration.yaml
+++ b/fili-core/src/test/resources/yaml/exampleConfiguration.yaml
@@ -1,0 +1,60 @@
+physical_tables:
+  physical_table_1:
+    dimensions: [ tld, platform ]
+    metrics: [ impressions ]
+    granularity: minute
+
+  physical_table_2:
+    granularity: hour
+    dimensions: [ tld ]
+    metrics: [ impressions ]
+
+logical_tables:
+  logical_table_1:
+    physical_tables: [ physical_table_1, physical_table_2 ]
+    metrics: [ impressions, incremented_impressions ]
+    granularities: [ minute, hour, day ]  # FIXME: inconsistent
+
+dimensions:
+  tld:
+    physical_name: top_level_domain
+    long_name: Top Level Domain
+    description: the top level domain
+    category: default
+    aggregatable: true
+
+  platform:
+    physical_name: user_platform
+    long_name: User Platform
+    description: the user's platform
+    category: default
+    fields: [id]
+    default_fields: [id]
+    aggregatable: true
+
+dimension_fields:
+  id:
+    description: Dimension ID
+    default_include: true
+
+  description:
+    description: Dimension Description
+    default_include: false
+
+base_metrics:
+  impressions:
+    def: longSum(impressions)
+    description: the total impressions
+
+
+derived_metrics:
+  incremented_impressions:
+    def: impressions + 1
+    description: the *real* number of impressions!
+
+makers:
+  sketch:
+    class: com.yahoo.bard.webservice.data.config.metric.makers.ThetaSketchSetOperationMaker
+    args:
+      - >
+        !!com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationPostAggFunction 'NOT'

--- a/fili-yaml/Dockerfile
+++ b/fili-yaml/Dockerfile
@@ -1,0 +1,10 @@
+# See: https://hub.docker.com/_/jetty/ for usage
+FROM jetty
+
+MAINTAINER jtolar@yahoo-inc.com
+
+ADD run-jetty.sh /run-jetty.sh
+RUN chmod 755 /run-jetty.sh
+ENTRYPOINT ["/run-jetty.sh"]
+
+COPY target/fili-yaml.war /var/lib/jetty/webapps/ROOT.war

--- a/fili-yaml/README.md
+++ b/fili-yaml/README.md
@@ -1,0 +1,32 @@
+Fili Yaml Application
+=====================
+
+An easy way to get Fili up and running in front of Druid. No programming required!
+
+Caveats: 
+* Does not yet support all features of Fili; your mileage may vary.
+
+## Example Usage
+
+```
+(cd .. && mvn clean install)
+./build-docker.sh
+docker build -t jetty-fili .
+docker run -p 8080:8080 -v`pwd`/fili.yaml:/fili.yaml -t jetty-fili  -f /fili.yaml -d bard__property=value -p config.properties
+```
+
+After a few seconds, you should see Fili running on port 8080.
+
+To actually make queries, Fili must be configured properly, of course. Some 
+settings you'll want to set via the command line or in a properties file:
+
+```
+bard__non_ui_druid_broker=http://druid-url:4080/druid/v2
+bard__ui_druid_broker=http://druid-url:4080/druid/v2
+bard__druid_coord=http://coord-url:8082/druid/coordinator/v1
+```
+
+Finally, the YAML config doesn't support dimension loading yet. Fili will refuse to
+return any data if dimensions are not loaded (healthcheck will fail), so you can
+use the `reset-dims.sh` script supplied here to initialize the dimensions (python
+and curl required).

--- a/fili-yaml/build-docker.sh
+++ b/fili-yaml/build-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t jetty-bard .

--- a/fili-yaml/example.yaml
+++ b/fili-yaml/example.yaml
@@ -1,0 +1,55 @@
+physical_tables:
+  table1:
+    dimensions: [ page_tld, gender ]
+    metrics: [ impressions ]
+    granularity: minute
+
+  table2:
+    granularity: day
+    dimensions: [ page_tld ]
+    metrics: [ impressions ]
+
+logical_tables:
+  example_logical_table:
+    physical_tables: [  table1, table2 ]
+    metrics: [ impressions, male_impressions ]
+    granularities: [ minute, hour, day ]
+
+dimensions:
+  page_tld:
+    physical_name: page_tld
+    long_name: Page TLD
+    description: the page top level domain
+    category: default
+    aggregatable: true
+
+  gender:
+    physical_name: gender
+    long_name: Gender
+    description: the user gender
+    category: default
+    fields: [id]
+    default_fields: [id]
+    aggregatable: true
+
+dimension_fields:
+  id:
+    description: Dimension ID
+    default_include: true
+
+  description:
+    description: Dimension Description
+    default_include: false
+
+base_metrics:
+  impressions:
+    def: longSum(impressions)
+    description: the total impressions
+
+
+derived_metrics:
+  male_impressions:
+    def: impressions | gender == 1
+    description: the number of impressions seen by males
+
+makers: {}

--- a/fili-yaml/pom.xml
+++ b/fili-yaml/pom.xml
@@ -1,0 +1,84 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
+
+    <artifactId>fili-yaml</artifactId>
+    <packaging>war</packaging>
+    <name>Fili: YAML config</name>
+    <description>Ready-to-deploy YAML config
+    </description>
+
+    <parent>
+        <groupId>com.yahoo.fili</groupId>
+        <artifactId>fili-parent-pom</artifactId>
+        <version>0.7-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.yahoo.fili</groupId>
+            <artifactId>fili</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.yahoo.fili</groupId>
+            <artifactId>fili-core</artifactId>
+        </dependency>
+
+        <!-- Servlet API -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+
+        <!-- Jersey -->
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>1</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <exec executable="/bin/sh">
+                                    <env key="BUILD_NUMBER" value="${project.build}" />
+                                    <arg value="-c" />
+                                    <arg
+                                        value="echo ${project.version}.${BUILD_NUMBER:=0} | sed -e s/-SNAPSHOT//g &gt; target/buildVersion" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+    </plugins>
+    </build>
+</project>

--- a/fili-yaml/reset-dims.sh
+++ b/fili-yaml/reset-dims.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+BARD_HOST=${1:localhost}
+
+# Reset all dimensions
+for dim in $(curl --silent http://$BARD_HOST:8080/v1/dimensions |python -c "import json; import sys; data = sys.stdin.read(); j=json.loads(data); print '\n'.join(i['name'] for i in j['rows'])"); do
+  echo reseting $dim
+  echo '{ "name": "'$dim'", "lastUpdated": "2016-01-01" }' | curl -X POST -d@- http://$BARD_HOST:8080/v1/cache/dimensions/$dim -H 'Content-Type: application/json'
+done

--- a/fili-yaml/run-jetty.sh
+++ b/fili-yaml/run-jetty.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+
+usage() {
+  cat <<EOF
+USAGE: 
+  $0 [OPTIONS] [-- JETTY_OPTIONS]
+OPTIONS:
+  -d --define prop=val  Define a java option (--define bard__some_setting=blah, -Xmx..., etc)
+  -f --file PATH        Provide path to YAML config file.
+                        You'll need to mount the location as a 
+                        volume within Docker with Docker's '-v' option.
+  -p --properties PATH  Provide a path to a java-esque properites file; 
+                        read and passed as properties via \$JAVA_OPTIONS.
+                        You'll need to mount the location as a 
+                        volume within Docker with Docker's '-v' option.
+  -h --help             Print this message.
+  --                    Any options after a bare "--" will be passed directly to the 
+                        Jetty start.jar command.
+EOF
+}
+
+
+while [[ $# > 0 ]]; do
+key="$1"
+
+case $key in
+    --)
+      shift;
+      break;
+      ;;
+    -f|--file)
+    JAVA_OPTIONS="$JAVA_OPTIONS -Dbard__config_binder_yaml_path=$2"
+    shift # past argument
+    ;;
+    -d|--define)
+    JAVA_OPTIONS="$JAVA_OPTIONS -D$2"
+    shift # past argument
+    ;;
+    -p|--properties)
+      while read property; do
+        JAVA_OPTIONS="$JAVA_OPTIONS -D$property"
+      done < $2;
+      shift # past argument
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo Unknown option: $key
+      usage
+      exit 1
+    ;;
+esac
+shift # past argument or value
+done
+
+export JAVA_OPTIONS
+echo "JAVA_OPTIONS: $JAVA_OPTIONS"
+
+echo exec java $JETTY_ARGS -jar "$JETTY_HOME/start.jar" "$@"
+exec java $JETTY_ARGS -jar "$JETTY_HOME/start.jar" "$@"

--- a/fili-yaml/src/main/resources/applicationConfig.properties
+++ b/fili-yaml/src/main/resources/applicationConfig.properties
@@ -1,0 +1,51 @@
+# Copyright 2016 Yahoo Inc.
+# Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+# Application configuration must specify a package name.  This prefix applies to all config properties.
+package_name = bard
+
+moduleDependencies = fili
+
+bard__version = Local Mode
+bard__resource_binder=com.yahoo.bard.webservice.data.config.provider.ConfigBinderFactory
+bard__config_binder_type=com.yahoo.bard.webservice.data.config.provider.yaml.YamlConfigProvider
+
+# The default.
+bard__config_binder_yaml_path=/bard.yaml
+
+# You'll probably want to override this
+bard__non_ui_druid_broker=http://localhost:8082/druid/v2
+bard__ui_druid_broker=http://localhost:8082/druid/v2
+bard__druid_coord=http://localhost:8081/druid/v2
+
+
+# Use memory for the default dimension backing store
+bard__dimension_backend=memory
+
+# Data Cache
+bard__druid_cache_enabled = false
+bard__druid_cache_v2_enabled = false
+
+# Flag to enable usage of metadata supplied by the druid coordinator
+# It requires coordinator URL (bard__druid_coord) to be set
+bard__druid_coordinator_metadata_enabled = true
+
+# Lucene index files path
+bard__lucene_index_path=/home/y/var/
+
+# maximum number of results to display without any filters - used for /dim/values endpoint
+bard__max_results_without_filters=10000
+
+# Default number of records per-page
+bard__default_per_page=10000
+
+# Enable permissive partial data, marking things as partial only when no metrics are available rather then when only one is not available
+bard__permissive_column_availability_enabled=false
+
+# Enable TopN optimization
+bard__top_n_enabled=true
+
+bard__default_asyncAfter=never
+
+# Flag to turn on case sensitive keys in keyvalue store
+bard__case_sensitive_keys_enabled = false

--- a/fili-yaml/src/main/resources/logback.xml
+++ b/fili-yaml/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} \(%F:%L\) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/fili-yaml/src/main/resources/userConfig.properties.sample
+++ b/fili-yaml/src/main/resources/userConfig.properties.sample
@@ -1,0 +1,5 @@
+# Copyright 2016 Yahoo Inc.
+# Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+
+# Overrides the default dimension backend.
+fili__dimension_backend = memory

--- a/fili-yaml/src/main/webapp/WEB-INF/web.xml
+++ b/fili-yaml/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,115 @@
+<web-app version="3.0"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <listener>
+        <listener-class>com.yahoo.bard.webservice.application.MetricServletContextListener</listener-class>
+    </listener>
+    <listener>
+        <listener-class>com.yahoo.bard.webservice.application.HealthCheckServletContextListener</listener-class>
+    </listener>
+
+    <servlet>
+        <servlet-name>Jersey Web Application</servlet-name>
+        <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+        <init-param>
+            <param-name>jersey.config.server.provider.packages</param-name>
+            <param-value>com.yahoo.bard.webservice.web.endpoints</param-value>
+        </init-param>
+        <init-param>
+            <param-name>javax.ws.rs.Application</param-name>
+            <param-value>com.yahoo.bard.webservice.application.ResourceConfig</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+        <async-supported>true</async-supported>
+    </servlet>
+
+    <servlet>
+        <servlet-name>Admin</servlet-name>
+        <servlet-class>com.codahale.metrics.servlets.AdminServlet</servlet-class>
+        <init-param>
+            <param-name>healthcheck-uri</param-name>
+            <param-value>/status.html</param-value>
+        </init-param>
+    </servlet>
+    
+    <!-- 
+    The following servlet declaration is copied from jetty's webdefault.xml. It is
+    here purely to avoid validation errors in some IDEs, such as eclipse, and is not
+    normally necessary in order to get the system to work. 
+     -->
+    <servlet>
+        <servlet-name>default</servlet-name>
+        <servlet-class>org.eclipse.jetty.servlet.DefaultServlet</servlet-class>
+        <init-param>
+                <param-name>aliases</param-name>
+                <param-value>false</param-value>
+        </init-param>
+        <init-param>
+                <param-name>acceptRanges</param-name>
+                <param-value>true</param-value>
+        </init-param>
+        <init-param>
+                <param-name>dirAllowed</param-name>
+                <param-value>false</param-value>
+        </init-param>
+        <init-param>
+                <param-name>welcomeServlets</param-name>
+                <param-value>false</param-value>
+        </init-param>
+        <init-param>
+                <param-name>redirectWelcome</param-name>
+                <param-value>false</param-value>
+        </init-param>
+        <init-param>
+                <param-name>maxCacheSize</param-name>
+                <param-value>256000000</param-value>
+        </init-param>
+        <init-param>
+                <param-name>maxCachedFileSize</param-name>
+                <param-value>200000000</param-value>
+        </init-param>
+        <init-param>
+                <param-name>maxCachedFiles</param-name>
+                <param-value>2048</param-value>
+        </init-param>
+        <init-param>
+                <param-name>gzip</param-name>
+                <param-value>true</param-value>
+        </init-param>
+        <init-param>
+                <param-name>etags</param-name>
+                <param-value>true</param-value>
+        </init-param>
+        <init-param>
+                <param-name>useFileMappedBuffer</param-name>
+                <param-value>true</param-value>
+        </init-param>
+        <!-- <init-param> <param-name>resourceCache</param-name> <param-value>resourceCache</param-value>
+                </init-param> -->
+        <!-- <init-param> <param-name>cacheControl</param-name> <param-value>max-age=3600,public</param-value>
+                </init-param> -->
+        <load-on-startup>0</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Jersey Web Application</servlet-name>
+        <url-pattern>/v1/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>Admin</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+    <filter>
+        <filter-name>instrumentedFilter</filter-name>
+        <filter-class>com.codahale.metrics.servlet.InstrumentedFilter</filter-class>
+        <async-supported>true</async-supported>
+    </filter>
+    <filter-mapping>
+        <filter-name>instrumentedFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+</web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>fili-core</module>
         <module>fili</module>
         <module>fili-wikipedia-example</module>
+        <module>fili-yaml</module>
     </modules>
 
     <organization>
@@ -366,6 +367,11 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-csv</artifactId>
+                <version>${version.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${version.jackson}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
This change is quite large (sorry about that...) but there are (almost) zero changes to the core code, so at least it shouldn't break any existing functionality; it just adds new broken functionality :).

* Adds a set of interfaces for setting up Fili via configuration (`ConfigProvider`). You can currently configure metrics, dimensions, physical and logical tables, and register custom metric makers. Notably, I've never had to set up dimension loading or search providers before, so those aren't supported yet but could presumably be added without too much trouble.

* There is also an implementation of AbstractBinderFactory that uses reflection to instantiate a specified ConfigProvider and provide all the necessary Fili configuration. With this, you can get Fili up and running in front of your Druid instance without writing a single line of code.

* There is an implementation of `ConfigProvider` for a YAML-driven configuration via Jackson's yaml support (jackson-dataformat-yaml).

* There's a new subproject, 'fili-yaml', that is set up to with the ConfigBinderFactory (this repo contains no actual java code). It just builds a war that can be configured easily with yaml. It also includes a couple scripts and a Dockerfile that can be used to stand up Fili via Docker, and a few instructions on how to do so. 

* Distinct from the YAML config, there is also a metric parser included (it's used by the YAML config provider, but could also be used independently of it). It lets you define metrics in a special DSL; for example, `(impressions + 3)/5 | gender == 2` would produce a filtered aggregate. There's not really any docs on the DSL included in this PR yet, but it's hopefully fairly intuitive. It doesn't support 100% of what you could do programmatically, but it's hopefully a good start.

* One of the few changes to existing code is that `ShardSpecMixIn` was updated to include 'linear' which is used for streaming.

* A couple assorted documentation updates.

* Updated the ClassScanner to handle array argument types.

The test coverage isn't perfect, but most things have at least one test :) (Notable exception: the metric parser; I've written tests for most of the classes it uses, just not the top-level parser). I have also tested this against our Druid instance, which was where I found the ShardSpecMixIn change. 

There's also a couple things in here (especially the metric parser) that I'm not 100% sure I have correct -- Fili/Druid-isms that I didn't dig into fully. I tried to make notes when I wasn't sure of something so there's a few FIXMEs scattered around.