### PR TITLE
Fixes a deadlock in `LuceneSearchProvider`.

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/LuceneSearchProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/LuceneSearchProvider.java
@@ -121,7 +121,7 @@ public class LuceneSearchProvider implements SearchProvider {
      *
      * @param firstTimeThrough  If true, will write an empty index and will then re-open the searcher
      */
-    private synchronized void reopenIndexSearcher(boolean firstTimeThrough) {
+    private void reopenIndexSearcher(boolean firstTimeThrough) {
         lock.writeLock().lock();
         try {
             // Close the current reader if open


### PR DESCRIPTION
-- There is a chance the `LuceneSearchProvider` will deadlock if one thread
is attempting to read a dimension for the first time while
another is attempting to load it:
        - Thread A is pushing in new dimension data. It invokes
                `refreshIndex`, and acquires the write lock.
        - Thread B is reading dimension data. It invokes
                `getResultsPage`, and
                then `initializeIndexSearcher`, then `reopenIndexSearcher`.
                It hits the write lock (acquired by Thread A) and blocks.
        - At the end of its computation of `refreshIndex`, Thread A
                attempts to invoke `reopenIndexSearcher`. However,
                `reopenIndexSearcher` is `synchronized`, and Thread B is
                already invoking it.
        - To fix the resulting deadlock, `reopenIndexSearcher` is no
          longer synchronized. Since threads need to acquire a write lock
          before doing anything else anyway, the method is still effectively
          synchronized.