### PR TITLE
Makes TimedPhase auto-closeable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,6 +378,11 @@ New Capabilities & Enhancements:
 
 ### Changed:
 
+- [`RequestLog` timings support the try-with-resources block](https://github.com/yahoo/fili/pull/143)
+    * A block of code can now be timed by wrapping the timed block in a try-with-resources block that 
+        starts the timer. Note: This won't work when performing timings across threads, or across
+        contexts. Those need to be started and stopped manually.
+
 - [Error messages generated during response processing include the request id.](https://github.com/yahoo/fili/pull/78)
 
 - [`DimensionStoreKeyUtils` now supports case sensitive row and column keys](https://github.com/yahoo/fili/pull/90)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ Current
 
 ### Deprecated:
 
+- [`RequestLog::stopMostRecentTimer` has been deprecated](https://github.com/yahoo/fili/pull/143)
+    - This method is a part of the infrastructure to support the recently
+    deprecated `RequestLog::switchTiming`.
+
+- [`RequestLog::switchTiming` has been deprecated](https://github.com/yahoo/fili/pull/141)
+    - `RequestLog::switchTiming` is very context-dependent, and therefore brittle. In particular, adding any
+        additional timers inside code called by a timed block may result in the original timer not stopping
+        properly. All usages of `switchTiming` should be replaced with explicit calls to `RequestLog::startTiming`
+        and `RequestLog::stopTiming`.
+
 
 
 ### Fixed:
@@ -258,11 +268,6 @@ Changes:
     * [JavaX Annotation API 1.2 -> 1.3](https://jcp.org/en/jsr/detail?id=250)
 
 ### Deprecated:
-
-- [`RequestLog::switchTiming` has been deprecated](https://github.com/yahoo/fili/pull/141)
-    - `RequestLog::switchTiming` is very context-dependent, and therefore brittle. In particular, adding any additional
-      timers inside code called by a timed block may result in the original timer not stopping properly. All usages of
-      `switchTiming` should be replaced with explicit calls to `RequestLog::startTiming` and `RequestLog::stopTiming`.
 
 - [Dimension Field Tagging and Dynamic Dimension Field Serilization](https://github.com/yahoo/fili/pull/137)
     * Deprecated `DimensionsServlet::getDimensionFieldListSummaryView` and `DimensionsServlet::getDimensionFieldSummaryView`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,19 +37,16 @@ Current
     * The previous message of `reject <url>` wasn't helpful, useful, nor very nice to users, and the message logged was
       not very useful either. The message has been made nicer (`Service is unhealthy. At least 1 healthcheck is
       failing`), and the log has been made better as well.
+- [`RequestLog` timings support the try-with-resources block](https://github.com/yahoo/fili/pull/143)
+    * A block of code can now be timed by wrapping the timed block in a try-with-resources block that 
+        starts the timer. Note: This won't work when performing timings across threads, or across
+        contexts. Those need to be started and stopped manually.
 
 ### Deprecated:
 
 - [`RequestLog::stopMostRecentTimer` has been deprecated](https://github.com/yahoo/fili/pull/143)
     - This method is a part of the infrastructure to support the recently
     deprecated `RequestLog::switchTiming`.
-
-- [`RequestLog::switchTiming` has been deprecated](https://github.com/yahoo/fili/pull/141)
-    - `RequestLog::switchTiming` is very context-dependent, and therefore brittle. In particular, adding any
-        additional timers inside code called by a timed block may result in the original timer not stopping
-        properly. All usages of `switchTiming` should be replaced with explicit calls to `RequestLog::startTiming`
-        and `RequestLog::stopTiming`.
-
 
 
 ### Fixed:
@@ -269,6 +266,11 @@ Changes:
 
 ### Deprecated:
 
+- [`RequestLog::switchTiming` has been deprecated](https://github.com/yahoo/fili/pull/141)
+    - `RequestLog::switchTiming` is very context-dependent, and therefore brittle. In particular, adding any additional
+      timers inside code called by a timed block may result in the original timer not stopping properly. All usages of
+      `switchTiming` should be replaced with explicit calls to `RequestLog::startTiming` and `RequestLog::stopTiming`.
+
 - [Dimension Field Tagging and Dynamic Dimension Field Serilization](https://github.com/yahoo/fili/pull/137)
     * Deprecated `DimensionsServlet::getDimensionFieldListSummaryView` and `DimensionsServlet::getDimensionFieldSummaryView`
       since there is no need for it anymore due to the change in serialization of `DimensionField`
@@ -377,11 +379,6 @@ New Capabilities & Enhancements:
         `AbstractBinderFactory`.
 
 ### Changed:
-
-- [`RequestLog` timings support the try-with-resources block](https://github.com/yahoo/fili/pull/143)
-    * A block of code can now be timed by wrapping the timed block in a try-with-resources block that 
-        starts the timer. Note: This won't work when performing timings across threads, or across
-        contexts. Those need to be started and stopped manually.
 
 - [Error messages generated during response processing include the request id.](https://github.com/yahoo/fili/pull/78)
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/async/MetadataHttpResponseChannel.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/async/MetadataHttpResponseChannel.java
@@ -66,7 +66,7 @@ public class MetadataHttpResponseChannel implements Observer<String> {
      * @param asyncResponse  The channel over which to send the response
      */
     private void send(Response response, AsyncResponse asyncResponse) {
-        if (RequestLog.isStarted(RESPONSE_WORKFLOW_TIMER)) {
+        if (RequestLog.isRunning(RESPONSE_WORKFLOW_TIMER)) {
             RequestLog.stopTiming(RESPONSE_WORKFLOW_TIMER);
         }
         asyncResponse.resume(response);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseChannel.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseChannel.java
@@ -113,7 +113,7 @@ public class HttpResponseChannel implements Observer<PreResponse> {
      * @param response  The Response to send back to the user
      */
     private void publishResponse(Response response) {
-        if (RequestLog.isStarted(RESPONSE_WORKFLOW_TIMER)) {
+        if (RequestLog.isRunning(RESPONSE_WORKFLOW_TIMER)) {
             RequestLog.stopTiming(RESPONSE_WORKFLOW_TIMER);
         }
         asyncResponse.resume(response);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -55,6 +55,7 @@ public class RequestLog {
 
     private String logId;
     private LogBlock info;
+    @Deprecated
     private TimedPhase mostRecentTimer;
     private final Map<String, TimedPhase> times;
     private final Set<String> threadIds;
@@ -271,7 +272,11 @@ public class RequestLog {
 
     /**
      * Stop the most recent stopwatch.
+     *
+     * @deprecated  Stopping a timer based on context is brittle, and prone to unexpected changes. Timers should be
+     * stopped explicitly, or started in a try-with-resources block
      */
+    @Deprecated
     public static void stopMostRecentTimer() {
         try {
             stopTiming(RLOG.get().mostRecentTimer.getName());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -86,54 +86,6 @@ public class RequestLog {
     }
 
     /**
-     * Represents a phase that is timed.
-     * TimedPhase is used to associate a Timer located in the registry with the exact duration of such a phase for a
-     * specific request.
-     */
-    private static class TimedPhase {
-        private final String name;
-        private long start;
-        private long duration;
-
-        /**
-         * Constructor.
-         *
-         * @param name  Name of the phase
-         */
-        private TimedPhase(String name) {
-            this.name = name;
-        }
-
-        /**
-         * Start the phase.
-         */
-        private void start() {
-            if (start != 0) {
-                LOG.warn("Tried to start timer that is already running: {}", name);
-                return;
-            }
-            start = System.nanoTime();
-        }
-
-        /**
-         * Stop the phase.
-         */
-        private void stop() {
-            if (start == 0) {
-                LOG.warn("Tried to stop timer that has not been started: {}", name);
-                return;
-            }
-            duration += System.nanoTime() - start;
-            REGISTRY.timer(name).update(duration, TimeUnit.NANOSECONDS);
-            start = 0;
-        }
-
-        private boolean isStarted() {
-            return start != 0;
-        }
-    }
-
-    /**
      * Resets the contents of a request log at the calling thread.
      */
     private void clear() {
@@ -180,19 +132,7 @@ public class RequestLog {
      * @return the map containing all the recorded times per phase in milliseconds
      */
     private Map<String, Long> getDurations() {
-        return times.values()
-                .stream()
-                .peek(
-                        phase -> {
-                            if (phase.start != 0) {
-                                LOG.warn(
-                                        "Exporting duration while timer is running. Measurement might be wrong: {}",
-                                        phase.name
-                                );
-                            }
-                        }
-                )
-                .collect(Collectors.toMap(phase -> phase.name, phase -> phase.duration));
+        return times.values().stream().collect(Collectors.toMap(TimedPhase::getName, TimedPhase::getDuration));
     }
 
     /**
@@ -221,15 +161,15 @@ public class RequestLog {
     }
 
     /**
-     * Check if a stopwatch is started.
+     * Check if a stopwatch is currently running.
      *
      * @param caller  the caller to name this stopwatch with its class's simple name
      *
      * @return whether this stopwatch is started
      */
 
-    public static boolean isStarted(Object caller) {
-        return isStarted(caller.getClass().getSimpleName());
+    public static boolean isRunning(Object caller) {
+        return isRunning(caller.getClass().getSimpleName());
     }
 
     /**
@@ -239,10 +179,10 @@ public class RequestLog {
      *
      * @return whether this stopwatch is started
      */
-    public static boolean isStarted(String timePhaseName) {
+    public static boolean isRunning(String timePhaseName) {
         RequestLog current = RLOG.get();
         TimedPhase timePhase = current.times.get(timePhaseName);
-        return timePhase != null && timePhase.isStarted();
+        return timePhase != null && timePhase.isRunning();
     }
 
     /**
@@ -250,9 +190,11 @@ public class RequestLog {
      * Time is accumulated if the stopwatch is already registered
      *
      * @param caller  the caller to name this stopwatch with its class's simple name
+     *
+     * @return The stopwatch
      */
-    public static void startTiming(Object caller) {
-        startTiming(caller.getClass().getSimpleName());
+    public static TimedPhase startTiming(Object caller) {
+        return startTiming(caller.getClass().getSimpleName());
     }
 
     /**
@@ -260,8 +202,10 @@ public class RequestLog {
      * Time is accumulated if the stopwatch is already registered
      *
      * @param timePhaseName  the name of this stopwatch
+     *
+     * @return The stopwatch
      */
-    public static void startTiming(String timePhaseName) {
+    public static TimedPhase startTiming(String timePhaseName) {
         RequestLog current = RLOG.get();
         TimedPhase timePhase = current.times.get(timePhaseName);
         if (timePhase == null) {
@@ -274,7 +218,7 @@ public class RequestLog {
             current.times.put(timePhaseName, timePhase);
         }
         current.mostRecentTimer = timePhase;
-        timePhase.start();
+        return timePhase.start();
     }
 
     /**
@@ -303,6 +247,15 @@ public class RequestLog {
     }
 
     /**
+     * Registers the final duration of a stopped timer with the RequestLog.
+     *
+     * @param stoppedPhase  The phase that has been stopped, and whose duration needs to be stored
+     */
+    public static void registerTime(TimedPhase stoppedPhase) {
+        RequestLog.REGISTRY.timer(stoppedPhase.getName()).update(stoppedPhase.getDuration(), stoppedPhase.getUnit());
+    }
+
+    /**
      * Pause a stopwatch.
      *
      * @param timePhaseName  the name of this stopwatch
@@ -313,7 +266,7 @@ public class RequestLog {
             LOG.warn("Tried to stop non-existent phase: {}", timePhaseName);
             return;
         }
-        timePhase.stop();
+        timePhase.close();
     }
 
     /**
@@ -321,7 +274,7 @@ public class RequestLog {
      */
     public static void stopMostRecentTimer() {
         try {
-            stopTiming(RLOG.get().mostRecentTimer.name);
+            stopTiming(RLOG.get().mostRecentTimer.getName());
         } catch (NullPointerException ignored) {
             LOG.warn("Stopping timing failed because mostRecentTimer wasn't registered.");
         }
@@ -450,8 +403,8 @@ public class RequestLog {
                         .stream()
                         .filter(
                                 e -> e.getKey().contains(DRUID_QUERY_TIMER) ||
-                                        (e.getKey().equals(REQUEST_WORKFLOW_TIMER) && !e.getValue().isStarted()) ||
-                                        (e.getKey().equals(RESPONSE_WORKFLOW_TIMER) && e.getValue().isStarted())
+                                        (e.getKey().equals(REQUEST_WORKFLOW_TIMER) && !e.getValue().isRunning()) ||
+                                        (e.getKey().equals(RESPONSE_WORKFLOW_TIMER) && e.getValue().isRunning())
                         )
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/TimedPhase.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/TimedPhase.java
@@ -1,0 +1,119 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Represents a phase that is timed.
+ * TimedPhase is used to associate a Timer located in the registry with the exact duration of such a phase for a
+ * specific request. Times are in nanoseconds.
+ * <p>
+ * Note: This class is NOT thread-safe. Timers are intended to be started once by one thread, and stopped once by
+ * one thread (though those threads are not necessarily the same).
+ */
+public class TimedPhase implements AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(TimedPhase.class);
+
+    private final String name;
+    private long start;
+    private long duration;
+
+    /**
+     * Constructor.
+     *
+     * @param name  Name of the phase
+     */
+    public TimedPhase(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Start the phase.
+     *
+     * @return This phase after being started
+     */
+    public TimedPhase start() {
+        if (isRunning()) {
+            LOG.warn("Tried to start timer that is already running: {}", name);
+        } else {
+            start = System.nanoTime();
+        }
+        return this;
+    }
+
+    /**
+     * Stop the phase.
+     * <p>
+     * This method just stops the timer. It does not register the time with the {@link RequestLog}. To register
+     * the timer, invoke {@link TimedPhase#registerTime()}. To do both with a single method call, see
+     * {@link TimedPhase#close()}
+     *
+     * @see TimedPhase#registerTime()
+     * @see TimedPhase#close()
+     */
+    public void stop() {
+        if (!isRunning()) {
+            LOG.warn("Tried to stop timer that has not been started: {}", name);
+            return;
+        }
+        duration += System.nanoTime() - start;
+        start = 0;
+    }
+
+    /**
+     * Registers the duration of this timer with the RequestLog.
+     * <p>
+     * It is highly recommended that you {@link TimedPhase#stop()}} the timer first. Otherwise, the timings may
+     * be inaccurate. To both stop and register the timer at once see {@link TimedPhase#close}.
+     *
+     * @see TimedPhase#stop()
+     * @see TimedPhase#close()
+     */
+    public void registerTime() {
+        RequestLog.registerTime(this);
+    }
+
+    /**
+     * Return the duration of the timer in nanoseconds.
+     *
+     * @return The duration of the timer in nanoseconds
+     */
+    public long getDuration() {
+        if (isRunning()) {
+            LOG.warn("Timer '{}' is still running. Timings may be incorrect.", getName());
+        }
+        return duration;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public TimeUnit getUnit() {
+        return TimeUnit.NANOSECONDS;
+    }
+
+    public boolean isRunning() {
+        return start != 0;
+    }
+
+    /**
+     * Stops the timer, and registers the timer with the RequestLog.
+     * <p>
+     *  This is primarily meant to be used by the try-with-resources block, which both stops the timer and registers it
+     *  with the RequestLog, though it can of course be called manually as well. If you want to stop the timer, but
+     *  don't want to register the timer just yet, then see {@link TimedPhase#stop}.
+     *
+     * @see TimedPhase#stop()
+     * @see TimedPhase#registerTime()
+     */
+    @Override
+    public void close() {
+        stop();
+        registerTime();
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/BardLoggingFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/BardLoggingFilter.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.web.filters;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 
 import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.TimedPhase;
 import com.yahoo.bard.webservice.logging.blocks.Epilogue;
 import com.yahoo.bard.webservice.logging.blocks.Preface;
 import com.yahoo.bard.webservice.util.CacheLastObserver;
@@ -88,15 +89,15 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
 
         appendRequestId(request.getHeaders().getFirst(X_REQUEST_ID_HEADER));
         RequestLog.startTiming(TOTAL_TIMER);
-        RequestLog.startTiming(this);
-        RequestLog.record(new Preface(request));
+        try (TimedPhase timer = RequestLog.startTiming(this)) {
+            RequestLog.record(new Preface(request));
 
-        // sets PROPERTY_REQ_LEN if content-length not defined
-        lengthOfRequestEntity(request);
+            // sets PROPERTY_REQ_LEN if content-length not defined
+            lengthOfRequestEntity(request);
 
-        // store start time to later calculate elapsed time
-        request.setProperty(PROPERTY_NANOS, System.nanoTime());
-        RequestLog.stopTiming(this);
+            // store start time to later calculate elapsed time
+            request.setProperty(PROPERTY_NANOS, System.nanoTime());
+        }
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/WeightCheckResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/WeightCheckResponseProcessor.java
@@ -38,7 +38,7 @@ public class WeightCheckResponseProcessor implements ResponseProcessor {
         return new FailureCallback() {
             @Override
             public void invoke(Throwable error) {
-                if (RequestLog.isStarted(REQUEST_WORKFLOW_TIMER)) {
+                if (RequestLog.isRunning(REQUEST_WORKFLOW_TIMER)) {
                     RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
                 }
                 next.getFailureCallback(druidQuery).invoke(error);
@@ -51,7 +51,7 @@ public class WeightCheckResponseProcessor implements ResponseProcessor {
     return new HttpErrorCallback() {
             @Override
             public void invoke(int statusCode, String reason, String responseBody) {
-                if (RequestLog.isStarted(REQUEST_WORKFLOW_TIMER)) {
+                if (RequestLog.isRunning(REQUEST_WORKFLOW_TIMER)) {
                     RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
                 }
                 next.getErrorCallback(druidQuery).invoke(statusCode, reason, responseBody);

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/WeightCheckResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/WeightCheckResponseProcessorSpec.groovy
@@ -44,7 +44,7 @@ class WeightCheckResponseProcessorSpec extends Specification{
         then: "no timer is stopped and proccessing continues to the next processor"
         // This check is artifial. Is meant to check that there is no call to stopTiming() for this timer in the
         // regular execution path of the WeightCheckResponseProcessor
-        RequestLog.isStarted(REQUEST_WORKFLOW_TIMER) == true
+        RequestLog.isRunning(REQUEST_WORKFLOW_TIMER) == true
         1 * next.processResponse(json, groupByQuery, null)
 
     }
@@ -57,7 +57,7 @@ class WeightCheckResponseProcessorSpec extends Specification{
         wcrp.getFailureCallback(groupByQuery).invoke(t)
 
         then: "The REQUEST_WORKFLOW_TIMER is stopped"
-        RequestLog.isStarted(REQUEST_WORKFLOW_TIMER) == false
+        RequestLog.isRunning(REQUEST_WORKFLOW_TIMER) == false
 
         then: "and the failure callback of the next processor is called"
         1 * next.getFailureCallback(groupByQuery) >> nextFail
@@ -77,7 +77,7 @@ class WeightCheckResponseProcessorSpec extends Specification{
         wcrp.getErrorCallback(groupByQuery).invoke(statusCode, reason, body)
 
         then: "The REQUEST_WORKFLOW_TIMER is stopped"
-        RequestLog.isStarted(REQUEST_WORKFLOW_TIMER) == false
+        RequestLog.isRunning(REQUEST_WORKFLOW_TIMER) == false
 
         then: "and the http error callback of the next processor is called"
         1 * next.getErrorCallback(groupByQuery) >> nextError


### PR DESCRIPTION
--This would allow us to wrap timed phases in a try-with-resources
block:

```java
   try(TimedPhase phase = RequestLog.startTiming("timerAllTheThings") {
                  doAllTheThings();
    }
```

--This has several advantages over the current approach:
        1. We always want to wrap the code that stops a timer in a finally block.
            Otherwise, the timer won't be stopped if we have an
            exception. try-with-resources makes that clean.
        2. It reduces the chances of typos when starting and stopping
            timers. It also reduces the chances of people staring a timer
            and then forgetting to stop it.
        3. It is more concise.

--This has several limitations:
        1. The minimum effort code to implement it is awkward. We'll
            need to do a much more significant (and not yet clear) refactor
            of RequestLog to handle this cleanly.
        2. Timers that cross threads can't be handled this way. Those
            still need to be stopped and started manually.

--Consequences that are more mixed:
        1. It exposes a lot more of the inner workings of RequestLog.
            This could make it easier to customers to perform their own
            custom timings, but it also exposes code that is very easy
            to use incorrectly if you don't have a strong understanding
            of it.