### PR TITLE
Initial commit of metric parser.

### DIFF
--- a/fili-metric-parser/README.md
+++ b/fili-metric-parser/README.md
@@ -1,0 +1,1 @@
+Metric grammar and parser for Fili metrics

--- a/fili-metric-parser/pom.xml
+++ b/fili-metric-parser/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
+
+    <artifactId>fili-metric-parser</artifactId>
+    <packaging>jar</packaging>
+    <name>Fili: antlr4 metric parser</name>
+    <description>Metric parsing using antlr4</description>
+
+    <parent>
+        <groupId>com.yahoo.fili</groupId>
+        <artifactId>fili-parent-pom</artifactId>
+        <version>0.7-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.yahoo.fili</groupId>
+            <artifactId>fili</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.yahoo.fili</groupId>
+            <artifactId>fili-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4</artifactId>
+            <version>4.6</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+                <version>4.6</version>
+                <configuration>
+                    <visitor>true</visitor>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>antlr</id>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/fili-metric-parser/src/main/antlr4/com/yahoo/bard/webservice/data/config/metric/antlrparser/FiliMetric.g4
+++ b/fili-metric-parser/src/main/antlr4/com/yahoo/bard/webservice/data/config/metric/antlrparser/FiliMetric.g4
@@ -1,0 +1,98 @@
+// Fili Metric Definition Grammar for antlr4
+//
+// Note: this grammar produces a binary parse tree
+
+grammar FiliMetric;
+
+filiExpression
+    : expression (FILTER filterExp)?
+    ;
+
+//
+// Boolean filter logic
+//
+filterExp
+    : andOrExp
+    | equalExp
+    ;
+
+andOrExp
+    : andOrExp (operator=(AND | OR) andOrArg)
+    | andOrArg (operator=(AND | OR) andOrArg)
+    ;
+
+equalExp
+    : (IDENTIFIER EQ QUOT IDENTIFIER QUOT)
+    | (IDENTIFIER EQ anynum)
+    ;
+
+andOrArg
+    : '(' filterExp ')'
+    | equalExp
+    ;
+
+//
+// Metric definition
+//
+expression
+    : atom
+    | mulDivExpression
+    | plusMinusExpression
+    ;
+
+mulDivExpression
+    : mulDivExpression (operator=(MUL | DIV) atom)
+    | (atom operator=(MUL | DIV) atom)
+    ;
+
+plusMinusExpression
+    : plusMinusExpression (operator=(PLUS | MINUS) plusMinusArg)
+    | plusMinusArg (operator=(PLUS | MINUS) plusMinusArg)
+    ;
+
+plusMinusArg
+    : atom
+    | mulDivExpression
+    ;
+
+atom
+    : anynum
+    | function
+    | IDENTIFIER
+    | '(' expression ')'
+    ;
+
+function
+    : IDENTIFIER '(' param_list ')'
+    | IDENTIFIER '(' ')'               // Note: Not clear that this use case is valid
+    ;
+
+param_list
+    : (expression COMMA)* expression   // Note: Not clear if this should be expression or identifier
+    ;
+
+anynum
+    : (MINUS INTEGER | PLUS INTEGER | INTEGER)
+    | (MINUS DECIMAL | PLUS DECIMAL | DECIMAL)
+    ;
+
+//
+// Lexer types
+//
+PLUS : '+' ;
+MINUS : '-' ;
+MUL : '*' ;
+DIV : '/' ;
+
+FILTER : '|' ;
+AND : '&&' ;
+OR : '||' ;
+EQ : '==' ;
+
+DECIMAL : [0-9]* '.' [0-9]+ ;
+INTEGER : [0-9]+ ;
+IDENTIFIER : [a-zA-Z0-9_]+ ;
+
+WHITESPACE : [ \t\r\n]+ -> skip ;
+COMMA : ',';
+QUOT : '"';

