### PR TITLE
Fix some timers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,13 @@ Current
 
 ### Changed:
 
+- [The druid query posting timer has been removed](https://github.com/yahoo/fili/pull/141)
+    * There wasn't really a good way of stopping timing only the posting itself. Since the timer is 
+       probably not that useful, it has been removed. 
+
 - [Dimension Field Tagging and Dynamic Dimension Field Serilization](https://github.com/yahoo/fili/pull/137)
     * Changed `fili-core` dimension endpoint `DimensionField` serialization strategy from hard coded static attributes to dynamic serialization based on `jackson` serializer
-
+        
 - [MetricMaker cleanup and simplification](https://github.com/yahoo/fili/pull/127)
     * Simplified raw aggregation makers
     * `ConstantMaker` now throws an `IllegalArgumentException` wrapping the raw NumberFormatException on a bad argument
@@ -208,6 +212,9 @@ Current
      so `LogicalDimensionColumn` is no longer needed
 
 ### Fixed:
+
+- [Stopped `DataApiRequest` timer](https://github.com/yahoo/fili/pull/141):
+    * Stopping the `DataApiRequest` timer that we forgot to stop
 
 - [Added missing coverage for `ThetaSketchEstimate` unwrapping in `MetricMaker.getSketchField`](https://github.com/yahoo/fili/pull/128) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,13 +49,18 @@ Current
 
 ### Changed:
 
+- [`RequestLog::switchTiming` has been removed]((https://github.com/yahoo/fili/pull/141)
+    - `RequestLog::switchTiming` is very context-dependent, and therefore brittle. In particular, adding any
+        additional timers inside code called by a timed block may result in the original timer not stopping
+        properly. All usages of `switchTiming` have been replaced with explicit starts and stops.
+
 - [The druid query posting timer has been removed](https://github.com/yahoo/fili/pull/141)
     * There wasn't really a good way of stopping timing only the posting itself. Since the timer is 
        probably not that useful, it has been removed. 
 
 - [Dimension Field Tagging and Dynamic Dimension Field Serilization](https://github.com/yahoo/fili/pull/137)
     * Changed `fili-core` dimension endpoint `DimensionField` serialization strategy from hard coded static attributes to dynamic serialization based on `jackson` serializer
-        
+
 - [MetricMaker cleanup and simplification](https://github.com/yahoo/fili/pull/127)
     * Simplified raw aggregation makers
     * `ConstantMaker` now throws an `IllegalArgumentException` wrapping the raw NumberFormatException on a bad argument
@@ -212,9 +217,6 @@ Current
      so `LogicalDimensionColumn` is no longer needed
 
 ### Fixed:
-
-- [Stopped `DataApiRequest` timer](https://github.com/yahoo/fili/pull/141):
-    * Stopping the `DataApiRequest` timer that we forgot to stop
 
 - [Added missing coverage for `ThetaSketchEstimate` unwrapping in `MetricMaker.getSketchField`](https://github.com/yahoo/fili/pull/128) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,11 @@ Current
 
 ### Changed:
 
-- [`RequestLog::switchTiming` has been removed]((https://github.com/yahoo/fili/pull/141)
+- [`RequestLog::switchTiming` has been deprecated]((https://github.com/yahoo/fili/pull/141)
     - `RequestLog::switchTiming` is very context-dependent, and therefore brittle. In particular, adding any
         additional timers inside code called by a timed block may result in the original timer not stopping
-        properly. All usages of `switchTiming` have been replaced with explicit starts and stops.
+        properly. All usages of `switchTiming` should be replaced with explicit calls to `RequestLog::startTiming`
+        and `RequestLog::stopTiming`.
 
 - [The druid query posting timer has been removed](https://github.com/yahoo/fili/pull/141)
     * There wasn't really a good way of stopping timing only the posting itself. Since the timer is 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,12 +49,6 @@ Current
 
 ### Changed:
 
-- [`RequestLog::switchTiming` has been deprecated]((https://github.com/yahoo/fili/pull/141)
-    - `RequestLog::switchTiming` is very context-dependent, and therefore brittle. In particular, adding any
-        additional timers inside code called by a timed block may result in the original timer not stopping
-        properly. All usages of `switchTiming` should be replaced with explicit calls to `RequestLog::startTiming`
-        and `RequestLog::stopTiming`.
-
 - [The druid query posting timer has been removed](https://github.com/yahoo/fili/pull/141)
     * There wasn't really a good way of stopping timing only the posting itself. Since the timer is 
        probably not that useful, it has been removed. 
@@ -191,6 +185,12 @@ Current
     * [JavaX Annotation API 1.2 -> 1.3](https://jcp.org/en/jsr/detail?id=250)
 
 ### Deprecated:
+
+- [`RequestLog::switchTiming` has been deprecated]((https://github.com/yahoo/fili/pull/141)
+    - `RequestLog::switchTiming` is very context-dependent, and therefore brittle. In particular, adding any
+        additional timers inside code called by a timed block may result in the original timer not stopping
+        properly. All usages of `switchTiming` should be replaced with explicit calls to `RequestLog::startTiming`
+        and `RequestLog::stopTiming`.
 
 - [Dimension Field Tagging and Dynamic Dimension Field Serilization](https://github.com/yahoo/fili/pull/137)
     * Deprecated `DimensionsServlet::getDimensionFieldListSummaryView` and `DimensionsServlet::getDimensionFieldSummaryView`

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImpl.java
@@ -297,52 +297,47 @@ public class AsyncDruidWebServiceImpl implements DruidWebService {
             DruidQuery<?> druidQuery
     ) {
         long seqNum = druidQuery.getContext().getSequenceNumber();
-        RequestLog.startTiming("PostingDruidQuery" + seqNum);
+        String entityBody;
+        RequestLog.startTiming("DruidQuerySerializationSeq" + seqNum);
         try {
-            String entityBody;
-            RequestLog.startTiming("DruidQuerySerializationSeq" + seqNum);
-            try {
-                entityBody = writer.writeValueAsString(druidQuery);
-            } catch (JsonProcessingException e) {
-                throw new IllegalStateException(e);
-            } finally {
-                RequestLog.stopTiming("DruidQuerySerializationSeq" + seqNum);
-            }
-
-            long totalQueries = druidQuery.getContext().getNumberOfQueries();
-            String format = String.format("%%0%dd", String.valueOf(totalQueries).length());
-            String timerName;
-            AtomicLong outstanding;
-
-            if (!(druidQuery instanceof WeightEvaluationQuery)) {
-                if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
-                    RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
-                }
-                outstanding = context.getNumberOfIncoming();
-                timerName = DRUID_QUERY_TIMER + String.format(format, seqNum);
-            } else {
-                outstanding = new AtomicLong(0);
-                timerName = DRUID_WEIGHTED_QUERY_TIMER + String.format(format, seqNum);
-            }
-
-            BoundRequestBuilder requestBuilder = webClient.preparePost(serviceConfig.getUrl())
-                    .setBody(entityBody)
-                    .addHeader("Content-Type", "application/json");
-
-            headersToAppend.get().forEach(requestBuilder::addHeader);
-
-            LOG.debug("druid json request: {}", entityBody);
-            sendRequest(
-                    success,
-                    error,
-                    failure,
-                    requestBuilder,
-                    timerName,
-                    outstanding
-            );
+            entityBody = writer.writeValueAsString(druidQuery);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
         } finally {
-            RequestLog.stopTiming("PostingDruidQuery" + seqNum);
+            RequestLog.stopTiming("DruidQuerySerializationSeq" + seqNum);
         }
+
+        long totalQueries = druidQuery.getContext().getNumberOfQueries();
+        String format = String.format("%%0%dd", String.valueOf(totalQueries).length());
+        String timerName;
+        AtomicLong outstanding;
+
+        if (!(druidQuery instanceof WeightEvaluationQuery)) {
+            if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
+                RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
+            }
+            outstanding = context.getNumberOfIncoming();
+            timerName = DRUID_QUERY_TIMER + String.format(format, seqNum);
+        } else {
+            outstanding = new AtomicLong(0);
+            timerName = DRUID_WEIGHTED_QUERY_TIMER + String.format(format, seqNum);
+        }
+
+        BoundRequestBuilder requestBuilder = webClient.preparePost(serviceConfig.getUrl())
+                .setBody(entityBody)
+                .addHeader("Content-Type", "application/json");
+
+        headersToAppend.get().forEach(requestBuilder::addHeader);
+
+        LOG.debug("druid json request: {}", entityBody);
+        sendRequest(
+                success,
+                error,
+                failure,
+                requestBuilder,
+                timerName,
+                outstanding
+        );
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -278,17 +278,6 @@ public class RequestLog {
     }
 
     /**
-     * Stop the most recent stopwatch and start this one.
-     * Time is accumulated if the stopwatch is already registered.
-     *
-     * @param nextPhase  the name of the stopwatch to be started
-     */
-    public static void switchTiming(String nextPhase) {
-        stopMostRecentTimer();
-        startTiming(nextPhase);
-    }
-
-    /**
      * Pause a stopwatch.
      *
      * @param caller  the caller to name this stopwatch with its class's simple name

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -278,6 +278,22 @@ public class RequestLog {
     }
 
     /**
+     * Stop the most recent stopwatch and start this one.
+     * Time is accumulated if the stopwatch is already registered.
+     *
+     * @param nextPhase  the name of the stopwatch to be started
+     *
+     * @deprecated This method is too dependent on context that can be too easily changed by internal method calls.
+     * Each timer should be explicitly started by {@link RequestLog#startTiming(String)} and stopped by
+     * {@link RequestLog#stopTiming(String)} instead
+     */
+    @Deprecated
+    public static void switchTiming(String nextPhase) {
+        stopMostRecentTimer();
+        startTiming(nextPhase);
+    }
+
+    /**
      * Pause a stopwatch.
      *
      * @param caller  the caller to name this stopwatch with its class's simple name

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
@@ -365,6 +365,7 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
                     uriInfo,
                     this
             );
+            RequestLog.stopTiming("DataApiRequest");
 
             if (requestMapper != null) {
                 apiRequest = (DataApiRequest) requestMapper.apply(apiRequest, containerRequestContext);


### PR DESCRIPTION
--We forgot to stop the `DataApiRequest` timer.

--When timing the posting of the Druid Query we
failed to account for the thread hopping during
asynchronous programming. As a result, not only
were we failing to stop the timer in the correct
instance of the RequestLog (the one that is used
by the response handling thread), but we also
attempted to stop a timer in a RequestLog that
has since been cleared. So we end up with two
warnings: One for attempting to stop a timer that
doesn't exist, and one for logging a timer that
was never stopped.

Since there isn't a good way to time just the
posting of the druid query, and it probably
isn't necessary anyway, the timing has been
removed.