### PR TITLE
Removes warning in getExtractionFunction

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/util/ModelUtil.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/util/ModelUtil.java
@@ -77,7 +77,7 @@ public class ModelUtil {
             );
         }
 
-        LOG.warn("Could not resolve ExtractionFunction from the provided Dimension: {}", sourceClass.toString());
+        LOG.debug("Could not resolve ExtractionFunction from the provided Dimension: {}", sourceClass.toString());
         return Optional.empty();
     }
 }


### PR DESCRIPTION
--`ModelUtil::getExtractionFunction` is a part of an optional feature,
but it only works on Dimensions that Fili supports directly in a very
non-extensible way. Therefore, if customers are using Fili with their
own implementation of `Dimension`, the customers end up with spurious
warnings about not being able to build an `ExtractionFunction`.

Since the feature isn't critical and can't be integrated with custom
dimensions right now, the log level has been reduced to debug until it
can be reworked to be more extensible.