--- a/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliExpressionVisitor.java
+++ b/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliExpressionVisitor.java
@@ -1,0 +1,239 @@
+package com.yahoo.bard.webservice.data.config.metric.parser;
+
+import com.yahoo.bard.webservice.data.config.metric.antlrparser.FiliMetricBaseVisitor;
+import com.yahoo.bard.webservice.data.config.metric.antlrparser.FiliMetricParser;
+import com.yahoo.bard.webservice.data.config.metric.makers.ArithmeticMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.ConstantMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.FilteredAggregationMaker;
+import com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.mappers.NoOpResultSetMapper;
+import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
+import com.yahoo.bard.webservice.druid.model.filter.Filter;
+import com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Antlr visitor for filiExpression grammar rule.
+ */
+public class FiliExpressionVisitor extends FiliMetricBaseVisitor<LogicalMetric> {
+
+    // This is obnoxious. I'm not sure whether
+    // 1) This needs to be static (do these need to be globally unique?)
+    // 2) This needs to exist (is there a better way?)
+    private static long TEMP_IDENTIFIER = 0;
+    private static String TEMP_BASE = "__temp_metric_";
+
+    protected final ParseContext context;
+
+    /**
+     * Construct a new visitor for the 'filiExpression' rule.
+     *
+     * Delegates filter expressions to their own visitor.
+     *
+     * @param context parse context
+     */
+    public FiliExpressionVisitor(ParseContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public LogicalMetric visitFiliExpression(FiliMetricParser.FiliExpressionContext ctx) {
+        LogicalMetric metric = visitExpression(ctx.expression());
+
+        if (ctx.filterExp() != null) {
+            FiliFilterVisitor filterVisitor = new FiliFilterVisitor(context);
+            Filter filter = filterVisitor.visit(ctx.filterExp());
+
+            // I don't think we can have more than one aggregation here.
+            Aggregation aggregation = metric
+                    .getTemplateDruidQuery()
+                    .getAggregations()
+                    .stream()
+                    .findFirst()
+                    .orElseThrow(() -> new RuntimeException(
+                            "Filtered aggregation requires aggregation but could not find one"));
+
+            FilteredAggregationMaker maker = new FilteredAggregationMaker(context.scopedDict, aggregation, filter);
+
+            // FIXME: I don't think dependant metrics are needed as we're wrapping the other metric (not sure).
+            metric = maker.make(getNewName(), Collections.emptyList());
+        }
+
+        // FIXME: this is kind of gross
+        LogicalMetric renamedMetric = new LogicalMetric(
+                metric.getTemplateDruidQuery(),
+                metric.getCalculation(),
+                context.name,
+                metric.getLongName(),
+                metric.getCategory(),
+                metric.getDescription()
+        );
+
+        return renamedMetric;
+    }
+
+    /**
+     * Given left and right sides and antlr operator type, build an arithmetic post agg.
+     *
+     * @param lhs left side parameter
+     * @param rhs right side parameter
+     * @param type antlr4 token type id
+     *
+     * @return arithmetic metric node
+     */
+    public static LogicalMetric buildArithmeticNode(ParseContext ctx, LogicalMetric lhs, LogicalMetric rhs, int type) {
+        ArithmeticPostAggregation.ArithmeticPostAggregationFunction function;
+
+        switch (type) {
+            case FiliMetricParser.PLUS:
+                function = ArithmeticPostAggregation.ArithmeticPostAggregationFunction.PLUS;
+                break;
+            case FiliMetricParser.MINUS:
+                function = ArithmeticPostAggregation.ArithmeticPostAggregationFunction.MINUS;
+                break;
+            case FiliMetricParser.MUL:
+                function = ArithmeticPostAggregation.ArithmeticPostAggregationFunction.MULTIPLY;
+                break;
+            case FiliMetricParser.DIV:
+                function = ArithmeticPostAggregation.ArithmeticPostAggregationFunction.DIVIDE;
+                break;
+            default:
+                throw new RuntimeException("Unknown type: " + type);
+        }
+
+        MetricMaker maker = new ArithmeticMaker(ctx.scopedDict, function, new NoOpResultSetMapper());
+        LogicalMetric result = maker.make(getNewName(), Arrays.asList(lhs.getName(), rhs.getName()));
+        ctx.scopedDict.add(result);
+        return result;
+
+    }
+
+    @Override
+    public LogicalMetric visitPlusMinusExpression(final FiliMetricParser.PlusMinusExpressionContext ctx) {
+        LogicalMetric lhs;
+        LogicalMetric rhs;
+
+        if (ctx.plusMinusExpression() != null) {
+            lhs = visitPlusMinusExpression(ctx.plusMinusExpression());
+            rhs = visitPlusMinusArg(ctx.plusMinusArg(0));
+        } else if (ctx.plusMinusArg(0) != null) {
+            lhs = visitPlusMinusArg(ctx.plusMinusArg(0));
+            rhs = visitPlusMinusArg(ctx.plusMinusArg(1));
+        } else {
+            throw new RuntimeException("error: could not parse");
+        }
+
+        // This returns a logical metric that has been added to the
+        // scopedDict with a new temporary name.
+        return buildArithmeticNode(context, lhs, rhs, ctx.operator.getType());
+    }
+
+    @Override
+    public LogicalMetric visitMulDivExpression(final FiliMetricParser.MulDivExpressionContext ctx) {
+        LogicalMetric lhs;
+        LogicalMetric rhs;
+
+        if (ctx.mulDivExpression() != null) {
+            lhs = visitMulDivExpression(ctx.mulDivExpression());
+            rhs = visitAtom(ctx.atom(0));
+        } else {
+            lhs = visitAtom(ctx.atom(0));
+            rhs = visitAtom(ctx.atom(1));
+        }
+
+        // This returns a logical metric that has been added to the
+        // scopedDict with a new temporary name.
+        return buildArithmeticNode(context, lhs, rhs, ctx.operator.getType());
+    }
+
+    @Override
+    public LogicalMetric visitAnynum(final FiliMetricParser.AnynumContext ctx) {
+        String value;
+        if (ctx.DECIMAL() != null) {
+            value = ctx.DECIMAL().getText();
+        } else if (ctx.INTEGER() != null) {
+            value = ctx.INTEGER().getText();
+        } else {
+            throw new RuntimeException("Error");
+        }
+
+        ConstantMaker maker = new ConstantMaker(context.scopedDict);
+        LogicalMetric metric = maker.make(getNewName(), Collections.singletonList(value));
+        context.scopedDict.add(metric);
+        return metric;
+    }
+
+    @Override
+    public LogicalMetric visitFunction(final FiliMetricParser.FunctionContext ctx) {
+        String functionName = ctx.IDENTIFIER().getText();
+        List<LogicalMetric> operands = new ArrayList<>();
+
+        if (ctx.param_list() != null && ctx.param_list().expression() != null) {
+            List<FiliMetricParser.ExpressionContext> children = ctx.param_list().expression();
+            for (FiliMetricParser.ExpressionContext child : children) {
+                operands.add(visitExpression(child));
+            }
+        }
+
+
+        List<String> parameterNames = operands
+                .stream()
+                .map(LogicalMetric::getName)
+                .collect(Collectors.toList());
+
+        MetricMaker maker = context.makerBuilder.build(functionName, context.scopedDict);
+        LogicalMetric metric = maker.make(getNewName(), parameterNames);
+        context.scopedDict.add(metric);
+        return metric;
+    }
+
+    @Override
+    public LogicalMetric visitAtom(final FiliMetricParser.AtomContext ctx) {
+        if (ctx.anynum() != null) {
+            return visitAnynum(ctx.anynum());
+        } else if (ctx.expression() != null) {
+            return visitExpression(ctx.expression());
+        } else if (ctx.function() != null) {
+            return visitFunction(ctx.function());
+        } else if (ctx.IDENTIFIER() != null) {
+
+            // If we come across an identifier, it could be referring to either an existing (dependant) metric,
+            // or a raw metric. This seems like a hack, but:
+            //
+            // - If we can find an existing logical metric in the dictionary, use that
+            // - Otherwise, return a new (empty) logical metric, with only a name. Presumably this is a raw name.
+            //   Unlike every other kind of metric produced by this parser, raw names are currently not added
+            //   to the scopedDict. Not sure if this is correct or not...
+            // FIXME added because it seems like there should be a better way to do this.
+            String name = ctx.IDENTIFIER().getText();
+            if (context.scopedDict.containsKey(name)) {
+                return context.scopedDict.get(name);
+            } else {
+                return new LogicalMetric(null, null, name);
+            }
+        } else {
+            throw new RuntimeException("Unknown atom");
+        }
+    }
+
+    /**
+     * Generate a globally unique new name.
+     * <p>
+     * Note: this assumes that we've chosen a sufficiently unique prefix.
+     *
+     * It's not clear to me at this time whether this needs to be globally unique or if uniqueness per-metric
+     * is OK.
+     *
+     * @return the new name
+     */
+    private synchronized static String getNewName() {
+        return TEMP_BASE + TEMP_IDENTIFIER++;
+    }
+
+}

--- a/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliExpressionVisitor.java
+++ b/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliExpressionVisitor.java
@@ -56,7 +56,7 @@ public class FiliExpressionVisitor extends FiliMetricBaseVisitor<LogicalMetric> 
                     .getAggregations()
                     .stream()
                     .findFirst()
-                    .orElseThrow(() -> new RuntimeException(
+                    .orElseThrow(() -> new MetricParseException(
                             "Filtered aggregation requires aggregation but could not find one"));
 
             FilteredAggregationMaker maker = new FilteredAggregationMaker(context.scopedDict, aggregation, filter);
@@ -104,7 +104,7 @@ public class FiliExpressionVisitor extends FiliMetricBaseVisitor<LogicalMetric> 
                 function = ArithmeticPostAggregation.ArithmeticPostAggregationFunction.DIVIDE;
                 break;
             default:
-                throw new RuntimeException("Unknown type: " + type);
+                throw new MetricParseException("Unknown type: " + type);
         }
 
         MetricMaker maker = new ArithmeticMaker(ctx.scopedDict, function, new NoOpResultSetMapper());
@@ -126,7 +126,7 @@ public class FiliExpressionVisitor extends FiliMetricBaseVisitor<LogicalMetric> 
             lhs = visitPlusMinusArg(ctx.plusMinusArg(0));
             rhs = visitPlusMinusArg(ctx.plusMinusArg(1));
         } else {
-            throw new RuntimeException("error: could not parse");
+            throw new MetricParseException("error: could not parse");
         }
 
         // This returns a logical metric that has been added to the
@@ -160,7 +160,7 @@ public class FiliExpressionVisitor extends FiliMetricBaseVisitor<LogicalMetric> 
         } else if (ctx.INTEGER() != null) {
             value = ctx.INTEGER().getText();
         } else {
-            throw new RuntimeException("Error");
+            throw new MetricParseException("Error: could not parse number");
         }
 
         ConstantMaker maker = new ConstantMaker(context.scopedDict);
