### PR TITLE
Decouples PhysicalTable name from Druid table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Current
 
 ### Changed:
 
+- [Fili's name for a PhysicalTable is decoupled from the name of the associated table in Druid](https://github.com/yahoo/fili/pull/123)
+
 - [No match found due to schema mismatch now a `500 Internal Server Error` response instead of a `400 Bad Request` response](https://github.com/yahoo/fili/pull/113)
     * This should never be a user fault, since that check is much earlier
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -49,7 +49,7 @@ public abstract class DataSource {
         return Collections.unmodifiableSet(
                 getPhysicalTables()
                         .stream()
-                        .map(PhysicalTable::getName)
+                        .map(PhysicalTable::getDruidName)
                         .collect(Collectors.toSet())
         );
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -49,7 +49,7 @@ public abstract class DataSource {
         return Collections.unmodifiableSet(
                 getPhysicalTables()
                         .stream()
-                        .map(PhysicalTable::getDruidName)
+                        .map(PhysicalTable::getFactTableName)
                         .collect(Collectors.toSet())
         );
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
@@ -25,7 +25,7 @@ public class TableDataSource extends DataSource {
     public TableDataSource(PhysicalTable physicalTable) {
         super(DefaultDataSourceType.TABLE, Collections.singleton(physicalTable));
 
-        this.name = physicalTable.getName();
+        this.name = physicalTable.getDruidName();
     }
 
     public String getName() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
@@ -25,7 +25,7 @@ public class TableDataSource extends DataSource {
     public TableDataSource(PhysicalTable physicalTable) {
         super(DefaultDataSourceType.TABLE, Collections.singleton(physicalTable));
 
-        this.name = physicalTable.getDruidName();
+        this.name = physicalTable.getFactTableName();
     }
 
     public String getName() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoader.java
@@ -110,7 +110,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
      * @param table  The physical table to be updated.
      */
     protected void queryDataSourceMetadata(PhysicalTable table) {
-        String resourcePath = String.format(DATASOURCE_METADATA_QUERY_FORMAT, table.getDruidName());
+        String resourcePath = String.format(DATASOURCE_METADATA_QUERY_FORMAT, table.getFactTableName());
 
         // Success callback will update datasource metadata on success
         SuccessCallback success = buildDataSourceMetadataSuccessCallback(table);
@@ -182,7 +182,10 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
                     DataSourceMetadata dataSourceMetadata = mapper.treeToValue(rootNode, DataSourceMetadata.class);
                     metadataService.update(table, dataSourceMetadata);
                 } catch (IOException e) {
-                    throw new UnsupportedOperationException(DRUID_METADATA_READ_ERROR.format(table.getDruidName()), e);
+                    throw new UnsupportedOperationException(
+                            DRUID_METADATA_READ_ERROR.format(table.getFactTableName()),
+                            e
+                    );
                 }
             }
         };
@@ -229,7 +232,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
             String msg = String.format(
                     "%s: HTTP error while trying to load metadata for table: %s - Status: %d, Cause: %s, Response body: %s",
                     getName(),
-                    table.getDruidName(),
+                    table.getFactTableName(),
                     statusCode,
                     reason,
                     responseBody
@@ -239,7 +242,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
                 LOG.warn(msg);
                 metadataService.update(
                         table,
-                        new DataSourceMetadata(table.getDruidName(), Collections.emptyMap(), Collections.emptyList())
+                        new DataSourceMetadata(table.getFactTableName(), Collections.emptyMap(), Collections.emptyList())
                 );
             } else {
                 LOG.error(msg);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoader.java
@@ -110,7 +110,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
      * @param table  The physical table to be updated.
      */
     protected void queryDataSourceMetadata(PhysicalTable table) {
-        String resourcePath = String.format(DATASOURCE_METADATA_QUERY_FORMAT, table.getName());
+        String resourcePath = String.format(DATASOURCE_METADATA_QUERY_FORMAT, table.getDruidName());
 
         // Success callback will update datasource metadata on success
         SuccessCallback success = buildDataSourceMetadataSuccessCallback(table);
@@ -182,7 +182,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
                     DataSourceMetadata dataSourceMetadata = mapper.treeToValue(rootNode, DataSourceMetadata.class);
                     metadataService.update(table, dataSourceMetadata);
                 } catch (IOException e) {
-                    throw new UnsupportedOperationException(DRUID_METADATA_READ_ERROR.format(table.getName()), e);
+                    throw new UnsupportedOperationException(DRUID_METADATA_READ_ERROR.format(table.getDruidName()), e);
                 }
             }
         };
@@ -229,7 +229,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
             String msg = String.format(
                     "%s: HTTP error while trying to load metadata for table: %s - Status: %d, Cause: %s, Response body: %s",
                     getName(),
-                    table.getName(),
+                    table.getDruidName(),
                     statusCode,
                     reason,
                     responseBody
@@ -239,7 +239,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
                 LOG.warn(msg);
                 metadataService.update(
                         table,
-                        new DataSourceMetadata(table.getName(), Collections.emptyMap(), Collections.emptyList())
+                        new DataSourceMetadata(table.getDruidName(), Collections.emptyMap(), Collections.emptyList())
                 );
             } else {
                 LOG.error(msg);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/SegmentMetadataLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/SegmentMetadataLoader.java
@@ -108,7 +108,7 @@ public class SegmentMetadataLoader extends Loader<Boolean> {
      * @param table  The physical table to be updated.
      */
     protected void querySegmentMetadata(PhysicalTable table) {
-        String resourcePath = String.format(SEGMENT_METADATA_QUERY_FORMAT, table.getName());
+        String resourcePath = String.format(SEGMENT_METADATA_QUERY_FORMAT, table.getDruidName());
 
         // Success callback will update segment metadata on success
         SuccessCallback success = buildSegmentMetadataSuccessCallback(table);
@@ -152,7 +152,7 @@ public class SegmentMetadataLoader extends Loader<Boolean> {
                         mapper.<RawSegmentMetadataConcrete>convertValue(rootNode, typeReference)
                 );
                 if (segmentMetadata.isEmpty()) {
-                    LOG.warn("Empty segment metadata detected when loading table '{}'", table.getName());
+                    LOG.warn("Empty segment metadata detected when loading table '{}'", table.getDruidName());
                 }
                 table.resetColumns(segmentMetadata, dimensionDictionary);
             }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/SegmentMetadataLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/SegmentMetadataLoader.java
@@ -108,7 +108,7 @@ public class SegmentMetadataLoader extends Loader<Boolean> {
      * @param table  The physical table to be updated.
      */
     protected void querySegmentMetadata(PhysicalTable table) {
-        String resourcePath = String.format(SEGMENT_METADATA_QUERY_FORMAT, table.getDruidName());
+        String resourcePath = String.format(SEGMENT_METADATA_QUERY_FORMAT, table.getFactTableName());
 
         // Success callback will update segment metadata on success
         SuccessCallback success = buildSegmentMetadataSuccessCallback(table);
@@ -152,7 +152,7 @@ public class SegmentMetadataLoader extends Loader<Boolean> {
                         mapper.<RawSegmentMetadataConcrete>convertValue(rootNode, typeReference)
                 );
                 if (segmentMetadata.isEmpty()) {
-                    LOG.warn("Empty segment metadata detected when loading table '{}'", table.getDruidName());
+                    LOG.warn("Empty segment metadata detected when loading table '{}'", table.getFactTableName());
                 }
                 table.resetColumns(segmentMetadata, dimensionDictionary);
             }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -38,24 +38,24 @@ public class PhysicalTable extends Table {
     private final Object mutex = new Object();
     private final Map<String, String> logicalToPhysicalColumnNames;
     private final Map<String, Set<String>> physicalToLogicalColumnNames;
-    private final String druidName;
+    private final String factTableName;
 
     /**
      * Create a physical table.
      *
      * @param name  Fili name of the physical table
-     * @param druidName  Name of the associated table in Druid
+     * @param factTableName  Name of the associated table in Druid
      * @param timeGrain  time grain of the table
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
      */
     public PhysicalTable(
             @NotNull String name,
-            @NotNull String druidName,
+            @NotNull String factTableName,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Map<String, String> logicalToPhysicalColumnNames
     ) {
         super(name, timeGrain);
-        this.druidName = druidName;
+        this.factTableName = factTableName;
         this.availableIntervalsRef = new AtomicReference<>();
         availableIntervalsRef.set(new LinkedHashMap<>());
         this.workingIntervals = Collections.synchronizedMap(new LinkedHashMap<>());
@@ -275,12 +275,12 @@ public class PhysicalTable extends Table {
         return getTimeGrain().getPeriod();
     }
 
-    public String getDruidName() {
-        return druidName;
+    public String getFactTableName() {
+        return factTableName;
     }
 
     @Override
     public String toString() {
-        return super.toString() + " druidName: " + druidName + " alignment: " + getTableAlignment();
+        return super.toString() + " factTableName: " + factTableName + " alignment: " + getTableAlignment();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -281,6 +281,6 @@ public class PhysicalTable extends Table {
 
     @Override
     public String toString() {
-        return super.toString() + "druidName: " + druidName + " alignment: " + getTableAlignment();
+        return super.toString() + " druidName: " + druidName + " alignment: " + getTableAlignment();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -38,20 +38,24 @@ public class PhysicalTable extends Table {
     private final Object mutex = new Object();
     private final Map<String, String> logicalToPhysicalColumnNames;
     private final Map<String, Set<String>> physicalToLogicalColumnNames;
+    private final String druidName;
 
     /**
      * Create a physical table.
      *
-     * @param name  name of the physical table
+     * @param name  Fili name of the physical table
+     * @param druidName  Name of the associated table in Druid
      * @param timeGrain  time grain of the table
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
      */
     public PhysicalTable(
             @NotNull String name,
+            @NotNull String druidName,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Map<String, String> logicalToPhysicalColumnNames
     ) {
         super(name, timeGrain);
+        this.druidName = druidName;
         this.availableIntervalsRef = new AtomicReference<>();
         availableIntervalsRef.set(new LinkedHashMap<>());
         this.workingIntervals = Collections.synchronizedMap(new LinkedHashMap<>());
@@ -64,6 +68,21 @@ public class PhysicalTable extends Table {
                         )
                 )
         );
+    }
+
+    /**
+     * Creates a physical table whose Fili and Druid names are the same.
+     *
+     * @param name  Fili name of the physical table
+     * @param timeGrain  time grain of the table
+     * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
+     */
+    public PhysicalTable(
+            @NotNull String name,
+            @NotNull ZonedTimeGrain timeGrain,
+            @NotNull Map<String, String> logicalToPhysicalColumnNames
+    ) {
+        this(name, name, timeGrain, logicalToPhysicalColumnNames);
     }
 
     @Override
@@ -256,8 +275,12 @@ public class PhysicalTable extends Table {
         return getTimeGrain().getPeriod();
     }
 
+    public String getDruidName() {
+        return druidName;
+    }
+
     @Override
     public String toString() {
-        return super.toString() + " alignment: " + getTableAlignment();
+        return super.toString() + "druidName: " + druidName + " alignment: " + getTableAlignment();
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/HasDruidNameSerializerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/HasDruidNameSerializerSpec.groovy
@@ -57,7 +57,7 @@ class HasDruidNameSerializerSpec extends Specification {
         def provider = Mock(SerializerProvider)
         def typeSer = Mock(TypeSerializer)
 
-        and: "value.getDruidName returns a known string"
+        and: "value.getFactTableName returns a known string"
         def knownString = "A Sample String"
         value.getDruidName() >> knownString
 
@@ -67,7 +67,7 @@ class HasDruidNameSerializerSpec extends Specification {
         then: "We've written the type prefix"
         1 * typeSer.writeTypePrefixForScalar(value, jgen)
 
-        and: "We've called regular serialization, writing value.getDruidName()"
+        and: "We've called regular serialization, writing value.getFactTableName()"
         1 * jgen.writeString(knownString)
 
         and: "We've written the type suffix"
@@ -80,14 +80,14 @@ class HasDruidNameSerializerSpec extends Specification {
         def jgen = Mock(JsonGenerator)
         def provider = Mock(SerializerProvider)
 
-        and: "value.getDruidName returns a known string"
+        and: "value.getFactTableName returns a known string"
         def knownString = "A Sample String"
         value.getDruidName() >> knownString
 
         when: "We call serialize"
         HasDruidNameSerializer.INSTANCE.serialize(value, jgen, provider)
 
-        then: "We've written value.getDruidName()"
+        then: "We've written value.getFactTableName()"
         1 * jgen.writeString(knownString)
     }
 


### PR DESCRIPTION
--Previously, the name of a `PhysicalTable` was one and the same as the
name of the associated datasource in Druid. However, this inhibits the
ability of Fili users to make creative use of Physical Tables to model
unusual Druid configurations.

--Therefore, the Fili name of a `PhysicalTable` has been decoupled from
the Druid name. The Fili name (`name`) is used to uniquely identify the
table in Fili, but the Druid name is the name serialized when building a
druid query. It is also the name used when querying Druid for the segment
metadata of a table.