### PR TITLE
Fix SegmentMetaDataLoader to use provided headers for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Current
 
 ### Fixed:
 
+- [SegmentMetadataLoader include provided request headers](https://github.com/yahoo/fili/pull/106)
+    * `SegmentMetadataLoader` sends requests with the provided request headers in `AsyncDruidWebservice` now
+    * Refactored `AsyncDruidWebserviceSpec` test and added test for checking `getJsonData` includes request headers as well
+
 - [Fix and refactor role based filter to allow CORS](https://github.com/yahoo/fili/pull/99)
     * Fix `RoleBasedAuthFilter` to bypass `OPTIONS` request for CORS
     * Discovered a bug where `user_roles` is declared but unset still reads as a list with empty string (included a temporary fix by commenting the variable declaration)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Current
 
 ### Changed:
 
+- [SegmentMetadataLoader include provided request headers](https://github.com/yahoo/fili/pull/106)
+    * `SegmentMetadataLoader` sends requests with the provided request headers in `AsyncDruidWebservice` now
+    * Refactored `AsyncDruidWebserviceSpec` test and added test for checking `getJsonData` includes request headers as well
+
 - [Include physical table name in warning log message for logicalToPhysical mapping](https://github.com/yahoo/fili/pull/94)
     * Without this name, it's hard to know what table seems to be misconfigured.
 
@@ -27,10 +31,6 @@ Current
 
 
 ### Fixed:
-
-- [SegmentMetadataLoader include provided request headers](https://github.com/yahoo/fili/pull/106)
-    * `SegmentMetadataLoader` sends requests with the provided request headers in `AsyncDruidWebservice` now
-    * Refactored `AsyncDruidWebserviceSpec` test and added test for checking `getJsonData` includes request headers as well
 
 - [Fix and refactor role based filter to allow CORS](https://github.com/yahoo/fili/pull/99)
     * Fix `RoleBasedAuthFilter` to bypass `OPTIONS` request for CORS

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImpl.java
@@ -274,11 +274,15 @@ public class AsyncDruidWebServiceImpl implements DruidWebService {
             String resourcePath
     ) {
         String url = String.format("%s%s", serviceConfig.getUrl(), resourcePath);
+
+        BoundRequestBuilder requestBuilder = webClient.prepareGet(url);
+        headersToAppend.get().forEach(requestBuilder::addHeader);
+
         sendRequest(
                 success,
                 error,
                 failure,
-                webClient.prepareGet(url),
+                requestBuilder,
                 DRUID_SEGMENT_METADATA_TIMER,
                 new AtomicLong(1)
         );

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImplSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImplSpec.groovy
@@ -21,9 +21,10 @@ class AsyncDruidWebServiceImplSpec extends Specification {
         weightEvaluationQuery.getContext() >> queryContext
 
         and:
-        Map<String, String> expectedHeaders = new HashMap<>()
-        expectedHeaders.put("k1", "v1")
-        expectedHeaders.put("k2", "v2")
+        Map<String, String> expectedHeaders = [
+                k1: "v1",
+                k2: "v2"
+        ]
         Supplier<Map<String, String>> supplier = Mock()
         supplier.get() >> expectedHeaders
 
@@ -45,10 +46,10 @@ class AsyncDruidWebServiceImplSpec extends Specification {
 
     def "Ensure that headersToAppend are added to request when calling getJsonObject"() {
         setup:
-        Map<String, String> expectedHeaders = new HashMap<>()
-        expectedHeaders.put("k1", "v1")
-        expectedHeaders.put("k2", "v2")
-
+        Map<String, String> expectedHeaders = [
+                k1: "v1",
+                k2: "v2"
+        ]
         Supplier<Map<String, String>> supplier = Mock()
         supplier.get() >> expectedHeaders
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImplSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImplSpec.groovy
@@ -14,24 +14,19 @@ import spock.lang.Specification
 import java.util.function.Supplier
 
 class AsyncDruidWebServiceImplSpec extends Specification {
-    def "Ensure that headersToAppend are added"() {
+    def "Ensure that headersToAppend are added to request when calling postDruidQuery"() {
         setup:
         WeightEvaluationQuery weightEvaluationQuery = Mock(WeightEvaluationQuery)
         QueryContext queryContext = Mock(QueryContext)
-        weightEvaluationQuery.getContext() >> { queryContext }
-        queryContext.numberOfQueries() >> { 1 }
-        queryContext.getSequenceNumber() >> { 1 }
+        weightEvaluationQuery.getContext() >> queryContext
 
         and:
         Map<String, String> expectedHeaders = new HashMap<>()
         expectedHeaders.put("k1", "v1")
         expectedHeaders.put("k2", "v2")
-        Supplier<Map<String, String>> supplier = new Supplier<Map<String, String>>() {
-            @Override
-            Map<String, String> get() {
-                return expectedHeaders
-            }
-        }
+        Supplier<Map<String, String>> supplier = Mock()
+        supplier.get() >> expectedHeaders
+
         AsyncDruidWebServiceImplWrapper webServiceImplWrapper = new AsyncDruidWebServiceImplWrapper(
                 DruidClientConfigHelper.getNonUiServiceConfig(),
                 new ObjectMapper(),
@@ -39,13 +34,32 @@ class AsyncDruidWebServiceImplSpec extends Specification {
         )
 
         when:
-        webServiceImplWrapper.postDruidQuery(
-                null,
-                null,
-                null,
-                null,
-                weightEvaluationQuery
-        );
+        webServiceImplWrapper.postDruidQuery(null, null, null, null, weightEvaluationQuery);
+
+        then:
+        HttpHeaders actualHeaders = webServiceImplWrapper.getHeaders()
+        for (Map.Entry<String, String> header : expectedHeaders) {
+            assert actualHeaders.get(header.getKey()) == header.getValue()
+        }
+    }
+
+    def "Ensure that headersToAppend are added to request when calling getJsonObject"() {
+        setup:
+        Map<String, String> expectedHeaders = new HashMap<>()
+        expectedHeaders.put("k1", "v1")
+        expectedHeaders.put("k2", "v2")
+
+        Supplier<Map<String, String>> supplier = Mock()
+        supplier.get() >> expectedHeaders
+
+        AsyncDruidWebServiceImplWrapper webServiceImplWrapper = new AsyncDruidWebServiceImplWrapper(
+                DruidClientConfigHelper.getNonUiServiceConfig(),
+                new ObjectMapper(),
+                supplier
+        )
+
+        when:
+        webServiceImplWrapper.getJsonObject(null, null, null, null);
 
         then:
         HttpHeaders actualHeaders = webServiceImplWrapper.getHeaders()


### PR DESCRIPTION
* `SegmentMetadataLoader` sends requests with the provided request headers in `AsyncDruidWebservice` now
* Refactored `AsyncDruidWebserviceSpec` test and added test for checking `getJsonData` includes request headers as well