@@ -218,7 +218,7 @@ public class FiliExpressionVisitor extends FiliMetricBaseVisitor<LogicalMetric> 
                 return new LogicalMetric(null, null, name);
             }
         } else {
-            throw new RuntimeException("Unknown atom");
+            throw new MetricParseException("Unknown atom");
         }
     }
 

--- a/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliFilterVisitor.java
+++ b/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliFilterVisitor.java
@@ -1,0 +1,62 @@
+package com.yahoo.bard.webservice.data.config.metric.parser;
+
+import com.yahoo.bard.webservice.data.config.metric.antlrparser.FiliMetricBaseVisitor;
+import com.yahoo.bard.webservice.data.config.metric.antlrparser.FiliMetricParser;
+import com.yahoo.bard.webservice.druid.model.filter.AndFilter;
+import com.yahoo.bard.webservice.druid.model.filter.Filter;
+import com.yahoo.bard.webservice.druid.model.filter.OrFilter;
+import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter;
+
+import java.util.Arrays;
+
+/**
+ * Visitor for antlr4 rule 'filterExp'.
+ */
+public class FiliFilterVisitor extends FiliMetricBaseVisitor<Filter> {
+    protected final ParseContext context;
+
+    /**
+     * Construct a new visitor for 'filterExp'.
+     *
+     * @param context parse context
+     */
+    public FiliFilterVisitor(ParseContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public Filter visitAndOrExp(final FiliMetricParser.AndOrExpContext ctx) {
+        Filter lhs, rhs;
+        if (ctx.andOrExp() != null) {
+            lhs = visitAndOrExp(ctx.andOrExp());
+            rhs = visitAndOrArg(ctx.andOrArg(0));
+        } else {
+            lhs = visitAndOrArg(ctx.andOrArg(0));
+            rhs = visitAndOrArg(ctx.andOrArg(1));
+        }
+
+
+        if (ctx.operator.getType() == FiliMetricParser.AND) {
+            return new AndFilter(Arrays.asList(lhs, rhs));
+        } else if (ctx.operator.getType() == FiliMetricParser.OR) {
+            return new OrFilter(Arrays.asList(lhs, rhs));
+        } else {
+            throw new RuntimeException("Could not parse filter");
+        }
+    }
+
+    @Override
+    public Filter visitEqualExp(final FiliMetricParser.EqualExpContext ctx) {
+        String lhs, rhs;
+        lhs = ctx.IDENTIFIER(0).getText();
+        if (ctx.anynum() != null) {
+            rhs = ctx.anynum().getText();
+        } else if(ctx.IDENTIFIER(1) != null) {
+            rhs = ctx.IDENTIFIER(1).getText();
+        } else {
+            throw new RuntimeException("Unknown parameter");
+        }
+
+        return new SelectorFilter(context.dimensionDictionary.findByApiName(lhs), rhs);
+    }
+}

--- a/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliFilterVisitor.java
+++ b/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliFilterVisitor.java
@@ -26,7 +26,8 @@ public class FiliFilterVisitor extends FiliMetricBaseVisitor<Filter> {
 
     @Override
     public Filter visitAndOrExp(final FiliMetricParser.AndOrExpContext ctx) {
-        Filter lhs, rhs;
+        Filter lhs;
+        Filter rhs;
         if (ctx.andOrExp() != null) {
             lhs = visitAndOrExp(ctx.andOrExp());
             rhs = visitAndOrArg(ctx.andOrArg(0));
@@ -41,20 +42,21 @@ public class FiliFilterVisitor extends FiliMetricBaseVisitor<Filter> {
         } else if (ctx.operator.getType() == FiliMetricParser.OR) {
             return new OrFilter(Arrays.asList(lhs, rhs));
         } else {
-            throw new RuntimeException("Could not parse filter");
+            throw new MetricParseException("Could not parse filter");
         }
     }
 
     @Override
     public Filter visitEqualExp(final FiliMetricParser.EqualExpContext ctx) {
-        String lhs, rhs;
+        String lhs;
+        String rhs;
         lhs = ctx.IDENTIFIER(0).getText();
         if (ctx.anynum() != null) {
             rhs = ctx.anynum().getText();
         } else if(ctx.IDENTIFIER(1) != null) {
             rhs = ctx.IDENTIFIER(1).getText();
         } else {
-            throw new RuntimeException("Unknown parameter");
+            throw new MetricParseException("Unknown parameter to expression");
         }
 
         return new SelectorFilter(context.dimensionDictionary.findByApiName(lhs), rhs);

--- a/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliLogicalMetricParser.java
+++ b/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/FiliLogicalMetricParser.java
@@ -1,0 +1,69 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.metric.parser;
+
+import com.yahoo.bard.webservice.data.config.metric.antlrparser.FiliMetricLexer;
+import com.yahoo.bard.webservice.data.config.metric.antlrparser.FiliMetricParser;
+import com.yahoo.bard.webservice.data.config.provider.MakerBuilder;
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.TokenStream;
+
+/**
+ * Parser used to build logical metrics from strings.
+ *
+ * Parser built using antlr4.
+ */
+public class FiliLogicalMetricParser {
+
+
+    protected final ParseContext context;
+
+    /**
+     * Create a metric parser.
+     *
+     * @param metricName The metric name
+     * @param metricDefinition The metric definition, as a string
+     * @param dict the base metric dictionary
+     * @param makerBuilder the metric maker builder
+     * @param dimensionDictionary the dimension dictionary
+     */
+    public FiliLogicalMetricParser(
+            String metricName,
+            String metricDefinition,
+            MetricDictionary dict,
+            MakerBuilder makerBuilder,
+            DimensionDictionary dimensionDictionary
+    ) {
+        this.context = new ParseContext(
+                metricName,
+                metricDefinition,
+                dict,
+                makerBuilder,
+                dimensionDictionary
+        );
+    }
+
+    /**
+     * Parses the metric def and returns a LogicalMetric.
+     *
+     * Note: caller should add to MetricDictionary as parse() use a scoped dictionary.
+     *
+     * @return a logical metric
+     */
+    public LogicalMetric parse() {
+        CharStream charStream = new ANTLRInputStream(this.context.metricDefinition);
+        FiliMetricLexer lexer = new FiliMetricLexer(charStream);
+        TokenStream tokens = new CommonTokenStream(lexer);
+        FiliMetricParser parser = new FiliMetricParser(tokens);
+
+        FiliExpressionVisitor visitor = new FiliExpressionVisitor(context);
+        return visitor.visitFiliExpression(parser.filiExpression());
+    }
+
+}

--- a/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/MetricParseException.java
+++ b/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/MetricParseException.java
@@ -1,0 +1,16 @@
+package com.yahoo.bard.webservice.data.config.metric.parser;
+
+/**
+ * Unchecked exception thrown when parsing metric.
+ */
+public class MetricParseException extends RuntimeException {
+
+    /**
+     * Construct a new MetricParseException.
+     *
+     * @param message the exception message
+     */
+   public MetricParseException(String message) {
+      super(message);
+   }
+}

--- a/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/ParseContext.java
+++ b/fili-metric-parser/src/main/java/com/yahoo/bard/webservice/data/config/metric/parser/ParseContext.java
@@ -1,0 +1,46 @@
+package com.yahoo.bard.webservice.data.config.metric.parser;
+
+import com.yahoo.bard.webservice.data.config.provider.MakerBuilder;
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
+/**
+ * Metric parser context: metric name, metric dictionary, etc.
+ */
+public class ParseContext {
+    protected String name;
+
+    // All lookups happen here; this is where the temporary metrics all end up
+    protected final MetricDictionary scopedDict;
+
+    protected final DimensionDictionary dimensionDictionary;
+    protected final MakerBuilder makerBuilder;
+    protected final String metricDefinition;
+
+    /**
+     * Constructor.
+     *
+     * @param metricName the metric name
+     * @param metricDefinition the metric definition string (to be parsed)
+     * @param dict the metric dictionary
+     * @param makerBuilder the metric maker builder
+     * @param dimensionDictionary the dimension dictionary
+     */
+    public ParseContext(
+            String metricName,
+            String metricDefinition,
+            MetricDictionary dict,
+            MakerBuilder makerBuilder,
+            DimensionDictionary dimensionDictionary
+    ) {
+        this.name = metricName;
+
+        // Get temporary scope for use here and make sure it's empty
+        this.scopedDict = dict.getScope("MetricParserScope");
+        this.scopedDict.clearLocal();
+
+        this.makerBuilder = makerBuilder;
+        this.dimensionDictionary = dimensionDictionary;
+        this.metricDefinition = metricDefinition;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>fili-core</module>
         <module>fili</module>
         <module>fili-wikipedia-example</module>
+        <module>fili-metric-parser</module>
     </modules>
 
     <organization>


### PR DESCRIPTION
For comments/suggestions (obviously, it's a little short on tests at the moment...I will write some once the approach is finalized).

It's gone through a few iterations: 
1. There was an initial version of this in #104, (and versions before that) that were all hand-written parsing code.
2. There was a version that used this antlr grammar for lexing and implemented the visitor interface, but kept around the `MetricNode`s used in #104. I tested this against our Druid cluster and it seemed to be working well.
3. This version: all of the custom parsing code was ripped out and replaced with a parser that  directly produces native Bard objects (`Filter`s and `LogicalMetric`s). It wasn't that hard, I should have just done it like that in the first place...

I've done some basic tests of (2) against Druid, so the antlr grammar here is...at least reasonably correct. (3) (this PR) I haven't built or tested against a real cluster, so I may have missed a couple little things when refactoring...

This does depend on the`MakerBuilder` code in #108 (I was thinking they were totally independent, but not quite), so it won't build with maven as-is.