### PR TITLE
The NoOpResultSetMapper is now O(1).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Current
 
 ### Changed:
 
+- [`NoOpResultSetMapper` now runs in constant time and space.](https://github.com/yahoo/fili/pull/119)
+
 - [Remove restriction for single physical dimension to multiple lookup dimensions](https://github.com/yahoo/fili/pull/112)
     * Modified physical dimension name to logical dimension name mapping into a `Map<String, Set<String>>` instead of `Map<String, String>` in `PhysicalTable.java`
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/NoOpResultSetMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/NoOpResultSetMapper.java
@@ -12,7 +12,7 @@ import com.yahoo.bard.webservice.table.Schema;
 public class NoOpResultSetMapper extends ResultSetMapper implements ColumnMapper {
     @Override
     public ResultSet map(ResultSet resultSet) {
-        return super.map(resultSet);
+        return resultSet;
     }
 
     @Override


### PR DESCRIPTION
--Previously, the `NoOpResultSetMapper` iterated through every result
and did nothing to it before adding it to a new `ResultSet`, resulting
in a no-op that took linear time and space. Now, the `NoOpResultSetMapper`
just returns the original `resultSet` it received, resulting in a
constant space and time no-op.