### PR TITLE
Fix `DataSource::getNames`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,8 @@ Current
 
 ### Fixed:
 
+- [`DataSource::getNames` now returns Fili identifiers, not fact store identifiers](https://github.com/yahoo/fili/pull/125/files)
+
 - [Fix and refactor role based filter to allow CORS](https://github.com/yahoo/fili/pull/99)
     * Fix `RoleBasedAuthFilter` to bypass `OPTIONS` request for CORS
     * Discovered a bug where `user_roles` is declared but unset still reads as a list with empty string (included a temporary fix by commenting the variable declaration)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -44,12 +44,17 @@ public abstract class DataSource {
         return physicalTables;
     }
 
+    /**
+     * Returns a set of identifiers used by Fili to identify this data source's physical tables.
+     *
+     * @return The set of names used by Fili to identify this data source's physical tables
+     */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Set<String> getNames() {
         return Collections.unmodifiableSet(
                 getPhysicalTables()
                         .stream()
-                        .map(PhysicalTable::getFactTableName)
+                        .map(PhysicalTable::getName)
                         .collect(Collectors.toSet())
         );
     }


### PR DESCRIPTION
--Currently, `DataSource::getNames` returns the fact names of its
physical tables. However, everywhere `getNames` is used for anything but
logging purposes, the names are resolved against the
`physicalTableDictionary`, which is based on Fili's name of the table,
not Druid's.

--Therefore, `DataSource::getNames` should really be returning the Fili
names, not the fact store names.