### PR TITLE
Default DimensionColumn name to use apiName instead of physicalName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Current
 
 ### Changed:
 
+- [Default DimensionColumn name to use apiName instead of physicalName](https://github.com/yahoo/fili/pull/115)
+    * Change `DimensionColumn.java` to use dimension api name instead of physical name as its name
+    * Modified tests according to the above change
+
 - [`NoOpResultSetMapper` now runs in constant time and space.](https://github.com/yahoo/fili/pull/119)
 
 - [Remove restriction for single physical dimension to multiple lookup dimensions](https://github.com/yahoo/fili/pull/112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Current
 
 - [Default DimensionColumn name to use apiName instead of physicalName](https://github.com/yahoo/fili/pull/115)
     * Change `DimensionColumn.java` to use dimension api name instead of physical name as its name
-    * Modified tests according to the above change
+    * Modified files dependent on `DimensionColumn.java` and corresponding tests according to the above change
 
 - [`NoOpResultSetMapper` now runs in constant time and space.](https://github.com/yahoo/fili/pull/119)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@ Current
 - [Default DimensionColumn name to use apiName instead of physicalName](https://github.com/yahoo/fili/pull/115)
     * Deprecated `TableUtils::getColumnNames(DataApiRequest, DruidAggregationQuery, PhysicalTable)` returning dimension physical name,
      in favor of `TableUtils::getColumnNames(DataApiRequest, DruidAggregationQuery)` returning dimension api name
+    * Deprecated `DimensionColumn::DimensionColumn addNewDimensionColumn(Schema, Dimension, PhysicalTable)` in favor of
+     `DimensionColumn::DimensionColumn addNewDimensionColumn(Schema, Dimension)` which uses api name instead of physical name as column identifier for columns
+    * Deprecated `LogicalDimensionColumn` in favor of `DimensionColumn` since `DimensionColumn` stores api name instead of physical name now,
+     so `LogicalDimensionColumn` is no longer needed
 
 ### Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,9 @@ Current
 
 ### Deprecated:
 
-
+- [Default DimensionColumn name to use apiName instead of physicalName](https://github.com/yahoo/fili/pull/115)
+    * Deprecated `TableUtils::getColumnNames(DataApiRequest, DruidAggregationQuery, PhysicalTable)` returning dimension physical name,
+     in favor of `TableUtils::getColumnNames(DataApiRequest, DruidAggregationQuery)` returning dimension api name
 
 ### Fixed:
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/PartialDataHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/PartialDataHandler.java
@@ -3,7 +3,6 @@
 package com.yahoo.bard.webservice.data;
 
 import static com.yahoo.bard.webservice.config.BardFeatureFlag.PERMISSIVE_COLUMN_AVAILABILITY;
-import static com.yahoo.bard.webservice.util.TableUtils.getColumnNames;
 
 import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
@@ -11,6 +10,7 @@ import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.util.IntervalUtils;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
+import com.yahoo.bard.webservice.util.TableUtils;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 
 import org.slf4j.Logger;
@@ -95,7 +95,7 @@ public class PartialDataHandler {
             Granularity granularity
     ) {
         SimplifiedIntervalList availableIntervals = physicalTables.stream()
-                .map(table -> getAvailability(table, getColumnNames(apiRequest, query, table)))
+                .map(table -> getAvailability(table, TableUtils.getColumnNames(apiRequest, query)))
                 .flatMap(SimplifiedIntervalList::stream)
                 .collect(SimplifiedIntervalList.getCollector());
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/PreResponseDeserializer.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/PreResponseDeserializer.java
@@ -237,8 +237,7 @@ public class PreResponseDeserializer {
         StreamSupport.stream(schemaNode.get(SCHEMA_DIM_COLUMNS).spliterator(), false)
                 .map(JsonNode::asText)
                 .map(this::resolveDimensionName)
-                .map(DimensionColumn::new)
-                .forEach(zonedSchema::addColumn);
+                .forEach(dimension -> DimensionColumn.addNewDimensionColumn(zonedSchema, dimension));
 
         schemaNode.get(SCHEMA_METRIC_COLUMNS_TYPE).fields().forEachRemaining(
                 field -> zonedSchema.addColumn(new MetricColumnWithValueType(field.getKey(), field.getValue().asText()))

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/PreResponseDeserializer.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/PreResponseDeserializer.java
@@ -20,7 +20,6 @@ import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.data.dimension.DimensionColumn;
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 import com.yahoo.bard.webservice.data.dimension.DimensionRow;
-import com.yahoo.bard.webservice.data.dimension.LogicalDimensionColumn;
 import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.data.metric.MetricColumnWithValueType;
 import com.yahoo.bard.webservice.data.time.GranularityParser;
@@ -238,7 +237,7 @@ public class PreResponseDeserializer {
         StreamSupport.stream(schemaNode.get(SCHEMA_DIM_COLUMNS).spliterator(), false)
                 .map(JsonNode::asText)
                 .map(this::resolveDimensionName)
-                .map(LogicalDimensionColumn::new)
+                .map(DimensionColumn::new)
                 .forEach(zonedSchema::addColumn);
 
         schemaNode.get(SCHEMA_METRIC_COLUMNS_TYPE).fields().forEachRemaining(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
@@ -224,7 +224,7 @@ public abstract class BaseTableLoader implements TableLoader {
                     .filter(table -> table.hasLogicalMapping(dim.getApiName()))
                     .findFirst()
                     .orElse(firstPhysicalTable);
-            DimensionColumn.addNewDimensionColumn(logicalTable, dim, physicalTable);
+            DimensionColumn.addNewDimensionColumn(logicalTable, dim);
         }
 
         // All metrics that are available for a particular logical table grain are added
@@ -293,7 +293,7 @@ public abstract class BaseTableLoader implements TableLoader {
         for (DimensionConfig dimensionConfig : definition.getDimensions()) {
             String apiName = dimensionConfig.getApiName();
             Dimension dimension = dimensionDictionary.findByApiName(apiName);
-            DimensionColumn.addNewDimensionColumn(physicalTable, dimension, physicalTable);
+            DimensionColumn.addNewDimensionColumn(physicalTable, dimension);
         }
 
         // Load the metric columns

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
@@ -17,13 +17,23 @@ public class DimensionColumn extends Column {
 
     /**
      * Constructor.
-     * Uses dimension DruidName for column name.
+     * Uses dimension api name for column name.
      *
-     * @param dimension  The column name
-     * @param physicalName  Physical column name backing dimension
+     * @param dimension  The column's corresponding dimension
      */
-    protected DimensionColumn(@NotNull Dimension dimension, @NotNull String physicalName) {
-        super(physicalName);
+    public DimensionColumn(@NotNull Dimension dimension) {
+        this(dimension, dimension.getApiName());
+    }
+
+    /**
+     * Constructor.
+     * Uses the given name as  for column name.
+     *
+     * @param dimension  The column's corresponding dimension
+     * @param columnName  Physical column name backing dimension
+     */
+    protected DimensionColumn(@NotNull Dimension dimension, @NotNull String columnName) {
+        super(columnName);
         this.dimension = dimension;
     }
 
@@ -32,15 +42,17 @@ public class DimensionColumn extends Column {
     }
 
     /**
-     * Method to create a DimensionColumn tied to a PhysicalTable.
+     * Method to create a DimensionColumn tied to a schema.
      *
-     * @param physicalTable  Physical table associated with dimension column
+     * @param schema  The schema to which the column needs to be added
      * @param d  The dimension the column encapsulates
      *
      * @return The dimension column created
      */
-    public static DimensionColumn addNewDimensionColumn(PhysicalTable physicalTable, Dimension d) {
-        return addNewDimensionColumn(physicalTable, d, physicalTable);
+    public static DimensionColumn addNewDimensionColumn(Schema schema, Dimension d) {
+        DimensionColumn col = new DimensionColumn(d);
+        schema.addColumn(col);
+        return col;
     }
 
     /**
@@ -51,9 +63,12 @@ public class DimensionColumn extends Column {
      * @param physicalTable  Physical table associated with dimension column
      *
      * @return The dimension column created
+     *
+     * @deprecated in favor of addNewDimensionColumn(Schema, Dimension) which stores api name instead of physical name
      */
+    @Deprecated
     public static DimensionColumn addNewDimensionColumn(Schema schema, Dimension d, PhysicalTable physicalTable) {
-        DimensionColumn col = new DimensionColumn(d, d.getApiName());
+        DimensionColumn col = new DimensionColumn(d, physicalTable.getPhysicalColumnName(d.getApiName()));
         schema.addColumn(col);
         return col;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
@@ -53,7 +53,7 @@ public class DimensionColumn extends Column {
      * @return The dimension column created
      */
     public static DimensionColumn addNewDimensionColumn(Schema schema, Dimension d, PhysicalTable physicalTable) {
-        DimensionColumn col = new DimensionColumn(d, physicalTable.getPhysicalColumnName(d.getApiName()));
+        DimensionColumn col = new DimensionColumn(d, d.getApiName());
         schema.addColumn(col);
         return col;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
@@ -17,7 +17,7 @@ public class DimensionColumn extends Column {
 
     /**
      * Constructor.
-     * Uses dimension api name for column name.
+     * Uses the given dimension's api name for column name.
      *
      * @param dimension  The column's corresponding dimension
      */
@@ -27,10 +27,10 @@ public class DimensionColumn extends Column {
 
     /**
      * Constructor.
-     * Uses the given name as  for column name.
+     * Uses the given columnName for column name.
      *
      * @param dimension  The column's corresponding dimension
-     * @param columnName  Physical column name backing dimension
+     * @param columnName  Column name backing dimension
      */
     protected DimensionColumn(@NotNull Dimension dimension, @NotNull String columnName) {
         super(columnName);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
@@ -21,7 +21,7 @@ public class DimensionColumn extends Column {
      *
      * @param dimension  The column's corresponding dimension
      */
-    public DimensionColumn(@NotNull Dimension dimension) {
+    protected DimensionColumn(@NotNull Dimension dimension) {
         this(dimension, dimension.getApiName());
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/LogicalDimensionColumn.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/LogicalDimensionColumn.java
@@ -4,7 +4,10 @@ package com.yahoo.bard.webservice.data.dimension;
 
 /**
  * A LogicalDimensionColumn defines a dimension column that is not tied to any particular physical table.
+ *
+ * @deprecated in favor of DimensionColumn which stores name as api name now
  */
+@Deprecated
 public class LogicalDimensionColumn extends DimensionColumn {
     /**
      * Constructor.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -54,8 +53,8 @@ public class PhysicalTable extends Table {
     ) {
         super(name, timeGrain);
         this.availableIntervalsRef = new AtomicReference<>();
-        availableIntervalsRef.set(new HashMap<>());
-        this.workingIntervals = Collections.synchronizedMap(new HashMap<>());
+        availableIntervalsRef.set(new LinkedHashMap<>());
+        this.workingIntervals = Collections.synchronizedMap(new LinkedHashMap<>());
         this.logicalToPhysicalColumnNames = Collections.unmodifiableMap(logicalToPhysicalColumnNames);
         this.physicalToLogicalColumnNames = Collections.unmodifiableMap(
                 this.logicalToPhysicalColumnNames.entrySet().stream().collect(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/AggregatableDimensionsMatcher.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/AggregatableDimensionsMatcher.java
@@ -43,7 +43,7 @@ public class AggregatableDimensionsMatcher implements PhysicalTableMatcher {
 
     @Override
     public boolean test(PhysicalTable table) {
-        Set<String> columnNames = TableUtils.getColumnNames(request, query.getInnermostQuery(), table);
+        Set<String> columnNames = TableUtils.getColumnNames(request, query.getInnermostQuery());
 
         return table.getDimensions().stream()
                 .filter(StreamUtils.not(Dimension::isAggregatable))

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/AggregatableDimensionsMatcher.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/AggregatableDimensionsMatcher.java
@@ -45,10 +45,10 @@ public class AggregatableDimensionsMatcher implements PhysicalTableMatcher {
     public boolean test(PhysicalTable table) {
         Set<String> columnNames = TableUtils.getColumnNames(request, query.getInnermostQuery());
 
+        // If table contains non-agg dimensions, query must contain all these non-agg dimensions to use this table.
         return table.getDimensions().stream()
                 .filter(StreamUtils.not(Dimension::isAggregatable))
                 .map(Dimension::getApiName)
-                .map(table::getPhysicalColumnName)
                 .allMatch(columnNames::contains);
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/AggregatableDimensionsMatcher.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/AggregatableDimensionsMatcher.java
@@ -19,7 +19,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- *  Use the granularity and columns of a query to determine whether or not tables can satisfy this query.
+ * Use the granularity and columns of a query to determine whether or not tables can satisfy this query.
+ * <p>
+ * If a given table contains non-agg dimensions, query must contain all these non-agg dimensions to use this table.
  */
 public class AggregatableDimensionsMatcher implements PhysicalTableMatcher {
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcher.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcher.java
@@ -57,7 +57,7 @@ public class SchemaPhysicalTableMatcher implements PhysicalTableMatcher {
                 .map(Column::getName)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        Set<String> columnNames = TableUtils.getColumnNames(request, query.getInnermostQuery(), table);
+        Set<String> columnNames = TableUtils.getColumnNames(request, query.getInnermostQuery());
 
         return supplyNames.containsAll(columnNames);
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/VolatileTimeComparator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/VolatileTimeComparator.java
@@ -100,7 +100,7 @@ public class VolatileTimeComparator implements Comparator<PhysicalTable> {
         //Next find the intervals on the physical table that are available.
         SimplifiedIntervalList tableAvailability = partialDataHandler.getAvailability(
                 table,
-                TableUtils.getColumnNames(apiRequest, query, table)
+                TableUtils.getColumnNames(apiRequest, query)
         );
         //Take the duration of their intersection.
         return IntervalUtils.getTotalDuration(tableAvailability.intersect(volatilePartialRequestIntervals));

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
@@ -36,8 +36,7 @@ public class TableUtils {
     ) {
         return Stream.<Stream<String>>of(
                 getDimensions(request, query)
-                        .map(Dimension::getApiName)
-                        .map(table::getPhysicalColumnName),
+                        .map(Dimension::getApiName),
                 query.getDependentFieldNames().stream()
         ).flatMap(Function.identity()).collect(Collectors.toSet());
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
@@ -46,12 +46,12 @@ public class TableUtils {
     }
 
     /**
-     * Get the table column names from the dimensions and metrics.
+     * Get the schema column names from the dimensions and metrics.
      *
      * @param request  A request which supplies grouping dimensions and filtering dimensions
      * @param query  A query model which has metric column and possibly dimension column names
      *
-     * @return a set of strings representing table column names
+     * @return a set of strings representing schema column names
      */
     public static Set<String> getColumnNames(DataApiRequest request, DruidAggregationQuery<?> query) {
         return Stream.of(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
@@ -37,7 +37,7 @@ public class TableUtils {
             DruidAggregationQuery<?> query,
             PhysicalTable table
     ) {
-        return Stream.<Stream<String>>of(
+        return Stream.of(
                 getDimensions(request, query)
                         .map(Dimension::getApiName)
                         .map(table::getPhysicalColumnName),
@@ -53,13 +53,9 @@ public class TableUtils {
      *
      * @return a set of strings representing table column names
      */
-    public static Set<String> getColumnNames(
-            DataApiRequest request,
-            DruidAggregationQuery<?> query
-    ) {
-        return Stream.<Stream<String>>of(
-                getDimensions(request, query)
-                        .map(Dimension::getApiName),
+    public static Set<String> getColumnNames(DataApiRequest request, DruidAggregationQuery<?> query) {
+        return Stream.of(
+                getDimensions(request, query).map(Dimension::getApiName),
                 query.getDependentFieldNames().stream()
         ).flatMap(Function.identity()).collect(Collectors.toSet());
     }
@@ -73,7 +69,7 @@ public class TableUtils {
      * @return a set of strings representing fact store column names
      */
     public static Stream<Dimension> getDimensions(DataApiRequest request, DruidAggregationQuery<?> query) {
-        return Stream.<Stream<Dimension>>of(
+        return Stream.of(
                 request.getDimensions().stream(),
                 request.getFilterDimensions().stream(),
                 query.getMetricDimensions().stream()

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
@@ -28,11 +28,34 @@ public class TableUtils {
      * @param table  Physical table used in resolving dimension names
      *
      * @return a set of strings representing fact store column names
+     *
+     * @deprecated in favor of getColumnNames(DataApiRequest, DruidAggregationQuery) returning dimension api name
      */
+    @Deprecated
     public static Set<String> getColumnNames(
             DataApiRequest request,
             DruidAggregationQuery<?> query,
             PhysicalTable table
+    ) {
+        return Stream.<Stream<String>>of(
+                getDimensions(request, query)
+                        .map(Dimension::getApiName)
+                        .map(table::getPhysicalColumnName),
+                query.getDependentFieldNames().stream()
+        ).flatMap(Function.identity()).collect(Collectors.toSet());
+    }
+
+    /**
+     * Get the table column names from the dimensions and metrics.
+     *
+     * @param request  A request which supplies grouping dimensions and filtering dimensions
+     * @param query  A query model which has metric column and possibly dimension column names
+     *
+     * @return a set of strings representing table column names
+     */
+    public static Set<String> getColumnNames(
+            DataApiRequest request,
+            DruidAggregationQuery<?> query
     ) {
         return Stream.<Stream<String>>of(
                 getDimensions(request, query)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/TableUtils.java
@@ -54,10 +54,10 @@ public class TableUtils {
      * @return a set of strings representing schema column names
      */
     public static Set<String> getColumnNames(DataApiRequest request, DruidAggregationQuery<?> query) {
-        return Stream.of(
+        return Stream.concat(
                 getDimensions(request, query).map(Dimension::getApiName),
                 query.getDependentFieldNames().stream()
-        ).flatMap(Function.identity()).collect(Collectors.toSet());
+        ).collect(Collectors.toSet());
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
@@ -11,8 +11,8 @@ import com.yahoo.bard.webservice.data.DruidResponseParser;
 import com.yahoo.bard.webservice.data.HttpResponseMaker;
 import com.yahoo.bard.webservice.data.ResultSet;
 import com.yahoo.bard.webservice.data.dimension.Dimension;
+import com.yahoo.bard.webservice.data.dimension.DimensionColumn;
 import com.yahoo.bard.webservice.data.dimension.DimensionField;
-import com.yahoo.bard.webservice.data.dimension.LogicalDimensionColumn;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.druid.client.FailureCallback;
@@ -159,7 +159,7 @@ public class ResultSetResponseProcessor extends MappingResponseProcessor impleme
         }
 
         for (Dimension dimension : druidQuery.getDimensions()) {
-            resultSetSchema.addColumn(new LogicalDimensionColumn(dimension));
+            resultSetSchema.addColumn(new DimensionColumn(dimension));
         }
 
         return druidResponseParser.parse(json, resultSetSchema, druidQuery.getQueryType());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
@@ -159,7 +159,7 @@ public class ResultSetResponseProcessor extends MappingResponseProcessor impleme
         }
 
         for (Dimension dimension : druidQuery.getDimensions()) {
-            resultSetSchema.addColumn(new DimensionColumn(dimension));
+            DimensionColumn.addNewDimensionColumn(resultSetSchema, dimension);
         }
 
         return druidResponseParser.parse(json, resultSetSchema, druidQuery.getQueryType());

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidResponseParserSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidResponseParserSpec.groovy
@@ -174,7 +174,7 @@ class DruidResponseParserSpec extends Specification {
 
         /* build Schema */
         ZonedSchema schema = new ZonedSchema(DAY, DateTimeZone.UTC)
-        DimensionColumn.addNewDimensionColumn(schema, dimensionDictionary.findByApiName("ageBracket"), new PhysicalTable("null", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
+        DimensionColumn.addNewDimensionColumn(schema, dimensionDictionary.findByApiName("ageBracket"))
         MetricColumn.addNewMetricColumn(schema, "pageViews")
         ResultSet resultSet = new DruidResponseParser().parse(jsonResult, schema, DefaultQueryType.TOP_N)
 
@@ -442,9 +442,9 @@ class DruidResponseParserSpec extends Specification {
 
     ZonedSchema buildSchema(List<String> metricNames) {
         Schema schema = new ZonedSchema(DAY, DateTimeZone.UTC)
-        DimensionColumn.addNewDimensionColumn(schema, dimensionDictionary.findByApiName("ageBracket"), new PhysicalTable("null", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
-        DimensionColumn.addNewDimensionColumn(schema, dimensionDictionary.findByApiName("gender"), new PhysicalTable("null", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
-        DimensionColumn.addNewDimensionColumn(schema, dimensionDictionary.findByApiName("unknown"), new PhysicalTable("null", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
+        DimensionColumn.addNewDimensionColumn(schema, dimensionDictionary.findByApiName("ageBracket"))
+        DimensionColumn.addNewDimensionColumn(schema, dimensionDictionary.findByApiName("gender"))
+        DimensionColumn.addNewDimensionColumn(schema, dimensionDictionary.findByApiName("unknown"))
         metricNames.each {
             MetricColumn.addNewMetricColumn(schema, it)
         }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
@@ -48,7 +48,7 @@ class PartialDataHandlerSpec extends Specification {
     }
 
     def setup() {
-        columnNames = ["user_device_type", "property", "os",  "page_views"] as Set
+        columnNames = ["userDeviceType", "property", "os",  "page_views"] as Set
 
         // Setup mock dimensions
         dim1 = Mock(KeyValueStoreDimension.class)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
@@ -156,7 +156,7 @@ public class QueryBuildingTestingResources {
         )
         d7 = new KeyValueStoreDimension(
                 "dim7",
-                "dim7",
+                "dim_7",
                 dimensionFields,
                 MapStoreManager.getInstance("dim7"),
                 ScanSearchProviderManager.getInstance("dim7"),
@@ -193,8 +193,8 @@ public class QueryBuildingTestingResources {
 
         tna1236d = new PhysicalTable("tableNA1236", utcDay, ["ageBracket":"age_bracket"])
         tna1237d = new PhysicalTable("tableNA1237", utcDay, ["ageBracket":"age_bracket"])
-        tna167d = new PhysicalTable("tableNA167", utcDay, ["ageBracket":"age_bracket"])
-        tna267d = new PhysicalTable("tableNA267", utcDay, new HashMap<>())
+        tna167d = new PhysicalTable("tableNA167", utcDay, ["ageBracket":"age_bracket", "dim7":"dim_7"])
+        tna267d = new PhysicalTable("tableNA267", utcDay, ["dim7":"dim_7"])
 
         t4h1 = new PhysicalTable("table4h1", utcHour, new HashMap<>())
         t4h2 = new PhysicalTable("table4h2", utcHour, new HashMap<>())

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/SerializationResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/SerializationResources.groovy
@@ -3,10 +3,10 @@
 package com.yahoo.bard.webservice.data
 import com.yahoo.bard.webservice.data.dimension.BardDimensionField
 import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.data.dimension.DimensionColumn
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.data.dimension.DimensionField
 import com.yahoo.bard.webservice.data.dimension.DimensionRow
-import com.yahoo.bard.webservice.data.dimension.LogicalDimensionColumn
 import com.yahoo.bard.webservice.data.dimension.MapStoreManager
 import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
 import com.yahoo.bard.webservice.data.dimension.impl.ScanSearchProviderManager
@@ -70,11 +70,11 @@ class SerializationResources extends Specification {
         Dimension ageBracketDim =  dimensionDictionary.findByApiName("ageBracket")
 
         DimensionRow ageBracketRow1 = BardDimensionField.makeDimensionRow(ageBracketDim, "1", "1")
-        dimensionRows1.put(new LogicalDimensionColumn(ageBracketDim), ageBracketRow1)
+        dimensionRows1.put(new DimensionColumn(ageBracketDim), ageBracketRow1)
         ageBracketDim.addDimensionRow(ageBracketRow1)
 
         DimensionRow ageBracketRow2 = BardDimensionField.makeDimensionRow(ageBracketDim, "4", "4")
-        dimensionRows2.put(new LogicalDimensionColumn(ageBracketDim), ageBracketRow2)
+        dimensionRows2.put(new DimensionColumn(ageBracketDim), ageBracketRow2)
         ageBracketDim.addDimensionRow(ageBracketRow2)
 
 
@@ -82,11 +82,11 @@ class SerializationResources extends Specification {
         Dimension genderDim = dimensionDictionary.findByApiName("gender")
 
         DimensionRow gendeRow1 = BardDimensionField.makeDimensionRow(genderDim, "m", "m")
-        dimensionRows1.put(new LogicalDimensionColumn(genderDim), gendeRow1)
+        dimensionRows1.put(new DimensionColumn(genderDim), gendeRow1)
         genderDim.addDimensionRow(gendeRow1)
 
         DimensionRow gendeRow2 = BardDimensionField.makeDimensionRow(genderDim, "f", "f")
-        dimensionRows2.put(new LogicalDimensionColumn(genderDim), gendeRow2)
+        dimensionRows2.put(new DimensionColumn(genderDim), gendeRow2)
         genderDim.addDimensionRow(gendeRow2)
 
 
@@ -94,11 +94,11 @@ class SerializationResources extends Specification {
         Dimension countryDim = dimensionDictionary.findByApiName("country")
 
         DimensionRow countyRow1 = BardDimensionField.makeDimensionRow(countryDim, "US", "US")
-        dimensionRows1.put(new LogicalDimensionColumn(countryDim), countyRow1)
+        dimensionRows1.put(new DimensionColumn(countryDim), countyRow1)
         countryDim.addDimensionRow(countyRow1)
 
         DimensionRow countyRow2 = BardDimensionField.makeDimensionRow(countryDim, "IN", "IN")
-        dimensionRows2.put(new LogicalDimensionColumn(countryDim), countyRow2)
+        dimensionRows2.put(new DimensionColumn(countryDim), countyRow2)
         countryDim.addDimensionRow(countyRow2)
 
         metricValues1 = new HashMap()
@@ -167,9 +167,9 @@ class SerializationResources extends Specification {
 
     ZonedSchema buildSchema(Map<String, String> metricNameClassNames) {
         Schema schema = new ZonedSchema(granularity, DateTimeZone.UTC)
-        schema.addColumn(new LogicalDimensionColumn(dimensionDictionary.findByApiName("ageBracket")))
-        schema.addColumn(new LogicalDimensionColumn(dimensionDictionary.findByApiName("gender")))
-        schema.addColumn(new LogicalDimensionColumn(dimensionDictionary.findByApiName("country")))
+        schema.addColumn(new DimensionColumn(dimensionDictionary.findByApiName("ageBracket")))
+        schema.addColumn(new DimensionColumn(dimensionDictionary.findByApiName("gender")))
+        schema.addColumn(new DimensionColumn(dimensionDictionary.findByApiName("country")))
         metricNameClassNames.each {
              schema.addColumn(new MetricColumnWithValueType(it.key, it.value))
         }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/metric/mappers/NoOpResultSetMapperSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/metric/mappers/NoOpResultSetMapperSpec.groovy
@@ -30,7 +30,7 @@ class NoOpResultSetMapperSpec extends Specification {
         dimensionFields.add(BardDimensionField.DESC)
 
         Map<DimensionColumn, DimensionRow> dimensionRows1 = ["dimName1", "dimName2"].collectEntries {
-            DimensionColumn dc = new DimensionColumn(new KeyValueStoreDimension(it, it, dimensionFields, MapStoreManager.getInstance(it), ScanSearchProviderManager.getInstance(it)), it)
+            DimensionColumn dc = new DimensionColumn(new KeyValueStoreDimension(it, it, dimensionFields, MapStoreManager.getInstance(it), ScanSearchProviderManager.getInstance(it)))
             DimensionRow dr = BardDimensionField.makeDimensionRow(dc.dimension, ""+it+"-id", ""+it+"-desc")
             [(dc) : dr]
         }
@@ -43,7 +43,7 @@ class NoOpResultSetMapperSpec extends Specification {
         Result rs1 = new Result(dimensionRows1, metricValues1, DateTime.now())
 
         Map<DimensionColumn, DimensionRow> dimensionRows2 = ["dimName3", "dimName4"].collectEntries {
-            DimensionColumn dc = new DimensionColumn(new KeyValueStoreDimension(it, it, dimensionFields, MapStoreManager.getInstance(it), ScanSearchProviderManager.getInstance(it)), it)
+            DimensionColumn dc = new DimensionColumn(new KeyValueStoreDimension(it, it, dimensionFields, MapStoreManager.getInstance(it), ScanSearchProviderManager.getInstance(it)))
             DimensionRow dr = BardDimensionField.makeDimensionRow(dc.dimension, ""+it+"-id", ""+it+"-desc")
             [(dc) : dr]
         }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/metric/mappers/RowNumMapperSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/metric/mappers/RowNumMapperSpec.groovy
@@ -53,8 +53,8 @@ class RowNumMapperSpec extends Specification {
         Dimension d2 = new KeyValueStoreDimension("d2", "d2-desc", dimensionFields, MapStoreManager.getInstance("d2"), ScanSearchProviderManager.getInstance("d2"))
 
         // Add dimension columns to the dummy schema created earlier
-        DimensionColumn dc1 = DimensionColumn.addNewDimensionColumn(schema, d1, new PhysicalTable("abc", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
-        DimensionColumn dc2 = DimensionColumn.addNewDimensionColumn(schema, d2, new PhysicalTable("abc", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
+        DimensionColumn dc1 = DimensionColumn.addNewDimensionColumn(schema, d1)
+        DimensionColumn dc2 = DimensionColumn.addNewDimensionColumn(schema, d2)
 
         // Create dummy DimensionRow's
         DimensionRow dr1 = BardDimensionField.makeDimensionRow(d1, "id1", "desc1")

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/FilteredAggregationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/FilteredAggregationSpec.groovy
@@ -73,15 +73,15 @@ class FilteredAggregationSpec extends Specification{
 
         PhysicalTable physicalTable = new PhysicalTable("NETWORK", DAY.buildZonedTimeGrain(UTC), [:])
 
-        physicalTable.addColumn(new DimensionColumn(ageDimension, physicalTable.getPhysicalColumnName(ageDimension.getApiName())))
-        physicalTable.addColumn(new DimensionColumn(ageDimension, physicalTable.getPhysicalColumnName(ageDimension.getApiName())))
+        physicalTable.addColumn(new DimensionColumn(ageDimension))
+        physicalTable.addColumn(new DimensionColumn(ageDimension))
         metricNames.each {physicalTable.addColumn(new MetricColumn(it))}
         physicalTable.commit()
 
         TableGroup tableGroup = new TableGroup([physicalTable] as LinkedHashSet, metricNames)
         LogicalTable table = new LogicalTable("NETWORK_DAY", DAY, tableGroup)
         tableGroup.dimensions.each {
-            DimensionColumn.addNewDimensionColumn(table, it, physicalTable)
+            DimensionColumn.addNewDimensionColumn(table, it)
         }
 
         SketchCountMaker sketchCountMaker = new SketchCountMaker(new MetricDictionary(), 16384)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoaderSpec.groovy
@@ -169,7 +169,7 @@ class DataSourceMetadataLoaderSpec extends Specification {
 
         expectedIntervalsMap = [:]
         dimensions123.each {
-            expectedIntervalsMap.put(new DimensionColumn(dimensionDict.findByApiName(it), it), [interval123] as Set)
+            expectedIntervalsMap.put(new DimensionColumn(dimensionDict.findByApiName(it)), [interval123] as Set)
         }
         metrics123.each { expectedIntervalsMap.put(new MetricColumn(it), [interval123] as Set) }
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PhysicalTableSpec.groovy
@@ -44,7 +44,7 @@ class PhysicalTableSpec extends Specification {
         dimension = new KeyValueStoreDimension("dimension", null, [BardDimensionField.ID] as LinkedHashSet, MapStoreManager.getInstance("dimension"), ScanSearchProviderManager.getInstance("apiProduct"))
         dimensionDictionary = new DimensionDictionary([dimension] as Set)
 
-        dimensionColumn = new DimensionColumn(dimension, dimension.getApiName())
+        dimensionColumn = new DimensionColumn(dimension)
 
         metricColumn1 = new MetricColumn("metric1")
         metricColumn2 = new MetricColumn("metric2")

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PhysicalTableSpec.groovy
@@ -44,7 +44,7 @@ class PhysicalTableSpec extends Specification {
         dimension = new KeyValueStoreDimension("dimension", null, [BardDimensionField.ID] as LinkedHashSet, MapStoreManager.getInstance("dimension"), ScanSearchProviderManager.getInstance("apiProduct"))
         dimensionDictionary = new DimensionDictionary([dimension] as Set)
 
-        dimensionColumn = new DimensionColumn(dimension, physicalTable.getPhysicalColumnName(dimension.getApiName()))
+        dimensionColumn = new DimensionColumn(dimension, dimension.getApiName())
 
         metricColumn1 = new MetricColumn("metric1")
         metricColumn2 = new MetricColumn("metric2")

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/TableUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/TableUtilsSpec.groovy
@@ -50,11 +50,6 @@ class TableUtilsSpec extends  Specification {
         metric3 = "m3"
     }
 
-    def setup() {
-        query.getDataSource() >> new TableDataSource(new PhysicalTable("table_name", DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
-    }
-
-
     @Unroll
     def "With #requestDimensions, #filterDimensions, #metricFilterDimensions dimension names are: #expected  "() {
         setup:
@@ -65,7 +60,7 @@ class TableUtilsSpec extends  Specification {
         expected = expected as Set
 
         expect:
-        TableUtils.getColumnNames(request, query, new PhysicalTable("", DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:])) == expected
+        TableUtils.getColumnNames(request, query) == expected
 
         where:
         requestDimensions | filterDimensions | metricFilterDimensions | expected
@@ -87,19 +82,6 @@ class TableUtilsSpec extends  Specification {
         query.dependentFieldNames >> ([metric1, metric2, metric3] as Set)
 
         expect:
-        TableUtils.getColumnNames(request, query, new PhysicalTable("", DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:])) == [d1Name, metric1, metric2, metric3] as Set
-    }
-
-    def "logicalName to physicalName mapping not required for metrics" () {
-        setup:
-        request.dimensions >> []
-        request.filterDimensions >> []
-        query.metricDimensions >> []
-        query.dependentFieldNames >> ([metric1] as Set)
-        PhysicalTable physicalTable = Mock(PhysicalTable)
-        0 * physicalTable.getPhysicalColumnName(_)
-
-        expect:
-        TableUtils.getColumnNames(request, query, physicalTable) == [metric1] as Set
+        TableUtils.getColumnNames(request, query) == [d1Name, metric1, metric2, metric3] as Set
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/TableUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/TableUtilsSpec.groovy
@@ -84,4 +84,15 @@ class TableUtilsSpec extends  Specification {
         expect:
         TableUtils.getColumnNames(request, query) == [d1Name, metric1, metric2, metric3] as Set
     }
+
+    def "metric name correctly is correctly represented as logicalName" () {
+        setup:
+        request.dimensions >> []
+        request.filterDimensions >> []
+        query.metricDimensions >> []
+        query.dependentFieldNames >> ([metric1] as Set)
+
+        expect:
+        TableUtils.getColumnNames(request, query) == [metric1] as Set
+    }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/AggregatabilityValidationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/AggregatabilityValidationSpec.groovy
@@ -73,7 +73,7 @@ class AggregatabilityValidationSpec extends Specification {
         tg.getDimensions() >> dimensionDict.apiNameToDimension.values()
         table = new LogicalTable("name", DAY, tg)
         dimensionDict.apiNameToDimension.values().each {
-            DimensionColumn.addNewDimensionColumn(table, it, new PhysicalTable("abc", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
+            DimensionColumn.addNewDimensionColumn(table, it)
         }
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestFilterSpec.groovy
@@ -62,7 +62,7 @@ class DataApiRequestFilterSpec extends Specification {
         tg.getDimensions() >> dimensionDict.apiNameToDimension.values()
         table = new LogicalTable("name", DAY, tg)
         dimensionDict.apiNameToDimension.values().each {
-            DimensionColumn.addNewDimensionColumn(table, it, new PhysicalTable("abc", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
+            DimensionColumn.addNewDimensionColumn(table, it)
         }
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestIntervalsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestIntervalsSpec.groovy
@@ -78,7 +78,7 @@ class DataApiRequestIntervalsSpec extends Specification {
         tg.getDimensions() >> dimensionDict.apiNameToDimension.values()
         table = new LogicalTable("name", DAY, tg)
         dimensionDict.apiNameToDimension.values().each {
-            DimensionColumn.addNewDimensionColumn(table, it, new PhysicalTable("abc", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
+            DimensionColumn.addNewDimensionColumn(table, it)
         }
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestSpec.groovy
@@ -85,7 +85,7 @@ class DataApiRequestSpec extends Specification {
         tg.getDimensions() >> dimensionDict.apiNameToDimension.values()
         table = new LogicalTable("name", DAY, tg)
         dimensionDict.apiNameToDimension.values().each {
-            DimensionColumn.addNewDimensionColumn(table, it, new PhysicalTable("abc", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
+            DimensionColumn.addNewDimensionColumn(table, it)
         }
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/IntersectionReportingFlagOffSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/IntersectionReportingFlagOffSpec.groovy
@@ -51,7 +51,7 @@ class IntersectionReportingFlagOffSpec extends Specification {
         tg.getDimensions() >> dimensionDict.apiNameToDimension.values()
         table = new LogicalTable("name", DAY, tg)
         dimensionDict.apiNameToDimension.values().each {
-            DimensionColumn.addNewDimensionColumn(table, it, new PhysicalTable("abc", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
+            DimensionColumn.addNewDimensionColumn(table, it)
         }
 
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ResponseSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ResponseSpec.groovy
@@ -221,7 +221,7 @@ class ResponseSpec extends Specification {
                 ScanSearchProviderManager.getInstance("product")
         )
         dim1.setLastUpdated(null)
-        dimensionColumns << new DimensionColumn(dim1, dim1.getApiName())
+        dimensionColumns << new DimensionColumn(dim1)
 
         Dimension dim2 = new KeyValueStoreDimension(
                 "platform",
@@ -231,7 +231,7 @@ class ResponseSpec extends Specification {
                 ScanSearchProviderManager.getInstance("platform")
         )
         dim2.setLastUpdated(null)
-        dimensionColumns << new DimensionColumn(dim2, dim2.getApiName())
+        dimensionColumns << new DimensionColumn(dim2)
 
         Dimension dim3 = new KeyValueStoreDimension(
                 "property",
@@ -241,7 +241,7 @@ class ResponseSpec extends Specification {
                 ScanSearchProviderManager.getInstance("property")
         )
         dim3.setLastUpdated(null)
-        dimensionColumns << new DimensionColumn(dim3, dim3.getApiName())
+        dimensionColumns << new DimensionColumn(dim3)
 
         def schema = Mock(Schema)
         schema.getColumns(_) >> { Class cls ->

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
@@ -122,7 +122,7 @@ class SketchIntersectionReportingResources extends Specification {
         table = new LogicalTable("NETWORK", DAY, tableGroup)
 
         for (Dimension dim : tableGroup.getDimensions()) {
-            DimensionColumn.addNewDimensionColumn(table, dim, physicalTable)
+            DimensionColumn.addNewDimensionColumn(table, dim)
         }
 
         metricDict = new MetricDictionary()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/TableFullViewProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/TableFullViewProcessorSpec.groovy
@@ -68,7 +68,7 @@ class TableFullViewProcessorSpec extends Specification {
     def "Check table meta data info at grain level"() {
 
         setup:
-        String expectedResponse = "[description:The pets all grain, dimensions:[[category:General, name:sex, longName:sex, uri:http://localhost:9998/v1/sex, cardinality:0], [category:General, name:species, longName:species, uri:http://localhost:9998/v1/species, cardinality:0], [category:General, name:breed, longName:breed, uri:http://localhost:9998/v1/breed, cardinality:0]], longName:All, metrics:[[category:General, name:rowNum, longName:rowNum, uri:http://localhost:9998/v1/rowNum], [category:General, name:limbs, longName:limbs, uri:http://localhost:9998/v1/limbs], [category:General, name:dayAvgLimbs, longName:dayAvgLimbs, uri:http://localhost:9998/v1/dayAvgLimbs]], name:all, retention:P1Y]"
+        String expectedResponse = "[description:The pets all grain, dimensions:[[category:General, name:species, longName:species, uri:http://localhost:9998/v1/species, cardinality:0], [category:General, name:sex, longName:sex, uri:http://localhost:9998/v1/sex, cardinality:0], [category:General, name:breed, longName:breed, uri:http://localhost:9998/v1/breed, cardinality:0]], longName:All, metrics:[[category:General, name:rowNum, longName:rowNum, uri:http://localhost:9998/v1/rowNum], [category:General, name:limbs, longName:limbs, uri:http://localhost:9998/v1/limbs], [category:General, name:dayAvgLimbs, longName:dayAvgLimbs, uri:http://localhost:9998/v1/dayAvgLimbs]], name:all, retention:P1Y]"
         LogicalTable petsTable = petsShapesTables.find {it.getName() == "pets"}
 
         when:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/TableFullViewProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/TableFullViewProcessorSpec.groovy
@@ -68,7 +68,7 @@ class TableFullViewProcessorSpec extends Specification {
     def "Check table meta data info at grain level"() {
 
         setup:
-        String expectedResponse = "[description:The pets all grain, dimensions:[[category:General, name:species, longName:species, uri:http://localhost:9998/v1/species, cardinality:0], [category:General, name:sex, longName:sex, uri:http://localhost:9998/v1/sex, cardinality:0], [category:General, name:breed, longName:breed, uri:http://localhost:9998/v1/breed, cardinality:0]], longName:All, metrics:[[category:General, name:rowNum, longName:rowNum, uri:http://localhost:9998/v1/rowNum], [category:General, name:limbs, longName:limbs, uri:http://localhost:9998/v1/limbs], [category:General, name:dayAvgLimbs, longName:dayAvgLimbs, uri:http://localhost:9998/v1/dayAvgLimbs]], name:all, retention:P1Y]"
+        String expectedResponse = "[description:The pets all grain, dimensions:[[category:General, name:breed, longName:breed, uri:http://localhost:9998/v1/breed, cardinality:0], [category:General, name:sex, longName:sex, uri:http://localhost:9998/v1/sex, cardinality:0], [category:General, name:species, longName:species, uri:http://localhost:9998/v1/species, cardinality:0]], longName:All, metrics:[[category:General, name:rowNum, longName:rowNum, uri:http://localhost:9998/v1/rowNum], [category:General, name:limbs, longName:limbs, uri:http://localhost:9998/v1/limbs], [category:General, name:dayAvgLimbs, longName:dayAvgLimbs, uri:http://localhost:9998/v1/dayAvgLimbs]], name:all, retention:P1Y]"
         LogicalTable petsTable = petsShapesTables.find {it.getName() == "pets"}
 
         when:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
@@ -118,7 +118,7 @@ class ThetaSketchIntersectionReportingResources extends Specification {
         table = new LogicalTable("NETWORK", DAY, tableGroup)
 
         for (Dimension dim : tableGroup.getDimensions()) {
-            DimensionColumn.addNewDimensionColumn(table, dim, physicalTable)
+            DimensionColumn.addNewDimensionColumn(table, dim)
         }
 
         metricDict = new MetricDictionary()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/UIJsonResponseSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/UIJsonResponseSpec.groovy
@@ -66,7 +66,7 @@ class UIJsonResponseSpec extends Specification {
                 [] as Set
         )
         newDimension.setLastUpdated(timeStamp)
-        DimensionColumn dimensionColumn = DimensionColumn.addNewDimensionColumn(newSchema, newDimension, new PhysicalTable("abc", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [:]))
+        DimensionColumn dimensionColumn = DimensionColumn.addNewDimensionColumn(newSchema, newDimension)
         MetricColumn metricColumn1 = MetricColumn.addNewMetricColumn(newSchema, "metricColumn1Name")
         MetricColumn metricColumn2 = MetricColumn.addNewMetricColumn(newSchema, "metricColumn2Name")
 


### PR DESCRIPTION
* Change `DimensionColumn.java` to use dimension api name instead of physical name as its name
* Modified tests according to the above change