### PR TITLE
Remove restriction for single physical dimension to multiple lookup dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Current
 
 ### Changed:
 
+- [Remove restriction for single physical dimension to multiple lookup dimensions](https://github.com/yahoo/fili/pull/112)
+    * Modified physical dimension name to logical dimension name mapping into a `Map<String, List<String>>` instead of `Map<String, String>` in `PhysicalTable.java`
+
 - [SegmentMetadataLoader include provided request headers](https://github.com/yahoo/fili/pull/106)
     * `SegmentMetadataLoader` sends requests with the provided request headers in `AsyncDruidWebservice` now
     * Refactored `AsyncDruidWebserviceSpec` test and added test for checking `getJsonData` includes request headers as well

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Current
 ### Changed:
 
 - [Remove restriction for single physical dimension to multiple lookup dimensions](https://github.com/yahoo/fili/pull/112)
-    * Modified physical dimension name to logical dimension name mapping into a `Map<String, List<String>>` instead of `Map<String, String>` in `PhysicalTable.java`
+    * Modified physical dimension name to logical dimension name mapping into a `Map<String, Set<String>>` instead of `Map<String, String>` in `PhysicalTable.java`
 
 - [SegmentMetadataLoader include provided request headers](https://github.com/yahoo/fili/pull/106)
     * `SegmentMetadataLoader` sends requests with the provided request headers in `AsyncDruidWebservice` now

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -143,16 +144,16 @@ public class PhysicalTable extends Table {
 
                 getLogicalColumnNames(physicalName).stream()
                         .map(dimensionDictionary::findByApiName)
-                        .filter(dimension -> dimension != null)
+                        .filter(Objects::nonNull)
                         .forEach(
-                                dimension -> {
-                                    DimensionColumn dimensionColumn = DimensionColumn.addNewDimensionColumn(
-                                            this,
-                                            dimension
-                                    );
-                                    workingIntervals.put(dimensionColumn, nameIntervals.getValue());
-                                }
-                        );
+                        dimension -> {
+                            DimensionColumn dimensionColumn = DimensionColumn.addNewDimensionColumn(
+                                    this,
+                                    dimension
+                            );
+                            workingIntervals.put(dimensionColumn, nameIntervals.getValue());
+                        }
+                );
             }
             for (Map.Entry<String, Set<Interval>> nameIntervals : metricIntervals.entrySet()) {
                 MetricColumn metricColumn = MetricColumn.addNewMetricColumn(this, nameIntervals.getKey());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -16,10 +16,8 @@ import org.joda.time.ReadablePeriod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -146,14 +144,14 @@ public class PhysicalTable extends Table {
                         .map(dimensionDictionary::findByApiName)
                         .filter(Objects::nonNull)
                         .forEach(
-                        dimension -> {
-                            DimensionColumn dimensionColumn = DimensionColumn.addNewDimensionColumn(
-                                    this,
-                                    dimension
-                            );
-                            workingIntervals.put(dimensionColumn, nameIntervals.getValue());
-                        }
-                );
+                                dimension -> {
+                                    DimensionColumn dimensionColumn = DimensionColumn.addNewDimensionColumn(
+                                            this,
+                                            dimension
+                                    );
+                                    workingIntervals.put(dimensionColumn, nameIntervals.getValue());
+                                }
+                        );
             }
             for (Map.Entry<String, Set<Interval>> nameIntervals : metricIntervals.entrySet()) {
                 MetricColumn metricColumn = MetricColumn.addNewMetricColumn(this, nameIntervals.getKey());
@@ -247,7 +245,7 @@ public class PhysicalTable extends Table {
      * @return Translated physicalName if applicable
      */
     private Set<String> getLogicalColumnNames(String physicalName) {
-        return physicalToLogicalColumnNames.getOrDefault(physicalName, new HashSet<>(Arrays.asList(physicalName)));
+        return physicalToLogicalColumnNames.getOrDefault(physicalName, Collections.singleton(physicalName));
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -141,8 +141,7 @@ public class PhysicalTable extends Table {
             for (Map.Entry<String, Set<Interval>> nameIntervals : dimensionIntervals.entrySet()) {
                 String physicalName = nameIntervals.getKey();
 
-                getLogicalColumnName(physicalName).stream()
-                        .sequential()
+                getLogicalColumnNames(physicalName).stream()
                         .map(dimensionDictionary::findByApiName)
                         .filter(dimension -> dimension != null)
                         .forEach(
@@ -246,7 +245,7 @@ public class PhysicalTable extends Table {
      * @param physicalName  Physical name to lookup in physical table
      * @return Translated physicalName if applicable
      */
-    private Set<String> getLogicalColumnName(String physicalName) {
+    private Set<String> getLogicalColumnNames(String physicalName) {
         return physicalToLogicalColumnNames.getOrDefault(physicalName, new HashSet<>(Arrays.asList(physicalName)));
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PhysicalTableSpec.groovy
@@ -153,8 +153,8 @@ class PhysicalTableSpec extends Specification {
 
     def "test physical to logical mapping is constructed correctly"() {
         setup:
-        def oneDimPhysicalTable = new PhysicalTable("test table", DAY.buildZonedTimeGrain(UTC), ['dimension':'druidDim'])
-        def twoDimPhysicalTable = new PhysicalTable("test table", DAY.buildZonedTimeGrain(UTC), ['dimension1':'druidDim', 'dimension2':'druidDim'])
+        PhysicalTable oneDimPhysicalTable = new PhysicalTable("test table", DAY.buildZonedTimeGrain(UTC), ['dimension':'druidDim'])
+        PhysicalTable twoDimPhysicalTable = new PhysicalTable("test table", DAY.buildZonedTimeGrain(UTC), ['dimension1':'druidDim', 'dimension2':'druidDim'])
 
         expect:
         oneDimPhysicalTable.getLogicalColumnNames('druidDim') == ['dimension'] as Set

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PhysicalTableSpec.groovy
@@ -150,4 +150,14 @@ class PhysicalTableSpec extends Specification {
         expect:
         physicalTable.getDimensions() == [dimension] as Set
     }
+
+    def "test physical to logical mapping is constructed correctly"() {
+        setup:
+        def oneDimPhysicalTable = new PhysicalTable("test table", DAY.buildZonedTimeGrain(UTC), ['dimension':'druidDim'])
+        def twoDimPhysicalTable = new PhysicalTable("test table", DAY.buildZonedTimeGrain(UTC), ['dimension1':'druidDim', 'dimension2':'druidDim'])
+
+        expect:
+        oneDimPhysicalTable.getLogicalColumnNames('druidDim') == ['dimension'] as Set
+        twoDimPhysicalTable.getLogicalColumnNames('druidDim') == ['dimension1', 'dimension2'] as Set
+    }
 }


### PR DESCRIPTION
* Modified physical dimension name to logical dimension name mapping into a `Map<String, List<String>>` instead of `Map<String, String>` in `PhysicalTable.java`