### PR TITLE
Expose the request phase durations stored by RequestLog: replaces Pr/100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,12 @@ Current
         starts the timer. Note: This won't work when performing timings across threads, or across
         contexts. Those need to be started and stopped manually.
 
+- [Expose the request phase durations stored by RequestLog](https://github.com/yahoo/fili/pull/100)
+    * Refactored the RequestLog by spinning the model out into a seperate class and marking the existing class as a
+    utility
+
+### Changed:
+
 ### Deprecated:
 
 - [`RequestLog::stopMostRecentTimer` has been deprecated](https://github.com/yahoo/fili/pull/143)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/async/MetadataHttpResponseChannel.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/async/MetadataHttpResponseChannel.java
@@ -4,7 +4,7 @@ package com.yahoo.bard.webservice.async;
 
 import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.RESPONSE_WORKFLOW_TIMER;
 
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 import com.yahoo.bard.webservice.web.handlers.RequestHandlerUtils;
 
@@ -66,8 +66,8 @@ public class MetadataHttpResponseChannel implements Observer<String> {
      * @param asyncResponse  The channel over which to send the response
      */
     private void send(Response response, AsyncResponse asyncResponse) {
-        if (RequestLog.isRunning(RESPONSE_WORKFLOW_TIMER)) {
-            RequestLog.stopTiming(RESPONSE_WORKFLOW_TIMER);
+        if (RequestLogUtils.isRunning(RESPONSE_WORKFLOW_TIMER)) {
+            RequestLogUtils.stopTiming(RESPONSE_WORKFLOW_TIMER);
         }
         asyncResponse.resume(response);
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseChannel.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseChannel.java
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.data;
 import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.RESPONSE_WORKFLOW_TIMER;
 
 import com.yahoo.bard.webservice.async.ResponseException;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.PreResponse;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
@@ -113,8 +113,8 @@ public class HttpResponseChannel implements Observer<PreResponse> {
      * @param response  The Response to send back to the user
      */
     private void publishResponse(Response response) {
-        if (RequestLog.isRunning(RESPONSE_WORKFLOW_TIMER)) {
-            RequestLog.stopTiming(RESPONSE_WORKFLOW_TIMER);
+        if (RequestLogUtils.isRunning(RESPONSE_WORKFLOW_TIMER)) {
+            RequestLogUtils.stopTiming(RESPONSE_WORKFLOW_TIMER);
         }
         asyncResponse.resume(response);
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/LuceneSearchProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/LuceneSearchProvider.java
@@ -11,8 +11,8 @@ import com.yahoo.bard.webservice.data.dimension.DimensionRow;
 import com.yahoo.bard.webservice.data.dimension.KeyValueStore;
 import com.yahoo.bard.webservice.data.dimension.SearchProvider;
 import com.yahoo.bard.webservice.data.dimension.TimeoutException;
-import com.yahoo.bard.webservice.logging.RequestLog;
 import com.yahoo.bard.webservice.logging.TimedPhase;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.util.DimensionStoreKeyUtils;
 import com.yahoo.bard.webservice.util.Pagination;
 import com.yahoo.bard.webservice.util.SinglePagePagination;
@@ -573,7 +573,7 @@ public class LuceneSearchProvider implements SearchProvider {
         lock.readLock().lock();
         try {
             ScoreDoc[] hits;
-            try (TimedPhase timer = RequestLog.startTiming("QueryingLucene")) {
+            try (TimedPhase timer = RequestLogUtils.startTiming("QueryingLucene")) {
                 hits = getPageOfData(
                         luceneIndexSearcher,
                         null,
@@ -598,7 +598,7 @@ public class LuceneSearchProvider implements SearchProvider {
             }
 
             // convert hits to dimension rows
-            try (TimedPhase timer = RequestLog.startTiming("LuceneHydratingDimensionRows")) {
+            try (TimedPhase timer = RequestLogUtils.startTiming("LuceneHydratingDimensionRows")) {
                 String idKey = DimensionStoreKeyUtils.getColumnKey(dimension.getKey().getName());
                 filteredDimRows = Arrays.stream(hits)
                         .map(
@@ -615,7 +615,6 @@ public class LuceneSearchProvider implements SearchProvider {
                         .map(dimension::findDimensionRowByKeyValue)
                         .collect(Collectors.toCollection(TreeSet::new));
             }
-
             documentCount = luceneIndexSearcher.count(query); //throws the caught IOException
         } catch (IOException e) {
             LOG.error("Unable to get count of matched rows for the query " + query.toString() +

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/DateTimeSortMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/DateTimeSortMapper.java
@@ -6,7 +6,7 @@ import com.yahoo.bard.webservice.data.Result;
 import com.yahoo.bard.webservice.data.ResultSet;
 import com.yahoo.bard.webservice.data.ResultSetSchema;
 import com.yahoo.bard.webservice.druid.model.orderby.SortDirection;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.TimedPhase;
 
 import org.joda.time.DateTime;
 
@@ -46,8 +46,7 @@ public class DateTimeSortMapper extends ResultSetMapper {
 
         Map<DateTime, List<Result>> bucketizedResultsMap = new LinkedHashMap<>();
 
-        RequestLog.startTiming("sortResultSet");
-        try {
+        try (TimedPhase timer = new TimedPhase("sortResultSet")) {
             for (Result result : resultSet) {
                 bucketizedResultsMap.computeIfAbsent(result.getTimeStamp(), ignored -> new ArrayList<>()).add(result);
             }
@@ -65,8 +64,6 @@ public class DateTimeSortMapper extends ResultSetMapper {
                             .flatMap(List::stream)
                             .collect(Collectors.toList())
             );
-        } finally {
-            RequestLog.stopTiming("sortResultSet");
         }
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/FailureCallback.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/FailureCallback.java
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.druid.client;
 import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.REQUEST_WORKFLOW_TIMER;
 import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.RESPONSE_WORKFLOW_TIMER;
 
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 /**
  * Callback from the async HTTP client on error.
@@ -24,8 +24,8 @@ public interface FailureCallback {
      * @param error  The error that caused the failure
      */
     default void dispatch(Throwable error) {
-        RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
-        RequestLog.startTiming(RESPONSE_WORKFLOW_TIMER);
+        RequestLogUtils.stopTiming(REQUEST_WORKFLOW_TIMER);
+        RequestLogUtils.startTiming(RESPONSE_WORKFLOW_TIMER);
         invoke(error);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/HttpErrorCallback.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/HttpErrorCallback.java
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.druid.client;
 import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.REQUEST_WORKFLOW_TIMER;
 import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.RESPONSE_WORKFLOW_TIMER;
 
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 /**
  * Callback from the async HTTP client on error.
@@ -28,8 +28,8 @@ public interface HttpErrorCallback {
      * @param statusCode  Http status code of the error response
      */
     default void dispatch(int statusCode, String reasonPhrase, String responseBody) {
-        RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
-        RequestLog.startTiming(RESPONSE_WORKFLOW_TIMER);
+        RequestLogUtils.stopTiming(REQUEST_WORKFLOW_TIMER);
+        RequestLogUtils.startTiming(RESPONSE_WORKFLOW_TIMER);
         invoke(statusCode, reasonPhrase, responseBody);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/AbstractDruidQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/AbstractDruidQuery.java
@@ -4,7 +4,7 @@ package com.yahoo.bard.webservice.druid.model.query;
 
 import com.yahoo.bard.webservice.druid.model.QueryType;
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -43,7 +43,7 @@ public abstract class AbstractDruidQuery<Q extends AbstractDruidQuery<? super Q>
         this.dataSource = dataSource;
         this.context = context == null ?
                 new QueryContext(Collections.<QueryContext.Param, Object>emptyMap(), null)
-                        .withQueryId(RequestLog.getId()) :
+                        .withQueryId(RequestLogUtils.getId()) :
                 doFork ? context.fork() : context;
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/JsonLogFormatter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/JsonLogFormatter.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * A log formatter that prints log in JSON format.
  */
 public class JsonLogFormatter implements LogFormatter {
-    private static final Logger LOG = LoggerFactory.getLogger(RequestLog.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RequestLogUtils.class);
     private final ObjectMapper objectMapper;
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -5,13 +5,8 @@ package com.yahoo.bard.webservice.logging;
 import static com.yahoo.bard.webservice.druid.client.impl.AsyncDruidWebServiceImpl.DRUID_QUERY_ALL_TIMER;
 import static com.yahoo.bard.webservice.druid.client.impl.AsyncDruidWebServiceImpl.DRUID_QUERY_MAX_TIMER;
 import static com.yahoo.bard.webservice.druid.client.impl.AsyncDruidWebServiceImpl.DRUID_QUERY_TIMER;
-import static com.yahoo.bard.webservice.util.StreamUtils.not;
-import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.REQUEST_WORKFLOW_TIMER;
-import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.RESPONSE_WORKFLOW_TIMER;
 
 import com.yahoo.bard.webservice.application.MetricRegistryFactory;
-import com.yahoo.bard.webservice.config.SystemConfig;
-import com.yahoo.bard.webservice.config.SystemConfigProvider;
 import com.yahoo.bard.webservice.logging.blocks.Durations;
 import com.yahoo.bard.webservice.logging.blocks.Preface;
 import com.yahoo.bard.webservice.logging.blocks.Threads;
@@ -23,10 +18,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalLong;
@@ -35,41 +28,36 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+
 /**
- * Represents the logging framework that provides timing capabilities of arbitrary phases on the handling lifecycle of a
- * request and accumulation of information for such a request in a single mega log line.
+ * The RequestLog holds data that we would like to log about the request. In particular, various timings are
+ * accumulated here.
  */
 public class RequestLog {
-
-    private static final Logger LOG = LoggerFactory.getLogger(RequestLog.class);
-    private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
-
-    private static final String ID_KEY = "logid";
-    private static final long MS_PER_NS = 1000000;
     private static final MetricRegistry REGISTRY = MetricRegistryFactory.getRegistry();
-    private static final ThreadLocal<RequestLog> RLOG = ThreadLocal.withInitial(RequestLog::new);
-    private static final String LOGINFO_ORDER_STRING = SYSTEM_CONFIG.getStringProperty(
-            SYSTEM_CONFIG.getPackageVariableName("requestlog_loginfo_order"), ""
-    );
-    private static final List<String> LOGINFO_ORDER = generateLogInfoOrder(LOGINFO_ORDER_STRING);
+    private static final Logger LOG = LoggerFactory.getLogger(RequestLog.class);
+    private static final long MS_PER_NS = 1000000;
 
-    private String logId;
-    private LogBlock info;
+    protected String logId;
+    protected LogBlock info;
     @Deprecated
-    private TimedPhase mostRecentTimer;
-    private final Map<String, TimedPhase> times;
-    private final Set<String> threadIds;
+    protected TimedPhase mostRecentTimer;
+    protected final Map<String, TimedPhase> times;
+    protected final Set<String> threadIds;
+
+    public static final String LOG_ID_KEY = "logid";
 
     /**
      * This class has only static methods and is not supposed to be directly instantiated.
      */
-    private RequestLog() {
+    protected RequestLog() {
         logId = null;
         info = null;
         mostRecentTimer = null;
         times = new LinkedHashMap<>();
         threadIds = new LinkedHashSet<>();
-        MDC.remove(ID_KEY);
+        MDC.remove(LOG_ID_KEY);
+        init();
     }
 
     /**
@@ -77,31 +65,47 @@ public class RequestLog {
      *
      * @param  rl request log object to copy from
      */
-    private RequestLog(RequestLog rl) {
+    protected RequestLog(RequestLog rl) {
         logId = rl.logId;
         info = rl.info;
         mostRecentTimer = rl.mostRecentTimer;
         times = new LinkedHashMap<>(rl.times);
         threadIds = new LinkedHashSet<>(rl.threadIds);
-        MDC.put(ID_KEY, logId);
+        MDC.put(LOG_ID_KEY, logId);
     }
 
     /**
      * Resets the contents of a request log at the calling thread.
      */
-    private void clear() {
+    protected void clear() {
         logId = null;
         info = null;
         mostRecentTimer = null;
         times.clear();
         threadIds.clear();
-        MDC.remove(ID_KEY);
+        MDC.remove(LOG_ID_KEY);
+    }
+
+    /**
+     * Copys the data from source into the current request log.
+     *
+     * @param source the request log to copy from
+     */
+    protected void restoreFrom(RequestLog source) {
+        clear();
+        logId = source.logId;
+        info = source.info;
+        mostRecentTimer = source.mostRecentTimer;
+        times.putAll(source.times);
+        threadIds.addAll(source.threadIds);
+        threadIds.add(Thread.currentThread().getName());
+
     }
 
     /**
      * Creates a new and empty request log at the calling thread.
      */
-    private void init() {
+    protected void init() {
         logId = UUID.randomUUID().toString();
         info = new LogBlock(logId);
         // Trick to place Durations and Threads in front of the Json while keep using a LinkedHashMap.
@@ -109,7 +113,7 @@ public class RequestLog {
         info.add(Durations.class);
         info.add(Threads.class);
         info.add(Preface.class);
-        getLoginfoOrder().stream().filter(entry -> !Objects.equals(entry, "Epilogue")).forEachOrdered(
+        RequestLogUtils.getLoginfoOrder().stream().filter(entry -> !Objects.equals(entry, "Epilogue")).forEachOrdered(
                 entry -> {
                     try {
                         @SuppressWarnings("unchecked")
@@ -124,24 +128,46 @@ public class RequestLog {
         times.clear();
         threadIds.clear();
         threadIds.add(Thread.currentThread().getName());
-        MDC.put(ID_KEY, logId);
+        MDC.put(LOG_ID_KEY, logId);
+    }
+
+    /**
+     * Retrieve a {@link TimedPhase} if it exists.
+     *
+     * @param phaseName the name of the timed phase
+     *
+     * @return the phase
+     */
+    protected TimedPhase getPhase(String phaseName) {
+        return times.get(phaseName);
+    }
+
+    /**
+     * Add a timed phase to the request log.
+     *
+     * @param phase the phase to be timed
+     */
+    protected void putPhase(TimedPhase phase) {
+        times.put(phase.getName(), phase);
     }
 
     /**
      * Adds the durations in milliseconds of all the recorded timed phases to a map.
      *
-     * @return the map containing all the recorded times per phase in milliseconds
+     * @return the map containing all the recorded times per phase in nanoseconds
      */
-    private Map<String, Long> getDurations() {
+    public Map<String, Long> getDurations() {
         return times.values().stream().collect(Collectors.toMap(TimedPhase::getName, TimedPhase::getDuration));
     }
 
     /**
      * Adds the durations in milliseconds of all the recorded timed phases to a map.
      *
+     * @param updateTimers a flag indicating whether or not the metrics registry should be updated
+     *
      * @return the map containing all the recorded times per phase in milliseconds
      */
-    private Map<String, Float> aggregateDurations() {
+    protected Map<String, Float> getAggregateDurations(boolean updateTimers) {
         Map<String, Long> durations = getDurations();
 
         OptionalLong max = durations.entrySet()
@@ -152,7 +178,9 @@ public class RequestLog {
                 .max();
 
         if (max.isPresent()) {
-            REGISTRY.timer(DRUID_QUERY_MAX_TIMER).update(max.getAsLong(), TimeUnit.NANOSECONDS);
+            if (updateTimers) {
+                REGISTRY.timer(DRUID_QUERY_MAX_TIMER).update(max.getAsLong(), TimeUnit.NANOSECONDS);
+            }
             durations.put(DRUID_QUERY_MAX_TIMER, max.getAsLong());
         }
 
@@ -162,288 +190,11 @@ public class RequestLog {
     }
 
     /**
-     * Check if a stopwatch is currently running.
+     * Registers the specified timer with the codahale metrics.
      *
-     * @param caller  the caller to name this stopwatch with its class's simple name
-     *
-     * @return whether this stopwatch is started
-     */
-
-    public static boolean isRunning(Object caller) {
-        return isRunning(caller.getClass().getSimpleName());
-    }
-
-    /**
-     * Check if a stopwatch is started.
-     *
-     * @param timePhaseName  the name of this stopwatch
-     *
-     * @return whether this stopwatch is started
-     */
-    public static boolean isRunning(String timePhaseName) {
-        RequestLog current = RLOG.get();
-        TimedPhase timePhase = current.times.get(timePhaseName);
-        return timePhase != null && timePhase.isRunning();
-    }
-
-    /**
-     * Start a stopwatch.
-     * Time is accumulated if the stopwatch is already registered
-     *
-     * @param caller  the caller to name this stopwatch with its class's simple name
-     *
-     * @return The stopwatch
-     */
-    public static TimedPhase startTiming(Object caller) {
-        return startTiming(caller.getClass().getSimpleName());
-    }
-
-    /**
-     * Start a stopwatch.
-     * Time is accumulated if the stopwatch is already registered
-     *
-     * @param timePhaseName  the name of this stopwatch
-     *
-     * @return The stopwatch
-     */
-    public static TimedPhase startTiming(String timePhaseName) {
-        RequestLog current = RLOG.get();
-        TimedPhase timePhase = current.times.get(timePhaseName);
-        if (timePhase == null) {
-            // If it was the first phase in general, create logging context as well
-            if (current.info == null) {
-                current.init();
-            }
-
-            timePhase = new TimedPhase(timePhaseName);
-            current.times.put(timePhaseName, timePhase);
-        }
-        current.mostRecentTimer = timePhase;
-        return timePhase.start();
-    }
-
-    /**
-     * Stop the most recent stopwatch and start this one.
-     * Time is accumulated if the stopwatch is already registered.
-     *
-     * @param nextPhase  the name of the stopwatch to be started
-     *
-     * @deprecated This method is too dependent on context that can be too easily changed by internal method calls.
-     * Each timer should be explicitly started by {@link RequestLog#startTiming(String)} and stopped by
-     * {@link RequestLog#stopTiming(String)} instead
-     */
-    @Deprecated
-    public static void switchTiming(String nextPhase) {
-        stopMostRecentTimer();
-        startTiming(nextPhase);
-    }
-
-    /**
-     * Pause a stopwatch.
-     *
-     * @param caller  the caller to name this stopwatch with its class's simple name
-     */
-    public static void stopTiming(Object caller) {
-        stopTiming(caller.getClass().getSimpleName());
-    }
-
-    /**
-     * Registers the final duration of a stopped timer with the RequestLog.
-     *
-     * @param stoppedPhase  The phase that has been stopped, and whose duration needs to be stored
+     * @param stoppedPhase  The timed phase to be registered
      */
     public static void registerTime(TimedPhase stoppedPhase) {
-        RequestLog.REGISTRY.timer(stoppedPhase.getName()).update(stoppedPhase.getDuration(), stoppedPhase.getUnit());
-    }
-
-    /**
-     * Pause a stopwatch.
-     *
-     * @param timePhaseName  the name of this stopwatch
-     */
-    public static void stopTiming(String timePhaseName) {
-        TimedPhase timePhase = RLOG.get().times.get(timePhaseName);
-        if (timePhase == null) {
-            LOG.warn("Tried to stop non-existent phase: {}", timePhaseName);
-            return;
-        }
-        timePhase.close();
-    }
-
-    /**
-     * Stop the most recent stopwatch.
-     *
-     * @deprecated  Stopping a timer based on context is brittle, and prone to unexpected changes. Timers should be
-     * stopped explicitly, or started in a try-with-resources block
-     */
-    @Deprecated
-    public static void stopMostRecentTimer() {
-        try {
-            stopTiming(RLOG.get().mostRecentTimer.getName());
-        } catch (NullPointerException ignored) {
-            LOG.warn("Stopping timing failed because mostRecentTimer wasn't registered.");
-        }
-    }
-
-    /**
-     * Record logging information in the logging context.
-     *
-     * @param logPhase  the name of the class destined to hold this logging information
-     *
-     * @see LogBlock
-     */
-    public static void record(LogInfo logPhase) {
-        try {
-            RLOG.get().info.add(logPhase);
-        } catch (NullPointerException ignored) {
-            LOG.warn(
-                    "Attempted to append log info while request log object was uninitialized: {}",
-                    logPhase.getClass().getSimpleName()
-            );
-        }
-    }
-
-    /**
-     * Write the request log object of the current thread as JSON.
-     * The thread's request log is cleared after a call to this method.
-     */
-    public static void log() {
-        RequestLog current = RLOG.get();
-        if (current.info == null) {
-            LOG.warn("Attempted to log while request log object was uninitialized");
-            return;
-        }
-        LOG.info(export());
-        current.clear();
-    }
-
-    /**
-     * Exports a snapshot of the request log of the current thread and also resets the request log for that thread.
-     *
-     * @return the log context of the current thread
-     */
-    public static RequestLog dump() {
-        RequestLog current = RLOG.get();
-        RequestLog copy = new RequestLog(current);
-        current.clear();
-        RLOG.remove();
-        return copy;
-    }
-
-    /**
-     * Exports a snapshot of the request log of the current thread without resetting the request log for that thread.
-     *
-     * @return the log context of the current thread
-     */
-    public static RequestLog copy() {
-        RequestLog current = RLOG.get();
-        return new RequestLog(current);
-    }
-
-    /**
-     * Returns the id of this request log as a string.
-     * If called on an empty request log context, it initializes it.
-     *
-     * @return the log id
-     */
-    public static String getId() {
-        RequestLog current = RLOG.get();
-        if (current.info == null) {
-            current.init();
-        }
-        return current.logId;
-    }
-
-    /**
-     * Prepend an id prefix to generated druid query id.
-     *
-     * @param idPrefix  Prefix for queryId sent to druid
-     */
-    public static void addIdPrefix(String idPrefix) {
-        RequestLog current = RLOG.get();
-        String newId = idPrefix + getId();
-        current.info = current.info.withUuid(newId);
-        current.logId = newId;
-        MDC.put(ID_KEY, newId);
-    }
-
-    /**
-     * Overwrite current thread's request log context.
-     * It first clears the request log of the current thread and then fills it with the contents found in ctx
-     *
-     * @param ctx  the log context to restore to current thread's request log
-     */
-    public static void restore(RequestLog ctx) {
-        RequestLog current = RLOG.get();
-        current.clear();
-        current.logId = ctx.logId;
-        current.info = ctx.info;
-        current.mostRecentTimer = ctx.mostRecentTimer;
-        current.times.putAll(ctx.times);
-        current.threadIds.addAll(ctx.threadIds);
-        current.threadIds.add(Thread.currentThread().getName());
-        MDC.put(ID_KEY, current.logId);
-    }
-
-    /**
-     * Accumulates timings and threads to current thread's request log context.
-     * It fills in the contents found in {@code ctx}. If the two contexts refer to different requests, then it logs a
-     * warning and returns.
-     *
-     * @param ctx  The log context to accumulate to current thread's request log
-     */
-    public static void accumulate(RequestLog ctx) {
-        RequestLog current = RLOG.get();
-        if (!Objects.equals(current.logId, ctx.logId)) {
-            LOG.warn(
-                    "Tried to accumulate information to the current request: {} from a different request context: {}",
-                    current.logId,
-                    ctx.logId
-            );
-            return;
-        }
-        // Accumulate all the timers that are not currently running
-        current.times.putAll(
-                ctx.times.entrySet()
-                        .stream()
-                        .filter(
-                                e -> e.getKey().contains(DRUID_QUERY_TIMER) ||
-                                        (e.getKey().equals(REQUEST_WORKFLOW_TIMER) && !e.getValue().isRunning()) ||
-                                        (e.getKey().equals(RESPONSE_WORKFLOW_TIMER) && e.getValue().isRunning())
-                        )
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-        );
-        current.threadIds.addAll(ctx.threadIds);
-        current.threadIds.add(Thread.currentThread().getName());
-    }
-
-    /**
-     * Exports current thread's request log object as a formatted string without resetting it.
-     *
-     * @return log object as a formatted string
-     */
-    public static String export() {
-        RequestLog current = RLOG.get();
-        record(new Durations(current.aggregateDurations()));
-        record(new Threads(current.threadIds));
-        return LogFormatterProvider.getInstance().format(current.info);
-    }
-
-    private List<String> getLoginfoOrder() {
-        return LOGINFO_ORDER;
-    }
-
-    /**
-     * Get the logging blocks that need to be at the "head" of the log output.
-     *
-     * @param order  Indication of order of the initial blocks.
-     *
-     * @return the blocks in order
-     */
-    private static List<String> generateLogInfoOrder(String order) {
-        return Arrays.stream(order.replaceAll("\\s+", "").split(","))
-                .filter(not(String::isEmpty))
-                .map(name -> "com.yahoo.bard.webservice.logging.blocks." + name)
-                .collect(Collectors.toList());
+        REGISTRY.timer(stoppedPhase.getName()).update(stoppedPhase.getDuration(), stoppedPhase.getUnit());
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLogUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLogUtils.java
@@ -1,0 +1,356 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.logging;
+
+import static com.yahoo.bard.webservice.druid.client.impl.AsyncDruidWebServiceImpl.DRUID_QUERY_TIMER;
+import static com.yahoo.bard.webservice.logging.RequestLog.LOG_ID_KEY;
+import static com.yahoo.bard.webservice.util.StreamUtils.not;
+import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.REQUEST_WORKFLOW_TIMER;
+import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.RESPONSE_WORKFLOW_TIMER;
+
+import com.yahoo.bard.webservice.config.SystemConfig;
+import com.yahoo.bard.webservice.config.SystemConfigProvider;
+import com.yahoo.bard.webservice.logging.blocks.Durations;
+import com.yahoo.bard.webservice.logging.blocks.Threads;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * An interface for application code to interact with the {@link RequestLog}.
+ */
+public class RequestLogUtils {
+    private static final String TOTAL_TIMER = "TotalTime";
+    private static final Logger LOG = LoggerFactory.getLogger(RequestLog.class);
+    private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
+    private static final List<String> LOGINFO_ORDER = generateLogInfoOrder();
+
+    private static final ThreadLocal<RequestLog> RLOG = ThreadLocal.withInitial(RequestLog::new);
+
+    /**
+     * Thou shalt not.
+     */
+    private RequestLogUtils() {
+    }
+
+    /**
+     * Check if a stopwatch is started.
+     *
+     * @param caller  the caller to name this stopwatch with its class's simple name
+     *
+     * @return whether this stopwatch is started
+     */
+    public static boolean isRunning(Object caller) {
+        return isRunning(caller.getClass().getSimpleName());
+    }
+
+    /**
+     * Check if a stopwatch is started.
+     *
+     * @param timePhaseName  the name of this stopwatch
+     *
+     * @return whether this stopwatch is started
+     */
+    public static boolean isRunning(String timePhaseName) {
+        RequestLog current = RLOG.get();
+        TimedPhase timePhase = current.getPhase(timePhaseName);
+        return timePhase != null && timePhase.isRunning();
+    }
+
+    /**
+     * Start timing the request.
+     * Should be called exactly once, when a request is received by Fili
+     */
+    public static void startTimingRequest() {
+        startTiming(TOTAL_TIMER);
+    }
+
+    /**
+     * Start a stopwatch.
+     * Time is accumulated if the stopwatch is already registered
+     *
+     * @param caller  the caller to name this stopwatch with its class's simple name
+     *
+     * @return The started stopwatch
+     */
+    public static TimedPhase startTiming(Object caller) {
+        return startTiming(caller.getClass().getSimpleName());
+    }
+
+    /**
+     * Start a stopwatch.
+     * Time is accumulated if the stopwatch is already registered
+     *
+     * @param timePhaseName  the name of this stopwatch
+     *
+     * @return The started stopwatch
+     */
+    public static TimedPhase startTiming(String timePhaseName) {
+        RequestLog current = RLOG.get();
+        TimedPhase timePhase = current.getPhase(timePhaseName);
+        if (timePhase == null) {
+            // If it was the first phase in general, create logging context as well
+            if (current.info == null) {
+                current.init();
+            }
+
+            timePhase = new TimedPhase(timePhaseName);
+            current.putPhase(timePhase);
+        }
+        current.mostRecentTimer = timePhase;
+        timePhase.start();
+        return timePhase;
+    }
+
+    /**
+     * Stop the most recent stopwatch and start this one.
+     * Time is accumulated if the stopwatch is already registered.
+     *
+     * @param nextPhase  the name of the stopwatch to be started
+     */
+    @Deprecated
+    public static void switchTiming(String nextPhase) {
+        stopMostRecentTimer();
+        startTiming(nextPhase);
+    }
+
+    /**
+     * Stops the request timer.
+     * Should be called exactly once, just before Fili responds to the request
+     */
+    public static void stopTimingRequest() {
+        stopTiming(TOTAL_TIMER);
+    }
+
+    /**
+     * Pause a stopwatch.
+     *
+     * @param caller  the caller to name this stopwatch with its class's simple name
+     */
+    public static void stopTiming(Object caller) {
+        stopTiming(caller.getClass().getSimpleName());
+    }
+
+    /**
+     * Pause a stopwatch.
+     *
+     * @param timePhaseName  the name of this stopwatch
+     */
+    public static void stopTiming(String timePhaseName) {
+        TimedPhase timePhase = RLOG.get().getPhase(timePhaseName);
+        if (timePhase == null) {
+            LOG.warn("Tried to stop non-existent phase: {}", timePhaseName);
+            return;
+        }
+        timePhase.stop();
+    }
+
+    /**
+     * Stop the most recent stopwatch.
+     */
+    @Deprecated
+    public static void stopMostRecentTimer() {
+        try {
+            stopTiming(RLOG.get().mostRecentTimer.getName());
+        } catch (NullPointerException ignored) {
+            LOG.warn("Stopping timing failed because mostRecentTimer wasn't registered.");
+        }
+    }
+
+    /**
+     * Expose the request phases and their durations in nanoseconds.
+     *
+     * @return a mapping of phase -&gt; duration (ns)
+     */
+    public static Map<String, Long> getDurations() {
+        return RLOG.get().getDurations();
+    }
+
+    /**
+     * Expose the request phases and their durations in milliseconds (including an entry for the longest druid query
+     * that ran).
+     *
+     * @return a mapping of phase -&gt; duration (ms)
+     */
+    public static Map<String, Float> getAggregateDurations() {
+        return RLOG.get().getAggregateDurations(false);
+    }
+
+    /**
+     * Record logging information in the logging context.
+     *
+     * @param logPhase  the name of the class destined to hold this logging information
+     *
+     * @see LogBlock
+     */
+    public static void record(LogInfo logPhase) {
+        try {
+            RLOG.get().info.add(logPhase);
+        } catch (NullPointerException ignored) {
+            LOG.warn(
+                    "Attempted to append log info while request log object was uninitialized: {}",
+                    logPhase.getClass().getSimpleName()
+            );
+        }
+    }
+
+    /**
+     * Write the request log object of the current thread as JSON.
+     * If the RequestLog's exported string is empty, then nothing is logged. The thread's request log is cleared after a
+     * call to this method.
+     */
+    public static void log() {
+        RequestLog current = RLOG.get();
+        if (current.info == null) {
+            LOG.warn("Attempted to log while request log object was uninitialized");
+            return;
+        }
+        String formattedString = export();
+        if (!formattedString.isEmpty()) {
+            LOG.info(formattedString);
+        }
+        current.clear();
+    }
+
+    /**
+     * Exports a snapshot of the request log of the current thread and also resets the request log for that thread.
+     *
+     * @return the log context of the current thread
+     */
+    public static RequestLog dump() {
+        RequestLog current = RLOG.get();
+        RequestLog copy = new RequestLog(current);
+        current.clear();
+        RLOG.remove();
+        return copy;
+    }
+
+    /**
+     * Exports a snapshot of the request log of the current thread without resetting the request log for that thread.
+     *
+     * @return the log context of the current thread
+     */
+    public static RequestLog copy() {
+        RequestLog current = RLOG.get();
+        return new RequestLog(current);
+    }
+
+    /**
+     * Returns the id of this request log as a string.
+     * If called on an empty request log context, it initializes it.
+     *
+     * @return the log id
+     */
+    public static String getId() {
+        RequestLog current = RLOG.get();
+        if (current.info == null) {
+            current.init();
+        }
+        return current.logId;
+    }
+
+    /**
+     * Prepend an id prefix to generated druid query id.
+     *
+     * @param idPrefix  Prefix for queryId sent to druid
+     */
+    public static void addIdPrefix(String idPrefix) {
+        RequestLog current = RLOG.get();
+        String newId = idPrefix + getId();
+        current.info = current.info.withUuid(newId);
+        current.logId = newId;
+        MDC.put(LOG_ID_KEY, newId);
+    }
+
+    /**
+     * Overwrite current thread's request log context.
+     * It first clears the request log of the current thread and then fills it with the contents found in ctx
+     *
+     * @param ctx  the log context to restore to current thread's request log
+     */
+    public static void restore(RequestLog ctx) {
+        RequestLog current = RLOG.get();
+        current.restoreFrom(ctx);
+        MDC.put(LOG_ID_KEY, current.logId);
+    }
+
+    /**
+     * Accumulates timings and threads to current thread's request log context.
+     * It fills in the contents found in {@code ctx}. If the two contexts refer to different requests, then it logs a
+     * warning and returns.
+     *
+     * @param ctx  The log context to accumulate to current thread's request log
+     */
+    public static void accumulate(RequestLog ctx) {
+        RequestLog current = RLOG.get();
+        if (!Objects.equals(current.logId, ctx.logId)) {
+            LOG.warn(
+                    "Tried to accumulate information to the current request: {} from a different request context: {}",
+                    current.logId,
+                    ctx.logId
+            );
+            return;
+        }
+        // Accumulate all the timers that are not currently running
+        current.times.putAll(
+                ctx.times.entrySet()
+                        .stream()
+                        .filter(
+                                e -> e.getKey().contains(DRUID_QUERY_TIMER) ||
+                                        (e.getKey().equals(REQUEST_WORKFLOW_TIMER) && !e.getValue().isRunning()) ||
+                                        (e.getKey().equals(RESPONSE_WORKFLOW_TIMER) && e.getValue().isRunning())
+                        )
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+        );
+        current.threadIds.addAll(ctx.threadIds);
+        current.threadIds.add(Thread.currentThread().getName());
+    }
+
+    /**
+     * Exports current thread's request log object as a formatted string without resetting it.
+     *
+     * @return log object as a formatted string
+     */
+    public static String export() {
+        RequestLog current = RLOG.get();
+        record(new Durations(current.getAggregateDurations(true)));
+        record(new Threads(current.threadIds));
+        return LogFormatterProvider.getInstance().format(current.info);
+    }
+
+    protected static List<String> getLoginfoOrder() {
+        return LOGINFO_ORDER;
+    }
+
+    /**
+     * Get the logging blocks that need to be at the "head" of the log output.
+     *
+     * @return the blocks in order
+     */
+    private static List<String> generateLogInfoOrder() {
+        String order = SYSTEM_CONFIG.getStringProperty(
+                SYSTEM_CONFIG.getPackageVariableName("requestlog_loginfo_order"), ""
+        );
+        return generateLogInfoOrder(order);
+    }
+
+    /**
+     * This is a silly method that is only exposed for testing.
+     *
+     * @param order The requested order of the initial blocks.
+     * @return the blocks in order
+     */
+    private static List<String> generateLogInfoOrder(String order) {
+        return Arrays.stream(order.replaceAll("\\s+", "").split(","))
+                .filter(not(String::isEmpty))
+                .map(name -> "com.yahoo.bard.webservice.logging.blocks." + name)
+                .collect(Collectors.toList());
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/DataApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/DataApiRequest.java
@@ -49,8 +49,8 @@ import com.yahoo.bard.webservice.druid.model.orderby.SortDirection;
 import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier;
-import com.yahoo.bard.webservice.logging.RequestLog;
 import com.yahoo.bard.webservice.logging.TimedPhase;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.table.LogicalTable;
 import com.yahoo.bard.webservice.table.TableIdentifier;
 import com.yahoo.bard.webservice.util.StreamUtils;
@@ -229,7 +229,7 @@ public class DataApiRequest extends ApiRequest {
         this.filters = generateFilters(filters, table, dimensionDictionary);
         validateRequestDimensions(this.filters.keySet(), this.table);
 
-        try (TimedPhase timer = RequestLog.startTiming("BuildingDruidFilter")) {
+        try (TimedPhase timer = RequestLogUtils.startTiming("BuildingDruidFilter")) {
             this.filter = filterBuilder.buildFilters(this.filters);
         } catch (DimensionRowNotFoundException e) {
             LOG.debug(e.getMessage());
@@ -388,7 +388,7 @@ public class DataApiRequest extends ApiRequest {
      * @return the request's TimeZone
      */
     private DateTimeZone generateTimeZone(String timeZoneId, DateTimeZone systemTimeZone) {
-        try (TimedPhase timer = RequestLog.startTiming("generatingTimeZone")) {
+        try (TimedPhase timer = RequestLogUtils.startTiming("generatingTimeZone")) {
             if (timeZoneId == null) {
                 return systemTimeZone;
             }
@@ -565,7 +565,7 @@ public class DataApiRequest extends ApiRequest {
             List<PathSegment> apiDimensions,
             DimensionDictionary dimensionDictionary
     ) throws BadApiRequestException {
-        try (TimedPhase timer = RequestLog.startTiming("GeneratingDimensions")) {
+        try (TimedPhase timer = RequestLogUtils.startTiming("GeneratingDimensions")) {
             // Dimensions are optional hence check if dimensions are requested.
             if (apiDimensions == null || apiDimensions.isEmpty()) {
                 return new LinkedHashSet<>();
@@ -616,7 +616,7 @@ public class DataApiRequest extends ApiRequest {
             @NotNull List<PathSegment> apiDimensionPathSegments,
             @NotNull DimensionDictionary dimensionDictionary
     ) {
-        try (TimedPhase timer = RequestLog.startTiming("GeneratingDimensionFields")) {
+        try (TimedPhase timer = RequestLogUtils.startTiming("GeneratingDimensionFields")) {
             return apiDimensionPathSegments.stream()
                     .filter(pathSegment -> !pathSegment.getPath().isEmpty())
                     .collect(Collectors.toMap(
@@ -799,7 +799,7 @@ public class DataApiRequest extends ApiRequest {
             DimensionDictionary dimensionDictionary,
             LogicalTable table
     ) throws BadApiRequestException {
-        try (TimedPhase timer = RequestLog.startTiming("GeneratingLogicalMetrics")) {
+        try (TimedPhase timer = RequestLogUtils.startTiming("GeneratingLogicalMetrics")) {
             LOG.trace("Metric dictionary: {}", metricDictionary);
 
             if (apiMetricQuery == null || "".equals(apiMetricQuery)) {
@@ -970,7 +970,7 @@ public class DataApiRequest extends ApiRequest {
             Granularity granularity,
             DateTimeFormatter dateTimeFormatter
     ) throws BadApiRequestException {
-        try (TimedPhase timer = RequestLog.startTiming("GeneratingIntervals")) {
+        try (TimedPhase timer = RequestLogUtils.startTiming("GeneratingIntervals")) {
             Set<Interval> generated = new LinkedHashSet<>();
             if (apiIntervalQuery == null || apiIntervalQuery.equals("")) {
                 LOG.debug(INTERVAL_MISSING.logFormat());
@@ -1061,7 +1061,7 @@ public class DataApiRequest extends ApiRequest {
             LogicalTable table,
             DimensionDictionary dimensionDictionary
     ) throws BadApiRequestException {
-        try (TimedPhase timer = RequestLog.startTiming("GeneratingFilters")) {
+        try (TimedPhase timer = RequestLogUtils.startTiming("GeneratingFilters")) {
             LOG.trace("Dimension Dictionary: {}", dimensionDictionary);
             // Set of filter objects
             Map<Dimension, Set<ApiFilter>> generated = new LinkedHashMap<>();
@@ -1132,7 +1132,7 @@ public class DataApiRequest extends ApiRequest {
             Set<LogicalMetric> logicalMetrics,
             MetricDictionary metricDictionary
     ) throws BadApiRequestException {
-        try (TimedPhase phase = RequestLog.startTiming("GeneratingHavings")) {
+        try (TimedPhase phase = RequestLogUtils.startTiming("GeneratingHavings")) {
             LOG.trace("Metric Dictionary: {}", metricDictionary);
             // Havings are optional hence check if havings are requested.
             if (havingQuery == null || "".equals(havingQuery)) {
@@ -1207,7 +1207,7 @@ public class DataApiRequest extends ApiRequest {
             Set<LogicalMetric> logicalMetrics,
             MetricDictionary metricDictionary
     ) throws BadApiRequestException {
-        try (TimedPhase timer = RequestLog.startTiming("GeneratingSortColumns")) {
+        try (TimedPhase timer = RequestLogUtils.startTiming("GeneratingSortColumns")) {
             String sortMetricName;
             LinkedHashSet<OrderByColumn> metricSortColumns = new LinkedHashSet<>();
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -12,7 +12,7 @@ import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 import com.yahoo.bard.webservice.data.dimension.DimensionField;
 import com.yahoo.bard.webservice.data.dimension.DimensionRow;
 import com.yahoo.bard.webservice.data.dimension.SearchProvider;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.logging.blocks.DimensionRequest;
 import com.yahoo.bard.webservice.table.LogicalTableDictionary;
 import com.yahoo.bard.webservice.util.Pagination;
@@ -115,8 +115,8 @@ public class DimensionsServlet extends EndpointServlet {
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new DimensionRequest("all", "no"));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new DimensionRequest("all", "no"));
 
             DimensionsApiRequest apiRequest = new DimensionsApiRequest(
                     null,
@@ -143,16 +143,16 @@ public class DimensionsServlet extends EndpointServlet {
                     null
             );
             LOG.debug("Dimensions Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return response;
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Status.BAD_REQUEST).entity(msg).build();
         }
     }
@@ -177,8 +177,8 @@ public class DimensionsServlet extends EndpointServlet {
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new DimensionRequest(dimensionName, "no"));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new DimensionRequest(dimensionName, "no"));
 
             DimensionsApiRequest apiRequest = new DimensionsApiRequest(
                     dimensionName,
@@ -202,21 +202,21 @@ public class DimensionsServlet extends EndpointServlet {
 
             String output = objectMappers.getMapper().writeValueAsString(result);
             LOG.debug("Dimension Endpoint Response: {}", output);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Status.OK).entity(output).build();
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (JsonProcessingException e) {
             String msg = String.format("Internal server error. JsonProcessingException : %s", e.getMessage());
             LOG.error(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Status.BAD_REQUEST).entity(msg).build();
         }
     }
@@ -264,8 +264,8 @@ public class DimensionsServlet extends EndpointServlet {
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new DimensionRequest(dimensionName, "yes"));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new DimensionRequest(dimensionName, "yes"));
 
             DimensionsApiRequest apiRequest = new DimensionsApiRequest(
                     dimensionName,
@@ -313,21 +313,21 @@ public class DimensionsServlet extends EndpointServlet {
             );
 
             LOG.debug("Dimension Value Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return response;
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (RowLimitReachedException e) {
             String msg = String.format("Row limit exceeded for dimension %s: %s", dimensionName, e.getMessage());
             LOG.debug(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(INSUFFICIENT_STORAGE).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.debug(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(BAD_REQUEST).entity(msg).build();
         }
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
@@ -8,7 +8,7 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import com.yahoo.bard.webservice.application.ObjectMappersSuite;
 import com.yahoo.bard.webservice.config.FeatureFlag;
 import com.yahoo.bard.webservice.config.FeatureFlagRegistry;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.logging.blocks.FeatureFlagRequest;
 import com.yahoo.bard.webservice.web.ApiRequest;
 
@@ -124,8 +124,8 @@ public class FeatureFlagsServlet extends EndpointServlet {
             @Context UriInfo uriInfo
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new FeatureFlagRequest("all"));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new FeatureFlagRequest("all"));
 
             FeatureFlagApiRequest apiRequest = new FeatureFlagApiRequest(format, perPage, page, uriInfo);
 
@@ -142,12 +142,12 @@ public class FeatureFlagsServlet extends EndpointServlet {
                     Arrays.asList("name", "value")
             );
             LOG.debug("Feature Flags Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return response;
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
     }
@@ -179,8 +179,8 @@ public class FeatureFlagsServlet extends EndpointServlet {
             @Context UriInfo uriInfo
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new FeatureFlagRequest(flagName));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new FeatureFlagRequest(flagName));
 
             FeatureFlagApiRequest apiRequest = new FeatureFlagApiRequest(format, "", "", uriInfo);
 
@@ -190,17 +190,17 @@ public class FeatureFlagsServlet extends EndpointServlet {
             String output = objectMappers.getMapper().writeValueAsString(status);
 
             LOG.debug("Feature Flags Endpoint Response: {}", output);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.OK).entity(output).build();
         } catch (JsonProcessingException e) {
             String msg = String.format("Internal server error. JsonProcessingException : %s", e.getMessage());
             LOG.error(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(INTERNAL_SERVER_ERROR).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
@@ -18,7 +18,7 @@ import com.yahoo.bard.webservice.data.HttpResponseMaker;
 import com.yahoo.bard.webservice.data.Result;
 import com.yahoo.bard.webservice.data.ResultSet;
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.logging.blocks.JobRequest;
 import com.yahoo.bard.webservice.util.AllPagesPagination;
 import com.yahoo.bard.webservice.util.Pagination;
@@ -149,8 +149,8 @@ public class JobsServlet extends EndpointServlet {
             @Suspended AsyncResponse asyncResponse
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new JobRequest("all"));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new JobRequest("all"));
 
             JobsApiRequest apiRequest = new JobsApiRequest (
                     format,
@@ -186,18 +186,18 @@ public class JobsServlet extends EndpointServlet {
                     .onErrorReturn(this::getErrorResponse)
                     .subscribe(
                             response -> {
-                                RequestLog.stopTiming(this);
+                                RequestLogUtils.stopTiming(this);
                                 asyncResponse.resume(response);
                             }
                     );
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             asyncResponse.resume(RequestHandlerUtils.makeErrorResponse(e.getStatus(), e, writer));
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             asyncResponse.resume(Response.status(INTERNAL_SERVER_ERROR).entity(e.getMessage()).build());
         }
     }
@@ -220,8 +220,8 @@ public class JobsServlet extends EndpointServlet {
             @Suspended AsyncResponse asyncResponse
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new JobRequest(ticket));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new JobRequest(ticket));
             JobsApiRequest apiRequest = new JobsApiRequest (
                     ResponseFormatType.JSON.toString(),
                     null,
@@ -241,11 +241,11 @@ public class JobsServlet extends EndpointServlet {
 
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             asyncResponse.resume(RequestHandlerUtils.makeErrorResponse(e.getStatus(), e, writer));
         } catch (IOException | IllegalStateException e) {
             LOG.debug("Bad request exception : {}", e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             asyncResponse.resume(RequestHandlerUtils.makeErrorResponse(BAD_REQUEST, e, writer));
         }
     }
@@ -277,8 +277,8 @@ public class JobsServlet extends EndpointServlet {
             @Suspended AsyncResponse asyncResponse
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new JobRequest(ticket));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new JobRequest(ticket));
 
             JobsApiRequest apiRequest = new JobsApiRequest (
                     format,
@@ -313,11 +313,11 @@ public class JobsServlet extends EndpointServlet {
 
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             asyncResponse.resume(RequestHandlerUtils.makeErrorResponse(e.getStatus(), e, writer));
         } catch (Error | Exception e) {
             LOG.debug("Exception processing request", e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             asyncResponse.resume(Response.status(INTERNAL_SERVER_ERROR).entity(e.getMessage()).build());
         }
     }
@@ -547,7 +547,7 @@ public class JobsServlet extends EndpointServlet {
      */
     protected Response getResponse(String jsonResponse) {
         LOG.trace("Jobs endpoint Response: {}", jsonResponse);
-        RequestLog.stopTiming(this);
+        RequestLogUtils.stopTiming(this);
         return Response.status(OK).entity(jsonResponse).build();
     }
 
@@ -562,12 +562,12 @@ public class JobsServlet extends EndpointServlet {
         //In case the given ticket does not exist in the ApiJobStore
         if (throwable instanceof JobNotFoundException) {
             LOG.debug(throwable.getMessage());
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(NOT_FOUND).entity(throwable.getMessage()).build();
         }
 
         LOG.error(throwable.getMessage());
-        RequestLog.stopTiming(this);
+        RequestLogUtils.stopTiming(this);
         //In case the job cannot be retrieved from the ApiJobStore or if it cannot be mapped to a Job
         return Response.status(INTERNAL_SERVER_ERROR).entity(throwable.getMessage()).build();
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
@@ -8,7 +8,7 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import com.yahoo.bard.webservice.application.ObjectMappersSuite;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.logging.blocks.MetricRequest;
 import com.yahoo.bard.webservice.table.LogicalTableDictionary;
 import com.yahoo.bard.webservice.web.MetricsApiRequest;
@@ -107,8 +107,8 @@ public class MetricsServlet extends EndpointServlet {
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new MetricRequest("all"));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new MetricRequest("all"));
 
             MetricsApiRequest apiRequest = new MetricsApiRequest(
                     null,
@@ -134,21 +134,21 @@ public class MetricsServlet extends EndpointServlet {
                     null
             );
             LOG.debug("Metrics Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return response;
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (IOException e) {
             String msg = String.format("Internal server error. IOException : %s", e.getMessage());
             LOG.error(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(INTERNAL_SERVER_ERROR).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
     }
@@ -173,8 +173,8 @@ public class MetricsServlet extends EndpointServlet {
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new MetricRequest(metricName));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new MetricRequest(metricName));
 
             MetricsApiRequest apiRequest = new MetricsApiRequest(metricName, null, "", "", metricDictionary, uriInfo);
 
@@ -190,21 +190,21 @@ public class MetricsServlet extends EndpointServlet {
 
             String output = objectMappers.getMapper().writeValueAsString(result);
             LOG.debug("Metric Endpoint Response: {}", output);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Status.OK).entity(output).build();
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (IOException e) {
             String msg = String.format("Internal server error. IOException : %s", e.getMessage());
             LOG.error(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(INTERNAL_SERVER_ERROR).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
@@ -7,7 +7,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 
 import com.yahoo.bard.webservice.application.ObjectMappersSuite;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.logging.blocks.SliceRequest;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
@@ -105,8 +105,8 @@ public class SlicesServlet extends EndpointServlet {
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new SliceRequest("all"));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new SliceRequest("all"));
 
             SlicesApiRequest apiRequest = new SlicesApiRequest(
                     null,
@@ -132,21 +132,21 @@ public class SlicesServlet extends EndpointServlet {
             );
 
             LOG.debug("Slice Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return response;
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (IOException e) {
             String msg = String.format("Internal server error. IOException : %s", e.getMessage());
             LOG.error(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(INTERNAL_SERVER_ERROR).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
     }
@@ -186,8 +186,8 @@ public class SlicesServlet extends EndpointServlet {
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new SliceRequest(sliceName));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new SliceRequest(sliceName));
 
             SlicesApiRequest apiRequest = new SlicesApiRequest(
                     sliceName,
@@ -205,15 +205,15 @@ public class SlicesServlet extends EndpointServlet {
 
             String output = objectMappers.getMapper().writeValueAsString(apiRequest.getSlice());
             LOG.debug("Slice Endpoint Response: {}", output);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.OK).entity(output).build();
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (IOException | IllegalStateException e) {
             LOG.debug("Bad request exception : {}", e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(BAD_REQUEST).entity("Exception: " + e.getMessage()).build();
         }
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
@@ -9,7 +9,7 @@ import com.yahoo.bard.webservice.application.ObjectMappersSuite;
 import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
 import com.yahoo.bard.webservice.data.filterbuilders.DruidFilterBuilder;
 import com.yahoo.bard.webservice.data.time.GranularityParser;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.logging.blocks.TableRequest;
 import com.yahoo.bard.webservice.table.LogicalTable;
 import com.yahoo.bard.webservice.table.LogicalTableDictionary;
@@ -151,8 +151,8 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new TableRequest(tableName != null ? tableName : "all", "all"));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new TableRequest(tableName != null ? tableName : "all", "all"));
 
             TablesApiRequest apiRequest = new TablesApiRequest(
                     tableName,
@@ -179,16 +179,16 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
                     null
             );
             LOG.debug("Tables Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return response;
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
     }
@@ -215,8 +215,8 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new TableRequest(tableName, grain));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new TableRequest(tableName, grain));
 
             TablesApiRequest apiRequest = new TablesApiRequest(
                     tableName,
@@ -235,21 +235,21 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             Map<String, Object> result = getLogicalTableFullView(apiRequest.getTable(), uriInfo);
             String output = objectMappers.getMapper().writeValueAsString(result);
             LOG.debug("Tables Endpoint Response: {}", output);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.OK).entity(output).build();
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (JsonProcessingException e) {
             String msg = String.format("Internal server error. JsonProcessingException : %s", e.getMessage());
             LOG.error(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(INTERNAL_SERVER_ERROR).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
     }
@@ -272,8 +272,8 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             @Context final ContainerRequestContext containerRequestContext
     ) {
         try {
-            RequestLog.startTiming(this);
-            RequestLog.record(new TableRequest("all", "all"));
+            RequestLogUtils.startTiming(this);
+            RequestLogUtils.record(new TableRequest("all", "all"));
 
             TablesApiRequest tablesApiRequest = new TablesApiRequest(
                     null,
@@ -297,12 +297,12 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             Response response = formatResponse(tablesApiRequest, paginatedResult, "tables", null);
 
             LOG.debug("Tables Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return response;
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
-            RequestLog.stopTiming(this);
+            RequestLogUtils.stopTiming(this);
             return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/BardLoggingFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/BardLoggingFilter.java
@@ -4,13 +4,13 @@ package com.yahoo.bard.webservice.web.filters;
 
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 
-import com.yahoo.bard.webservice.logging.RequestLog;
 import com.yahoo.bard.webservice.logging.TimedPhase;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.logging.blocks.Epilogue;
 import com.yahoo.bard.webservice.logging.blocks.Preface;
 import com.yahoo.bard.webservice.util.CacheLastObserver;
 
-import org.glassfish.jersey.filter.LoggingFilter;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +41,7 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.WriterInterceptor;
 import javax.ws.rs.ext.WriterInterceptorContext;
@@ -67,15 +68,16 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
     ClientResponseFilter, WriterInterceptor {
 
     private static final Logger LOG = LoggerFactory.getLogger(BardLoggingFilter.class);
-    private static final String PROPERTY_NANOS = LoggingFilter.class.getName() + ".nanos";
-    private static final String PROPERTY_REQ_LEN = LoggingFilter.class.getName() + ".reqlen";
-    private static final String PROPERTY_OUTPUT_STREAM = LoggingFilter.class.getName() + ".ostream";
+    private static final String PROP_PREFIX = BardLoggingFilter.class.getName();
+    private static final String PROPERTY_NANOS = PROP_PREFIX + ".nanos";
+    private static final String PROPERTY_REQ_LEN = PROP_PREFIX + ".reqlen";
+    private static final String PROPERTY_OUTPUT_STREAM = PROP_PREFIX + ".ostream";
     private static final Pattern VALID_REQUEST_ID = Pattern.compile("[a-zA-Z0-9+/=\\-_]+");
+    public static final String X_REQUEST_ID_HEADER = "x-request-id";
 
     public static final double MILLISECONDS_PER_NANOSECOND = 1000000.0;
-    public static final String TOTAL_TIMER = "TotalTime";
     public static final String CLIENT_TOTAL_TIMER = "ClientRequestTotalTime";
-    public static final String X_REQUEST_ID_HEADER = "x-request-id";
+
 
     /**
      * Intercept the Container request to add length of request and a start timestamp.
@@ -86,18 +88,45 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
      */
     @Override
     public void filter(ContainerRequestContext request) throws IOException {
-
-        appendRequestId(request.getHeaders().getFirst(X_REQUEST_ID_HEADER));
-        RequestLog.startTiming(TOTAL_TIMER);
-        try (TimedPhase timer = RequestLog.startTiming(this)) {
-            RequestLog.record(new Preface(request));
+        appendRequestId(request.getHeaders());
+        RequestLogUtils.startTimingRequest();
+        try (TimedPhase timer = RequestLogUtils.startTiming(this)) {
+            RequestLogUtils.record(new Preface(request));
+            appendRequestId(request.getHeaders());
+            RequestLogUtils.record(new Preface(request));
 
             // sets PROPERTY_REQ_LEN if content-length not defined
             lengthOfRequestEntity(request);
-
             // store start time to later calculate elapsed time
             request.setProperty(PROPERTY_NANOS, System.nanoTime());
+            RequestLogUtils.stopTiming(this);
         }
+    }
+
+    /**
+     * Add a request id to pass to druid. Only added if x-request-id follows the format specified at:
+     * https://devcenter.heroku.com/articles/http-request-id
+     *
+     * @param headers  Request id to add as queryId prefix to druid
+     */
+    public static void appendRequestId(MultivaluedMap<String, String> headers) {
+        String requestId = headers.getFirst(X_REQUEST_ID_HEADER);
+        if (isInvalidRequestId(requestId)) {
+            return; // Ignore according to https://devcenter.heroku.com/articles/http-request-id
+        }
+        RequestLogUtils.addIdPrefix(requestId);
+    }
+
+    /**
+     * Validate whether or not a string is acceptable as an x-request-id header argument.
+     *
+     * @param requestId  Request id to validate
+     * @return True if the request id is not valid, false otherwise
+     */
+    public static boolean isInvalidRequestId(String requestId) {
+        return StringUtils.isEmpty(requestId)
+                || requestId.length() > 200
+                || !VALID_REQUEST_ID.matcher(requestId).matches();
     }
 
     /**
@@ -113,8 +142,7 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
     @Override
     public void filter(ContainerRequestContext request, ContainerResponseContext response)
         throws IOException {
-        appendRequestId(request.getHeaders().getFirst(X_REQUEST_ID_HEADER));
-        RequestLog.startTiming(this);
+        appendRequestId(request.getHeaders());
         StringBuilder debugMsgBuilder = new StringBuilder();
 
         debugMsgBuilder.append("\tRequest: ").append(request.getMethod());
@@ -144,7 +172,7 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
             msg = response.hasEntity() ? response.getEntity().toString() : "Request without entity failed";
         }
         CacheLastObserver<Long> responseLengthObserver = new CacheLastObserver<>();
-        RequestLog.record(new Epilogue(msg, status, responseLengthObserver));
+        RequestLogUtils.record(new Epilogue(msg, status, responseLengthObserver));
 
         // if response is not yet finalized, we must intercept the output stream
         if (response.getLength() == -1 && response.hasEntity()) {
@@ -159,9 +187,9 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
             debugMsgBuilder.append("length=").append(response.getLength()).append("\t");
             Observable.just((long) response.getLength()).subscribe(responseLengthObserver);
             LOG.debug(debugMsgBuilder.toString());
-            RequestLog.stopTiming(this);
-            RequestLog.stopTiming(TOTAL_TIMER);
-            RequestLog.log();
+            RequestLogUtils.stopTiming(this);
+            RequestLogUtils.stopTimingRequest();
+            RequestLogUtils.log();
         }
     }
 
@@ -174,8 +202,8 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
      */
     @Override
     public void filter(ClientRequestContext request) throws IOException {
-        appendRequestId(request.getStringHeaders().getFirst(X_REQUEST_ID_HEADER));
-        RequestLog.startTiming(CLIENT_TOTAL_TIMER);
+        appendRequestId(request.getStringHeaders());
+        RequestLogUtils.startTiming(CLIENT_TOTAL_TIMER);
         request.setProperty(PROPERTY_NANOS, System.nanoTime());
     }
 
@@ -202,31 +230,7 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
         }
 
         LOG.debug(debugMsgBuilder.toString());
-        RequestLog.stopTiming(CLIENT_TOTAL_TIMER);
-    }
-
-    /**
-     * Add a request id to pass to druid. Only added if x-request-id follows the format specified at:
-     * https://devcenter.heroku.com/articles/http-request-id
-     *
-     * @param requestId  Request id to add as queryId prefix to druid
-     */
-    private void appendRequestId(String requestId) {
-        if (isNotValidRequestId(requestId)) {
-            return; // Ignore according to https://devcenter.heroku.com/articles/http-request-id
-        }
-        RequestLog.addIdPrefix(requestId);
-    }
-
-    /**
-     * Validate whether or not a string is acceptable as an x-request-id header argument.
-     *
-     * @param requestId  Request id to validate
-     * @return True if the request id is not valid, false otherwise
-     */
-    private boolean isNotValidRequestId(String requestId) {
-        return requestId == null || requestId.isEmpty() || requestId.length() > 200
-               || !VALID_REQUEST_ID.matcher(requestId).matches();
+        RequestLogUtils.stopTiming(CLIENT_TOTAL_TIMER);
     }
 
     /**
@@ -310,9 +314,9 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
             throw e;
         } finally {
             try {
-                RequestLog.stopTiming(this);
-                RequestLog.stopTiming(TOTAL_TIMER);
-                RequestLog.log();
+                RequestLogUtils.stopTiming(this);
+                RequestLogUtils.stopTimingRequest();
+                RequestLogUtils.log();
             } catch (Exception e) {
                 LOG.error("Error finalizing the BardLoggingFilter output stream wrapper.", e);
             }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/HealthCheckFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/HealthCheckFilter.java
@@ -3,7 +3,7 @@
 package com.yahoo.bard.webservice.web.filters;
 
 import com.yahoo.bard.webservice.application.HealthCheckRegistryFactory;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 import com.codahale.metrics.health.HealthCheck.Result;
 
@@ -32,8 +32,7 @@ public class HealthCheckFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-
-        RequestLog.startTiming(this);
+        RequestLogUtils.startTiming(this);
         String path = requestContext.getUriInfo().getAbsolutePath().getPath();
 
         if (path.startsWith("/v1/data") || path.startsWith("/data")) {
@@ -42,7 +41,7 @@ public class HealthCheckFilter implements ContainerRequestFilter {
             if (!unhealthyChecks.keySet().isEmpty()) {
                 unhealthyChecks.entrySet()
                         .forEach(entry -> LOG.error("Healthcheck '{}' failed: {}", entry.getKey(), entry.getValue()));
-                RequestLog.stopTiming(this);
+                RequestLogUtils.stopTiming(this);
                 requestContext.abortWith(
                         Response.status(Status.SERVICE_UNAVAILABLE)
                                 .entity("Service is unhealthy. At least 1 healthcheck is failing")
@@ -51,7 +50,7 @@ public class HealthCheckFilter implements ContainerRequestFilter {
                 return;
             }
         }
-        RequestLog.stopTiming(this);
+        RequestLogUtils.stopTiming(this);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/RateLimitFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/RateLimitFilter.java
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.web.filters;
 import static com.yahoo.bard.webservice.web.ResponseCode.RATE_LIMIT;
 
 import com.yahoo.bard.webservice.config.SystemConfigException;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.util.Utils;
 import com.yahoo.bard.webservice.web.DataApiRequestTypeIdentifier;
 import com.yahoo.bard.webservice.web.RateLimiter;
@@ -56,7 +56,7 @@ public class RateLimitFilter implements ContainerRequestFilter, ContainerRespons
     @SuppressWarnings("checkstyle:cyclomaticcomplexity")
     public void filter(ContainerRequestContext request) throws IOException {
 
-        RequestLog.startTiming(this);
+        RequestLogUtils.startTiming(this);
         URI uri = request.getUriInfo().getAbsolutePath();
         String path = uri.getPath();
 
@@ -94,13 +94,13 @@ public class RateLimitFilter implements ContainerRequestFilter, ContainerRespons
             } else {
                 String msg = String.format("Rate limit reached. Reject %s", uri.toString());
                 LOG.debug(msg);
-                RequestLog.stopTiming(this);
+                RequestLogUtils.stopTiming(this);
                 request.abortWith(Response.status(RATE_LIMIT).entity(msg).build());
                 return;
             }
         }
 
-        RequestLog.stopTiming(this);
+        RequestLogUtils.stopTiming(this);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/RequestIdHeaderFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/RequestIdHeaderFilter.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.filters;
 
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 import java.io.IOException;
 
@@ -18,6 +18,6 @@ public class RequestIdHeaderFilter implements ContainerResponseFilter {
 
     @Override
     public void filter(ContainerRequestContext request, ContainerResponseContext response) throws IOException {
-        response.getHeaders().putSingle(X_REQUEST_ID, RequestLog.getId());
+        response.getHeaders().putSingle(X_REQUEST_ID, RequestLogUtils.getId());
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/ResponseCorsFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/ResponseCorsFilter.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.filters;
 
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 import java.io.IOException;
 
@@ -23,7 +23,7 @@ public class ResponseCorsFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
             throws IOException {
-        RequestLog.startTiming(this);
+        RequestLogUtils.startTiming(this);
         MultivaluedMap<String, Object> headers = responseContext.getHeaders();
 
         String origin = requestContext.getHeaderString("origin");
@@ -39,6 +39,6 @@ public class ResponseCorsFilter implements ContainerResponseFilter {
 
         headers.add("Access-Control-Allow-Methods", "*");
         headers.add("Access-Control-Allow-Credentials", "true");
-        RequestLog.stopTiming(this);
+        RequestLogUtils.stopTiming(this);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandler.java
@@ -7,7 +7,7 @@ import com.yahoo.bard.webservice.druid.client.FailureCallback;
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
 import com.yahoo.bard.webservice.druid.client.SuccessCallback;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.responseprocessors.LoggingContext;
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor;
@@ -45,7 +45,7 @@ public class AsyncWebServiceRequestHandler extends BaseDataRequestHandler {
         SuccessCallback success = new SuccessCallback() {
             @Override
             public void invoke(JsonNode rootNode) {
-                response.processResponse(rootNode, druidQuery, new LoggingContext(RequestLog.copy()));
+                response.processResponse(rootNode, druidQuery, new LoggingContext(RequestLogUtils.copy()));
             }
         };
         HttpErrorCallback error = response.getErrorCallback(druidQuery);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheRequestHandler.java
@@ -9,6 +9,7 @@ import com.yahoo.bard.webservice.application.MetricRegistryFactory;
 import com.yahoo.bard.webservice.data.cache.DataCache;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo;
 import com.yahoo.bard.webservice.util.Utils;
 import com.yahoo.bard.webservice.web.DataApiRequest;
@@ -84,16 +85,16 @@ public class CacheRequestHandler extends BaseDataRequestHandler {
                 if (jsonResult != null) {
                     try {
                         if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
-                            RequestLog.record(new BardQueryInfo(druidQuery.getQueryType().toJson(), true));
-                            RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
+                            RequestLogUtils.record(new BardQueryInfo(druidQuery.getQueryType().toJson(), true));
+                            RequestLogUtils.stopTiming(REQUEST_WORKFLOW_TIMER);
                         }
 
                         if (context.getNumberOfIncoming().decrementAndGet() == 0) {
-                            RequestLog.startTiming(RESPONSE_WORKFLOW_TIMER);
+                            RequestLogUtils.startTiming(RESPONSE_WORKFLOW_TIMER);
                         }
 
                         CACHE_HITS.mark(1);
-                        RequestLog logCtx = RequestLog.dump();
+                        RequestLog logCtx = RequestLogUtils.dump();
                         nextResponse.processResponse(
                                 mapper.readTree(jsonResult),
                                 druidQuery,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
@@ -2,7 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.handlers;
 
-
 import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.REQUEST_WORKFLOW_TIMER;
 import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.RESPONSE_WORKFLOW_TIMER;
 
@@ -11,6 +10,7 @@ import com.yahoo.bard.webservice.data.cache.DataCache;
 import com.yahoo.bard.webservice.data.cache.TupleDataCache;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo;
 import com.yahoo.bard.webservice.metadata.QuerySigningService;
 import com.yahoo.bard.webservice.util.Utils;
@@ -99,16 +99,16 @@ public class CacheV2RequestHandler extends BaseDataRequestHandler {
                     )) {
                         try {
                             if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
-                                RequestLog.record(new BardQueryInfo(druidQuery.getQueryType().toJson(), true));
-                                RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
+                                RequestLogUtils.record(new BardQueryInfo(druidQuery.getQueryType().toJson(), true));
+                                RequestLogUtils.stopTiming(REQUEST_WORKFLOW_TIMER);
                             }
 
                             if (context.getNumberOfIncoming().decrementAndGet() == 0) {
-                                RequestLog.startTiming(RESPONSE_WORKFLOW_TIMER);
+                                RequestLogUtils.startTiming(RESPONSE_WORKFLOW_TIMER);
                             }
 
                             CACHE_HITS.mark(1);
-                            RequestLog logCtx = RequestLog.dump();
+                            RequestLog logCtx = RequestLogUtils.dump();
                             nextResponse.processResponse(
                                     mapper.readTree(cacheEntry.getValue()),
                                     druidQuery,
@@ -121,7 +121,7 @@ public class CacheV2RequestHandler extends BaseDataRequestHandler {
                             LOG.warn("Error processing cached value: ", e);
                         }
                     } else {
-                        LOG.debug("Cache entry present but invalid for query with id: {}", RequestLog.getId());
+                        LOG.debug("Cache entry present but invalid for query with id: {}", RequestLogUtils.getId());
                         CACHE_POTENTIAL_HITS.mark(1);
                         CACHE_MISSES.mark(1);
                     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/RequestHandlerUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/RequestHandlerUtils.java
@@ -3,7 +3,7 @@
 package com.yahoo.bard.webservice.web.handlers;
 
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -130,7 +130,7 @@ public class RequestHandlerUtils {
         responseMap.put("reason", reason);
         responseMap.put("description", description);
         responseMap.put("druidQuery", druidQuery);
-        responseMap.put("requestId", RequestLog.getId());
+        responseMap.put("requestId", RequestLogUtils.getId());
 
         String json;
         try {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/SplitQueryRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/SplitQueryRequestHandler.java
@@ -9,6 +9,7 @@ import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.util.IntervalUtils;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor;
@@ -105,7 +106,7 @@ public class SplitQueryRequestHandler implements DataRequestHandler {
                 );
 
         // Save RequestLog up to here
-        final RequestLog logCtx = RequestLog.dump();
+        final RequestLog logCtx = RequestLogUtils.dump();
 
         final SplitQueryResponseProcessor mergingResponse =
                 new SplitQueryResponseProcessor(response, request, druidQuery, expectedIntervals, logCtx);
@@ -117,7 +118,7 @@ public class SplitQueryRequestHandler implements DataRequestHandler {
 
         queries.stream().forEach(
                 q -> {
-                    RequestLog.restore(logCtx);
+                    RequestLogUtils.restore(logCtx);
                     next.handleRequest(context, request, q, mergingResponse);
                 }
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
@@ -23,7 +23,7 @@ import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
 import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.table.Column;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.PageNotFoundException;
@@ -95,7 +95,7 @@ public class ResultSetResponseProcessor extends MappingResponseProcessor impleme
     @Override
     public void processResponse(JsonNode json, DruidAggregationQuery<?> druidQuery, LoggingContext metadata) {
         try {
-            RequestLog.restore(metadata.getRequestLog());
+            RequestLogUtils.restore(metadata.getRequestLog());
             ResultSet resultSet = buildResultSet(json, druidQuery, apiRequest.getTimeZone());
             resultSet = mapResultSet(resultSet);
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/SplitQueryResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/SplitQueryResponseProcessor.java
@@ -7,6 +7,7 @@ import com.yahoo.bard.webservice.druid.client.FailureCallback;
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -124,7 +125,7 @@ public class SplitQueryResponseProcessor implements ResponseProcessor {
 
         if (completed.decrementAndGet() == 0) {
             Pair<JsonNode, LoggingContext> mergedResponse = mergeResponses(completedIntervals);
-            RequestLog.restore(mergedResponse.getValue().getRequestLog());
+            RequestLogUtils.restore(mergedResponse.getValue().getRequestLog());
             next.processResponse(mergedResponse.getKey(), queryBeforeSplit, mergedResponse.getValue());
         }
     }
@@ -153,14 +154,14 @@ public class SplitQueryResponseProcessor implements ResponseProcessor {
     private Pair<JsonNode, LoggingContext> mergeResponses(List<Pair<JsonNode, LoggingContext>> responses) {
         JsonNodeFactory factory = new JsonNodeFactory(true);
         ArrayNode result = factory.arrayNode();
-        RequestLog.restore(logCtx);
+        RequestLogUtils.restore(logCtx);
         for (Pair<JsonNode, LoggingContext> entry : responses) {
             for (JsonNode jsonNode : entry.getKey()) {
                 result.add(jsonNode);
             }
-            RequestLog.accumulate(entry.getValue().getRequestLog());
+            RequestLogUtils.accumulate(entry.getValue().getRequestLog());
         }
-        RequestLog updatedCtx = RequestLog.dump();
+        RequestLog updatedCtx = RequestLogUtils.dump();
         return new Pair<>(result, new LoggingContext(updatedCtx));
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/WeightCheckResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/WeightCheckResponseProcessor.java
@@ -7,7 +7,7 @@ import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.REQU
 import com.yahoo.bard.webservice.druid.client.FailureCallback;
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -38,8 +38,8 @@ public class WeightCheckResponseProcessor implements ResponseProcessor {
         return new FailureCallback() {
             @Override
             public void invoke(Throwable error) {
-                if (RequestLog.isRunning(REQUEST_WORKFLOW_TIMER)) {
-                    RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
+                if (RequestLogUtils.isRunning(REQUEST_WORKFLOW_TIMER)) {
+                    RequestLogUtils.stopTiming(REQUEST_WORKFLOW_TIMER);
                 }
                 next.getFailureCallback(druidQuery).invoke(error);
             }
@@ -51,8 +51,8 @@ public class WeightCheckResponseProcessor implements ResponseProcessor {
     return new HttpErrorCallback() {
             @Override
             public void invoke(int statusCode, String reason, String responseBody) {
-                if (RequestLog.isRunning(REQUEST_WORKFLOW_TIMER)) {
-                    RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
+                if (RequestLogUtils.isRunning(REQUEST_WORKFLOW_TIMER)) {
+                    RequestLogUtils.stopTiming(REQUEST_WORKFLOW_TIMER);
                 }
                 next.getErrorCallback(druidQuery).invoke(statusCode, reason, responseBody);
             }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/TimingSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/TimingSpec.groovy
@@ -34,7 +34,7 @@ class TimingSpec extends Specification {
         // Hook with test appender
         logAppender = new TestLogAppender()
         // Reset request log before using it in this test
-        RequestLog.dump()
+        RequestLogUtils.dump()
     }
 
     def cleanupSpec() {
@@ -91,10 +91,10 @@ class TimingSpec extends Specification {
         String timerName = "StartStopTest"
 
         when: "We start the timer, wait the expected duration, and stop the timer"
-        RequestLog.startTiming(timerName)
+        RequestLogUtils.startTiming(timerName)
         sleep((int) expectedDuration)
-        RequestLog.stopTiming(timerName)
-        RequestLog.log()
+        RequestLogUtils.stopTiming(timerName)
+        RequestLogUtils.log()
         Map res = extractTimesFromLogs(timerName)
 
         then: "One log line is produced in the expected duration range"
@@ -106,10 +106,10 @@ class TimingSpec extends Specification {
         String timerName = "StartStopTest"
 
         when: "We start the timer and stop it twice"
-        RequestLog.startTiming(timerName)
-        RequestLog.stopTiming(timerName)
-        RequestLog.stopTiming(timerName)
-        RequestLog.log()
+        RequestLogUtils.startTiming(timerName)
+        RequestLogUtils.stopTiming(timerName)
+        RequestLogUtils.stopTiming(timerName)
+        RequestLogUtils.log()
 
         then: "One log line is produced and a warning"
         String warningLine
@@ -133,10 +133,10 @@ class TimingSpec extends Specification {
         String timerName = "StartStopTest"
 
         when: "We start the timer and stop it twice"
-        RequestLog.startTiming(timerName)
-        RequestLog.startTiming(timerName)
-        RequestLog.stopTiming(timerName)
-        RequestLog.log()
+        RequestLogUtils.startTiming(timerName)
+        RequestLogUtils.startTiming(timerName)
+        RequestLogUtils.stopTiming(timerName)
+        RequestLogUtils.log()
 
         then: "One log line is produced and a warning"
         String warningLine
@@ -167,14 +167,14 @@ class TimingSpec extends Specification {
         String timerName = "ThreadSwitchTest"
 
         when: "We start the timer in one thread and stop it in the other after waiting for the expected duration"
-        RequestLog.startTiming("ThreadSwitchTest")
+        RequestLogUtils.startTiming("ThreadSwitchTest")
 
-        final RequestLog ctx = RequestLog.dump()
+        final RequestLog ctx = RequestLogUtils.dump()
         def thread = Thread.start {
             sleep(500)
-            RequestLog.restore(ctx)
-            RequestLog.stopTiming("ThreadSwitchTest")
-            RequestLog.log()
+            RequestLogUtils.restore(ctx)
+            RequestLogUtils.stopTiming("ThreadSwitchTest")
+            RequestLogUtils.log()
         }
         thread.join()
 
@@ -201,14 +201,14 @@ class TimingSpec extends Specification {
 
         when: "We nest a timer within another timer in a for loop"
         for (int i = 0; i < 2; ++i) {
-            RequestLog.startTiming(outerTimerName)
+            RequestLogUtils.startTiming(outerTimerName)
             sleep(duration)
-            RequestLog.startTiming(innerTimerName)
+            RequestLogUtils.startTiming(innerTimerName)
             sleep(duration)
-            RequestLog.stopMostRecentTimer()
-            RequestLog.stopTiming(outerTimerName)
+            RequestLogUtils.stopMostRecentTimer()
+            RequestLogUtils.stopTiming(outerTimerName)
         }
-        RequestLog.log()
+        RequestLogUtils.log()
         Map res = extractTimesFromLogs(outerTimerName, innerTimerName)
 
         then: "One log line is produced in the expected duration range"
@@ -220,7 +220,7 @@ class TimingSpec extends Specification {
     @Unroll
     def "Test parsing order of LogInfo parts in RequestLog for requested order: #inputOrderString"() {
         expect:
-        RequestLog.generateLogInfoOrder(inputOrderString) == expectedList
+        RequestLogUtils.generateLogInfoOrder(inputOrderString) == expectedList
 
         where:
         expectedList << [[], [], [], [pkgString + "Part1", pkgString + "Part2"], [pkgString + "Part2", pkgString +

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/RequestIdPrefixesDruidQueryIdSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/RequestIdPrefixesDruidQueryIdSpec.groovy
@@ -7,6 +7,7 @@ import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.util.JsonSlurper
 import com.yahoo.bard.webservice.util.JsonSortStrategy
 import com.yahoo.bard.webservice.web.filters.BardLoggingFilter
+
 import org.apache.commons.lang.StringUtils
 
 import javax.ws.rs.core.MultivaluedHashMap
@@ -27,7 +28,7 @@ class RequestIdPrefixesDruidQueryIdSpec extends BaseDataServletComponentSpec {
 
     @Override
     Class<?>[] getResourceClasses() {
-        [ DataServlet.class, BardLoggingFilter.class ]
+        [DataServlet.class, BardLoggingFilter.class ]
     }
 
     @Override
@@ -78,10 +79,9 @@ class RequestIdPrefixesDruidQueryIdSpec extends BaseDataServletComponentSpec {
     }
 
     def "verify invalid x-request-id values"() {
-        BardLoggingFilter filter = new BardLoggingFilter()
-        assert !filter.isValidRequestId('abcd$') // Invalid char
-        assert !filter.isValidRequestId(StringUtils.leftPad('a', 200, 'a')) // Too long
-        assert !filter.isValidRequestId('') // empty string
-        assert !filter.isValidRequestId(null) // null
+        assert !BardLoggingFilter.isInvalidRequestId('abcd$') // Invalid char
+        assert !BardLoggingFilter.isInvalidRequestId(StringUtils.leftPad('a', 200, 'a')) // Too long
+        assert !BardLoggingFilter.isInvalidRequestId('') // empty string
+        assert !BardLoggingFilter.isInvalidRequestId(null) // null
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/BardLoggingFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/BardLoggingFilterSpec.groovy
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.web.filters
 
 import com.yahoo.bard.webservice.logging.RequestLog
+import com.yahoo.bard.webservice.logging.RequestLogUtils
 
 import spock.lang.Specification
 import org.slf4j.MDC
@@ -29,7 +30,7 @@ class BardLoggingFilterSpec extends Specification {
     }
 
     def cleanup() {
-        MDC.remove(RequestLog.ID_KEY)
+        RequestLogUtils.dump()
         fakeHeaders.clear()
     }
 
@@ -42,7 +43,7 @@ class BardLoggingFilterSpec extends Specification {
         filter.filter(requestContext)
 
         then:
-        MDC.get(RequestLog.ID_KEY).startsWith(requestId)
+        MDC.get(RequestLog.LOG_ID_KEY).startsWith(requestId)
 
         where:
         requestId << [
@@ -78,11 +79,10 @@ class BardLoggingFilterSpec extends Specification {
         filter.filter(requestContext)
 
         then:
-        !MDC.get(RequestLog.ID_KEY)?.startsWith(requestId)
+        !MDC.get(RequestLog.LOG_ID_KEY)?.startsWith(requestId)
 
         where:
         requestId << [
-                "",
                 "##",
                 "arequest#",
                 "5rreques!id",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
@@ -27,8 +27,8 @@ import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery
 import com.yahoo.bard.webservice.druid.model.query.Granularity
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
-import com.yahoo.bard.webservice.logging.RequestLog
 import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.logging.RequestLogUtils
 import com.yahoo.bard.webservice.table.Schema
 import com.yahoo.bard.webservice.web.DataApiRequest
 import com.yahoo.bard.webservice.web.ResponseFormatType
@@ -238,7 +238,7 @@ class ResultSetResponseProcessorSpec extends Specification {
         resultSetResponseProcessor.processResponse(
                 jsonMock,
                 groupByQuery,
-                new LoggingContext(RequestLog.dump())
+                new LoggingContext(RequestLogUtils.dump())
         )
 
         then:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/SplitQueryResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/SplitQueryResponseProcessorSpec.groovy
@@ -6,7 +6,7 @@ import com.yahoo.bard.webservice.data.cache.HashDataCache.Pair
 import com.yahoo.bard.webservice.druid.client.FailureCallback
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
-import com.yahoo.bard.webservice.logging.RequestLog
+import com.yahoo.bard.webservice.logging.RequestLogUtils
 import com.yahoo.bard.webservice.web.DataApiRequest
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -56,7 +56,7 @@ public class SplitQueryResponseProcessorSpec extends Specification {
                 apiRequest,
                 groupByQuery1,
                 expectedIntervals,
-                RequestLog.dump()
+                RequestLogUtils.dump()
         )
     }
 
@@ -112,8 +112,8 @@ public class SplitQueryResponseProcessorSpec extends Specification {
 
     def "Test stitch Json"() {
         setup:
-        completedIntervals.add(new Pair<>(node1, new LoggingContext(RequestLog.dump())))
-        completedIntervals.add(new Pair<>(node2, new LoggingContext(RequestLog.dump())))
+        completedIntervals.add(new Pair<>(node1, new LoggingContext(RequestLogUtils.dump())))
+        completedIntervals.add(new Pair<>(node2, new LoggingContext(RequestLogUtils.dump())))
 
         when:
         Pair<JsonNode, LoggingContext> result = sqrp.mergeResponses(completedIntervals)
@@ -127,7 +127,7 @@ public class SplitQueryResponseProcessorSpec extends Specification {
         groupByQuery2.getIntervals() >> [interval1] >> [interval2]
 
         when:
-        sqrp.processResponse(node1, groupByQuery2, new LoggingContext(RequestLog.dump()))
+        sqrp.processResponse(node1, groupByQuery2, new LoggingContext(RequestLogUtils.dump()))
 
         then:
         sqrp.completed.get() == 1
@@ -136,7 +136,7 @@ public class SplitQueryResponseProcessorSpec extends Specification {
         0 * next.processResponse(_, _, _)
 
         when:
-        sqrp.processResponse(node2, groupByQuery2, new LoggingContext(RequestLog.dump()))
+        sqrp.processResponse(node2, groupByQuery2, new LoggingContext(RequestLogUtils.dump()))
         then:
         sqrp.completed.get() == 0
         !sqrp.failed.get()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/WeightCheckResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/WeightCheckResponseProcessorSpec.groovy
@@ -7,7 +7,7 @@ import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.REQU
 import com.yahoo.bard.webservice.druid.client.FailureCallback
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
-import com.yahoo.bard.webservice.logging.RequestLog
+import com.yahoo.bard.webservice.logging.RequestLogUtils
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
@@ -28,8 +28,8 @@ class WeightCheckResponseProcessorSpec extends Specification{
 
     def setup() {
         // Artificial starting of the request workflow timer before each test
-        RequestLog.dump()
-        RequestLog.startTiming(REQUEST_WORKFLOW_TIMER)
+        RequestLogUtils.dump()
+        RequestLogUtils.startTiming(REQUEST_WORKFLOW_TIMER)
     }
 
     def "Test Constructor"() {
@@ -44,7 +44,7 @@ class WeightCheckResponseProcessorSpec extends Specification{
         then: "no timer is stopped and proccessing continues to the next processor"
         // This check is artifial. Is meant to check that there is no call to stopTiming() for this timer in the
         // regular execution path of the WeightCheckResponseProcessor
-        RequestLog.isRunning(REQUEST_WORKFLOW_TIMER) == true
+        RequestLogUtils.isRunning(REQUEST_WORKFLOW_TIMER)
         1 * next.processResponse(json, groupByQuery, null)
 
     }
@@ -57,7 +57,7 @@ class WeightCheckResponseProcessorSpec extends Specification{
         wcrp.getFailureCallback(groupByQuery).invoke(t)
 
         then: "The REQUEST_WORKFLOW_TIMER is stopped"
-        RequestLog.isRunning(REQUEST_WORKFLOW_TIMER) == false
+        !RequestLogUtils.isRunning(REQUEST_WORKFLOW_TIMER)
 
         then: "and the failure callback of the next processor is called"
         1 * next.getFailureCallback(groupByQuery) >> nextFail
@@ -71,13 +71,13 @@ class WeightCheckResponseProcessorSpec extends Specification{
         String body = "body"
         FailureCallback fc = Mock(FailureCallback)
         HttpErrorCallback ec
-        RequestLog.startTiming(REQUEST_WORKFLOW_TIMER)
+        RequestLogUtils.startTiming(REQUEST_WORKFLOW_TIMER)
 
         when: "Http error occurs"
         wcrp.getErrorCallback(groupByQuery).invoke(statusCode, reason, body)
 
         then: "The REQUEST_WORKFLOW_TIMER is stopped"
-        RequestLog.isRunning(REQUEST_WORKFLOW_TIMER) == false
+        !RequestLogUtils.isRunning(REQUEST_WORKFLOW_TIMER)
 
         then: "and the http error callback of the next processor is called"
         1 * next.getErrorCallback(groupByQuery) >> nextError

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/web/endpoints/TestFilterServlet.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/web/endpoints/TestFilterServlet.java
@@ -2,16 +2,11 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.endpoints;
 
-import com.yahoo.bard.webservice.logging.RequestLog;
-
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.List;
+import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -26,6 +21,10 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Stub Servlet for testing servlet filters in isolation.
@@ -64,7 +63,7 @@ public class TestFilterServlet implements Runnable {
                 new Thread(this).start();
             }
 
-            responses.add(new Pair<>(asyncResponse, RequestLog.dump()));
+            responses.add(new Pair<>(asyncResponse, RequestLogUtils.dump()));
         }
     }
 
@@ -95,7 +94,7 @@ public class TestFilterServlet implements Runnable {
             // release waiting requests
             synchronized (responses) {
                 for (Pair<AsyncResponse, RequestLog> response : responses) {
-                    RequestLog.restore(response.second);
+                    RequestLogUtils.restore(response.second);
                     response.first.resume("OK");
                 }
 

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/web/endpoints/TestLoggingServlet.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/web/endpoints/TestLoggingServlet.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.endpoints;
 
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
@@ -48,13 +48,13 @@ public class TestLoggingServlet {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/log")
     public void getSucceed(@Context UriInfo uriInfo, @Suspended AsyncResponse asyncResponse) {
-        RequestLog.startTiming(this);
+        RequestLogUtils.startTiming(this);
         try {
             Thread.sleep(200);
         } catch (InterruptedException ignore) {
             // Do nothing
         }
-        RequestLog.stopTiming(this);
+        RequestLogUtils.stopTiming(this);
 
         Response response = Response.status(Response.Status.OK).build();
         asyncResponse.resume(response);
@@ -72,7 +72,7 @@ public class TestLoggingServlet {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/webbug")
     public void getFailWithWebAppException(@Context UriInfo uriInfo) {
-        RequestLog.startTiming(this);
+        RequestLogUtils.startTiming(this);
         try {
             Thread.sleep(200);
             throw new WebApplicationException(
@@ -95,7 +95,7 @@ public class TestLoggingServlet {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/genericbug")
     public void getFailWithRuntimeException(@Context UriInfo uriInfo) {
-        RequestLog.startTiming(this);
+        RequestLogUtils.startTiming(this);
         try {
             Thread.sleep(200);
             throw new RuntimeException("Oops! Generic Exception");

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/web/filters/TestLogWrapperFilter.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/web/filters/TestLogWrapperFilter.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.filters;
 
-import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.RequestLogUtils;
 
 import javax.inject.Singleton;
 import javax.ws.rs.client.ClientRequestContext;
@@ -25,23 +25,23 @@ public class TestLogWrapperFilter implements ContainerRequestFilter, ContainerRe
 
     @Override
     public void filter(final ContainerRequestContext request) {
-        RequestLog.startTiming("TestLogWrapper");
+        RequestLogUtils.startTiming("TestLogWrapper");
     }
 
     @Override
     public void filter(ContainerRequestContext request, ContainerResponseContext response) {
-        RequestLog.stopTiming("TestLogWrapper");
-        RequestLog.log();
+        RequestLogUtils.stopTiming("TestLogWrapper");
+        RequestLogUtils.log();
     }
 
     @Override
     public void filter(final ClientRequestContext request) {
-        RequestLog.startTiming("TestLogWrapper");
+        RequestLogUtils.startTiming("TestLogWrapper");
     }
 
     @Override
     public void filter(ClientRequestContext request, ClientResponseContext response) {
-        RequestLog.stopTiming("TestLogWrapper");
-        RequestLog.log();
+        RequestLogUtils.stopTiming("TestLogWrapper");
+        RequestLogUtils.log();
     }
 }


### PR DESCRIPTION
* Add FiliTimingFilter to allow applications to use custom logging filters while retaining the non-logging related behaviors of the BardLoggingFilter
* Refactored the RequestLog by spinning the model out into a seperate class and marking the existing class as a utility

## New methods
* `RequestLogUtils.startTimingRequest`
* `RequestLogUtils.stopTimingRequest`