### PR TITLE
1. Implement QueryPlanning and DataSource Constraints into Resolvers and Matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Current
 -------
 
 ### Added:
+- [QueryPlanningConstraint and DataSourceConstraint](https://github.com/yahoo/fili/pull/169)
+    * Added `QueryPlanningConstraint` to replace current interface of Matchers and Resolvers arguments during query planning
+    * Added `DataSourceConstraint` to allow implementation of `PartitionedFactTable`'s availability in the near future
 
 - [Major refactor for availability and schemas and tables](https://github.com/yahoo/fili/pull/165)
     * `ImmutableAvailability` - provides immutable, typed replacement for maps of column availabilities
@@ -43,6 +46,9 @@ Current
 - [Support timeouts for lucene search provider](https://github.com/yahoo/fili/pull/183)
 
 ### Changed:
+- [QueryPlanningConstraint and DataSourceConstraint](https://github.com/yahoo/fili/pull/169)
+    * `QueryPlanningConstraint` replaces current interface of Matchers and Resolvers `DataApiRequest` and `TemplateDruidQuery` arguments during query planning
+    * Modified `findMissingTimeGrainIntervals` method in `PartialDataHandler` to take a set of columns instead of `DataApiRequest` and `DruidAggregationQuery`
 
 - [Major refactor for availability and schemas and tables](https://github.com/yahoo/fili/pull/165)
     * `Schema` and `Table` became interfaces

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/async/AsyncUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/async/AsyncUtils.java
@@ -61,10 +61,8 @@ public class AsyncUtils {
         }
 
         return new PreResponse(
-                new ResultSet(new ResultSetSchema(
-                        AllGranularity.INSTANCE,
-                        Collections.emptySet()),
-                        Collections.emptyList()
+                new ResultSet(
+                        new ResultSetSchema(AllGranularity.INSTANCE, Collections.emptySet()), Collections.emptyList()
                 ),
                 responseContext
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
@@ -1,4 +1,4 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data;
 
@@ -28,6 +28,7 @@ import com.yahoo.bard.webservice.table.LogicalTableDictionary;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.TableGroup;
 import com.yahoo.bard.webservice.table.TableIdentifier;
+import com.yahoo.bard.webservice.table.resolver.QueryPlanningConstraint;
 import com.yahoo.bard.webservice.table.resolver.NoMatchFoundException;
 import com.yahoo.bard.webservice.table.resolver.PhysicalTableResolver;
 import com.yahoo.bard.webservice.web.DataApiRequest;
@@ -118,7 +119,10 @@ public class DruidQueryBuilder {
         TableGroup group = logicalTable.getTableGroup();
 
         // Resolve the table from the the group, the combined dimensions in request, and template time grain
-        PhysicalTable table = resolver.resolve(group.getPhysicalTables(), request, template);
+        PhysicalTable table = resolver.resolve(
+                group.getPhysicalTables(),
+                new QueryPlanningConstraint(request, template)
+        );
 
         return druidTopNMetric != null ?
             buildTopNQuery(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/RowNumMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/RowNumMapper.java
@@ -43,7 +43,6 @@ public class RowNumMapper extends ResultSetMapper {
 
     @Override
     protected Result map(Result result, ResultSetSchema schema) {
-        // map for rows is not
         throw new UnsupportedOperationException("This code should never be reached.");
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
@@ -25,7 +25,7 @@ public class TableDataSource extends DataSource {
     public TableDataSource(ConcretePhysicalTable physicalTable) {
         super(DefaultDataSourceType.TABLE, Collections.singleton(physicalTable));
 
-        this.name = physicalTable.getFactTableName();
+        this.name = physicalTable.getAvailability().getDataSourceNames().stream().findFirst().get().asName();
     }
 
     public String getName() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/AggregatableDimensionsMatcher.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/AggregatableDimensionsMatcher.java
@@ -31,7 +31,7 @@ public class AggregatableDimensionsMatcher implements PhysicalTableMatcher {
     /**
      * Constructor saves metrics, dimensions, coarsest time grain, and logical table name (for logging).
      *
-     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
+     * @param requestConstraints  Contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      */
     public AggregatableDimensionsMatcher(QueryPlanningConstraint requestConstraints) {
         this.requestConstraints = requestConstraints;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolver.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolver.java
@@ -1,14 +1,11 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver;
 
-import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.application.MetricRegistryFactory;
-import com.yahoo.bard.webservice.data.dimension.Dimension;
-import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
-import com.yahoo.bard.webservice.util.TableUtils;
+import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 
@@ -23,7 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
-import java.util.stream.Collectors;
 
 /**
  *  Abstract parent to with business rule agnostic implementations of core methods.
@@ -45,32 +41,26 @@ public abstract class BasePhysicalTableResolver implements PhysicalTableResolver
     /**
      * Create a list of matchers based on a request and query.
      *
-     * @param apiRequest  The ApiRequest for the query
-     * @param query a partial query representation
+     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      *
      * @return a list of matchers to be applied, in order
      */
-    public abstract List<PhysicalTableMatcher> getMatchers(DataApiRequest apiRequest, TemplateDruidQuery query);
+    public abstract List<PhysicalTableMatcher> getMatchers(QueryPlanningConstraint requestConstraints);
 
     /**
      * Create a binary operator which returns the 'better' of two physical table.
      *
-     * @param apiRequest  The ApiRequest for the query
-     * @param query a partial query representation
+     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      *
      * @return a list of matchers to be applied, in order
      */
-    public abstract BinaryOperator<PhysicalTable> getBetterTableOperator(
-            DataApiRequest apiRequest,
-            TemplateDruidQuery query
-    );
+    public abstract BinaryOperator<PhysicalTable> getBetterTableOperator(QueryPlanningConstraint requestConstraints);
 
     /**
      * Filter to a set of tables matching the rules of this resolver.
      *
      * @param candidateTables  The physical tables being filtered
-     * @param apiRequest  The request being filtered to
-     * @param query  a partial query representation
+     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      *
      * @return a set of physical tables which all match the criteria of a request and partial query
      *
@@ -78,10 +68,9 @@ public abstract class BasePhysicalTableResolver implements PhysicalTableResolver
      */
     public Set<PhysicalTable> filter(
             Collection<PhysicalTable> candidateTables,
-            DataApiRequest apiRequest,
-            TemplateDruidQuery query
+            QueryPlanningConstraint requestConstraints
     ) throws NoMatchFoundException {
-        return filter(candidateTables, getMatchers(apiRequest, query));
+        return filter(candidateTables, getMatchers(requestConstraints));
     }
 
     /**
@@ -108,15 +97,12 @@ public abstract class BasePhysicalTableResolver implements PhysicalTableResolver
     @Override
     public PhysicalTable resolve(
             Collection<PhysicalTable> candidateTables,
-            DataApiRequest apiRequest,
-            TemplateDruidQuery query
+            QueryPlanningConstraint requestConstraints
     ) throws NoMatchFoundException {
+
         // Minimum grain at which the request can be aggregated from
-        Granularity minimumTableTimeGrain = resolveAcceptingGrain.apply(apiRequest, query);
-        TemplateDruidQuery innerQuery = (TemplateDruidQuery) query.getInnermostQuery();
-        Set<String> columnNames = TableUtils.getDimensions(apiRequest, innerQuery)
-                .map(Dimension::getApiName)
-                .collect(Collectors.toSet());
+        Granularity minimumTableTimeGrain = requestConstraints.getMinimumGranularity();
+        Set<String> columnNames = requestConstraints.getAllColumnNames();
         LOG.trace(
                 "Resolving Table using TimeGrain: {}, dimension API names: {} and TableGroup: {}",
                 minimumTableTimeGrain,
@@ -125,9 +111,9 @@ public abstract class BasePhysicalTableResolver implements PhysicalTableResolver
         );
 
         try {
-            Set<PhysicalTable> physicalTables = filter(candidateTables, apiRequest, query);
+            Set<PhysicalTable> physicalTables = filter(candidateTables, requestConstraints);
 
-            BinaryOperator<PhysicalTable> betterTable = getBetterTableOperator(apiRequest, query);
+            BinaryOperator<PhysicalTable> betterTable = getBetterTableOperator(requestConstraints);
             PhysicalTable bestTable = physicalTables.stream().reduce(betterTable).get();
 
             REGISTRY.meter("request.physical.table." + bestTable.getName() + "." + bestTable.getTimeGrain()).mark();
@@ -135,7 +121,7 @@ public abstract class BasePhysicalTableResolver implements PhysicalTableResolver
             return bestTable;
         } catch (NoMatchFoundException me) {
             // Blow up if we couldn't match a table, log and return if we can
-            logMatchException(apiRequest, minimumTableTimeGrain, innerQuery);
+            logMatchException(requestConstraints, minimumTableTimeGrain);
             throw me;
         }
     }
@@ -143,23 +129,16 @@ public abstract class BasePhysicalTableResolver implements PhysicalTableResolver
     /**
      * Log out inability to find a matching table.
      *
-     * @param apiRequest  Request for which we're trying to find a table
+     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      * @param minimumTableTimeGrain  Minimum grain that we needed to meet
-     * @param innerQuery  Innermost query for the query we were trying to match
      */
     public void logMatchException(
-            DataApiRequest apiRequest,
-            Granularity minimumTableTimeGrain,
-            TemplateDruidQuery innerQuery
+            QueryPlanningConstraint requestConstraints,
+            Granularity minimumTableTimeGrain
     ) {
         // Get the dimensions and metrics as lists of names
-        Set<String> requestDimensionNames = TableUtils.getDimensions(apiRequest, innerQuery)
-                .map(Dimension::getApiName)
-                .collect(Collectors.toSet());
-
-        Set<String> requestMetricNames = apiRequest.getLogicalMetrics().stream()
-                .map(LogicalMetric::getName)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<String> requestDimensionNames = requestConstraints.getAllDimensionNames();
+        Set<String> requestMetricNames = requestConstraints.getLogicalMetricNames();
 
         String msg = ErrorMessageFormat.NO_PHYSICAL_TABLE_MATCHED.logFormat(
                 requestDimensionNames,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
@@ -1,0 +1,83 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.resolver;
+
+import com.yahoo.bard.webservice.data.dimension.Dimension;
+import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
+import com.yahoo.bard.webservice.web.ApiFilter;
+import com.yahoo.bard.webservice.web.DataApiRequest;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Constraints for retrieving potential table availability for a given query.
+ */
+public class DataSourceConstraint {
+
+    private final Set<Dimension> requestDimensions;
+    private final Set<Dimension> filterDimensions;
+    private final Set<Dimension> metricDimensions;
+    private final Set<String> metricNames;
+    private final Map<Dimension, Set<ApiFilter>> apiFilters;
+
+    /**
+     * Constructor.
+     *
+     * @param dataApiRequest  Api request containing the constraints information.
+     * @param templateDruidQuery  Query containing metric constraint information.
+     */
+    public DataSourceConstraint(DataApiRequest dataApiRequest, DruidAggregationQuery<?> templateDruidQuery) {
+        this.requestDimensions = dataApiRequest.getDimensions();
+        this.filterDimensions = dataApiRequest.getFilterDimensions();
+        this.metricDimensions = templateDruidQuery.getMetricDimensions();
+        this.metricNames = templateDruidQuery.getDependentFieldNames();
+        this.apiFilters = dataApiRequest.getFilters();
+    }
+
+    public Set<Dimension> getRequestDimensions() {
+        return requestDimensions;
+    }
+
+    public Set<String> getRequestDimensionNames() {
+        return getRequestDimensions().stream().map(Dimension::getApiName).collect(Collectors.toSet());
+    }
+
+    public Set<Dimension> getFilterDimensions() {
+        return filterDimensions;
+    }
+
+    public Set<Dimension> getMetricDimensions() {
+        return metricDimensions;
+    }
+
+    public Set<String> getMetricNames() {
+        return metricNames;
+    }
+
+    public Set<Dimension> getAllDimensions() {
+        return Stream.of(
+                getRequestDimensions().stream(),
+                getFilterDimensions().stream(),
+                getMetricDimensions().stream()
+        ).flatMap(Function.identity()).collect(Collectors.toSet());
+    }
+
+    public Set<String> getAllDimensionNames() {
+        return getAllDimensions().stream().map(Dimension::getApiName).collect(Collectors.toSet());
+    }
+
+    public Set<String> getAllColumnNames() {
+        return Stream.of(
+                getAllDimensionNames().stream(),
+                getMetricNames().stream()
+        ).flatMap(Function.identity()).collect(Collectors.toSet());
+    }
+
+    public Map<Dimension, Set<ApiFilter>> getApiFilters() {
+        return apiFilters;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DefaultPhysicalTableResolver.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DefaultPhysicalTableResolver.java
@@ -50,16 +50,11 @@ public class DefaultPhysicalTableResolver extends BasePhysicalTableResolver {
 
     @Override
     public List<PhysicalTableMatcher> getMatchers(QueryPlanningConstraint requestConstraints) {
-        SchemaPhysicalTableMatcher schemaMatcher =
-                new SchemaPhysicalTableMatcher(requestConstraints);
-
-        TimeAlignmentPhysicalTableMatcher timeAlignmentMatcher =
-                new TimeAlignmentPhysicalTableMatcher(requestConstraints);
-
-        AggregatableDimensionsMatcher aggregatabilityMatcher =
-                new AggregatableDimensionsMatcher(requestConstraints);
-
-        return Arrays.asList(schemaMatcher, aggregatabilityMatcher, timeAlignmentMatcher);
+        return Arrays.asList(
+                new SchemaPhysicalTableMatcher(requestConstraints),
+                new AggregatableDimensionsMatcher(requestConstraints),
+                new TimeAlignmentPhysicalTableMatcher(requestConstraints)
+        );
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DefaultPhysicalTableResolver.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DefaultPhysicalTableResolver.java
@@ -1,14 +1,12 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver;
 
 import com.yahoo.bard.webservice.config.BardFeatureFlag;
 import com.yahoo.bard.webservice.data.PartialDataHandler;
-import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
 import com.yahoo.bard.webservice.data.volatility.VolatileIntervalsService;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.util.ChainingComparator;
-import com.yahoo.bard.webservice.web.DataApiRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,30 +49,32 @@ public class DefaultPhysicalTableResolver extends BasePhysicalTableResolver {
     }
 
     @Override
-    public List<PhysicalTableMatcher> getMatchers(DataApiRequest apiRequest, TemplateDruidQuery query) {
-        SchemaPhysicalTableMatcher schemaMatcher = new SchemaPhysicalTableMatcher(
-                apiRequest,
-                query,
-                resolveAcceptingGrain.apply(apiRequest, query)
-        );
-        TimeAlignmentPhysicalTableMatcher timeAlignmentMatcher = new TimeAlignmentPhysicalTableMatcher(apiRequest);
-        AggregatableDimensionsMatcher aggregatabilityMatcher = new AggregatableDimensionsMatcher(apiRequest, query);
+    public List<PhysicalTableMatcher> getMatchers(QueryPlanningConstraint requestConstraints) {
+        SchemaPhysicalTableMatcher schemaMatcher =
+                new SchemaPhysicalTableMatcher(requestConstraints);
+
+        TimeAlignmentPhysicalTableMatcher timeAlignmentMatcher =
+                new TimeAlignmentPhysicalTableMatcher(requestConstraints);
+
+        AggregatableDimensionsMatcher aggregatabilityMatcher =
+                new AggregatableDimensionsMatcher(requestConstraints);
 
         return Arrays.asList(schemaMatcher, aggregatabilityMatcher, timeAlignmentMatcher);
     }
 
     @Override
-    public BinaryOperator<PhysicalTable> getBetterTableOperator(DataApiRequest apiRequest, TemplateDruidQuery query) {
+    public BinaryOperator<PhysicalTable> getBetterTableOperator(QueryPlanningConstraint requestConstraints) {
         List<Comparator<PhysicalTable>> comparators = new ArrayList<>();
 
         if (BardFeatureFlag.PARTIAL_DATA.isOn()) {
-            comparators.add(new PartialTimeComparator(apiRequest, query, partialDataHandler));
             comparators.add(
-                    new VolatileTimeComparator(apiRequest, query, partialDataHandler, volatileIntervalsService)
-            );
+                    new PartialTimeComparator(requestConstraints, partialDataHandler));
+            comparators.add(
+                    new VolatileTimeComparator(requestConstraints, partialDataHandler, volatileIntervalsService));
         }
         comparators.add(COMPARE_GRANULARITY);
         comparators.add(CARDINALITY_COMPARATOR);
+
         ChainingComparator<PhysicalTable> tableComparator = new ChainingComparator<>(comparators);
         return BinaryOperator.minBy(tableComparator);
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PartialTimeComparator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PartialTimeComparator.java
@@ -1,13 +1,11 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver;
 
 import com.yahoo.bard.webservice.data.PartialDataHandler;
-import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.util.IntervalUtils;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
-import com.yahoo.bard.webservice.web.DataApiRequest;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -18,19 +16,16 @@ import java.util.Comparator;
 public class PartialTimeComparator implements Comparator<PhysicalTable> {
 
     private final PartialDataHandler partialDataHandler;
-    private final DataApiRequest request;
-    private final TemplateDruidQuery query;
+    private final QueryPlanningConstraint requestConstraints;
 
     /**
      * Constructor.
      *
-     * @param request  Request for which we're comparing parial time
-     * @param query  TDQ for which time is being compared
+     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      * @param handler  Handler for Partial Data
      */
-    public PartialTimeComparator(DataApiRequest request, TemplateDruidQuery query, PartialDataHandler handler) {
-        this.request = request;
-        this.query = query;
+    public PartialTimeComparator(QueryPlanningConstraint requestConstraints, PartialDataHandler handler) {
+        this.requestConstraints = requestConstraints;
         this.partialDataHandler = handler;
     }
 
@@ -47,20 +42,18 @@ public class PartialTimeComparator implements Comparator<PhysicalTable> {
         // choose table with most data available for given columns
         long missingDurationLeft = IntervalUtils.getTotalDuration(
                 partialDataHandler.findMissingTimeGrainIntervals(
-                        request,
-                        query,
+                        requestConstraints.getAllColumnNames(),
                         Collections.singleton(left),
-                        new SimplifiedIntervalList(request.getIntervals()),
-                        request.getGranularity()
+                        new SimplifiedIntervalList(requestConstraints.getIntervals()),
+                        requestConstraints.getRequestGranularity()
                 )
         );
         long missingDurationRight = IntervalUtils.getTotalDuration(
                 partialDataHandler.findMissingTimeGrainIntervals(
-                        request,
-                        query,
+                        requestConstraints.getAllColumnNames(),
                         Collections.singleton(right),
-                        new SimplifiedIntervalList(request.getIntervals()),
-                        request.getGranularity()
+                        new SimplifiedIntervalList(requestConstraints.getIntervals()),
+                        requestConstraints.getRequestGranularity()
                 )
         );
         long difference = missingDurationLeft - missingDurationRight;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalTableResolver.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalTableResolver.java
@@ -1,10 +1,8 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver;
 
-import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
 import com.yahoo.bard.webservice.table.PhysicalTable;
-import com.yahoo.bard.webservice.web.DataApiRequest;
 
 import java.util.Collection;
 
@@ -18,8 +16,7 @@ public interface PhysicalTableResolver {
      * Choose the best fit Physical Table from a table group.
      *
      * @param candidateTables  The tables being considered for match
-     * @param apiRequest  The ApiRequest for the query
-     * @param query  a partial query representation
+     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      *
      * @return The table, if any, that satisfies all criteria and best matches the query
      *
@@ -27,7 +24,6 @@ public interface PhysicalTableResolver {
      */
     PhysicalTable resolve(
             Collection<PhysicalTable> candidateTables,
-            DataApiRequest apiRequest,
-            TemplateDruidQuery query
+            QueryPlanningConstraint requestConstraints
     ) throws NoMatchFoundException;
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalTableResolver.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalTableResolver.java
@@ -16,7 +16,7 @@ public interface PhysicalTableResolver {
      * Choose the best fit Physical Table from a table group.
      *
      * @param candidateTables  The tables being considered for match
-     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
+     * @param requestConstraints  Contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      *
      * @return The table, if any, that satisfies all criteria and best matches the query
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraint.java
@@ -1,0 +1,66 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.resolver;
+
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
+import com.yahoo.bard.webservice.druid.model.query.Granularity;
+import com.yahoo.bard.webservice.table.LogicalTable;
+import com.yahoo.bard.webservice.web.DataApiRequest;
+
+import org.joda.time.Interval;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Constraints used to match and resolve the best table for a given query.
+ */
+public class QueryPlanningConstraint extends DataSourceConstraint {
+
+    private final LogicalTable logicalTable;
+    private final Set<Interval> intervals;
+    private final Set<LogicalMetric> logicalMetrics;
+    private final Granularity minimumGranularity;
+    private final Granularity requestGranularity;
+
+    /**
+     * Constructor.
+     *
+     * @param dataApiRequest Api request containing the constraints information.
+     * @param templateDruidQuery Query containing metric constraint information.
+     */
+    public QueryPlanningConstraint(DataApiRequest dataApiRequest, TemplateDruidQuery templateDruidQuery) {
+        super(dataApiRequest, templateDruidQuery);
+
+        this.logicalTable = dataApiRequest.getTable();
+        this.intervals = dataApiRequest.getIntervals();
+        this.minimumGranularity = new RequestQueryGranularityResolver().apply(dataApiRequest, templateDruidQuery);
+        this.requestGranularity = dataApiRequest.getGranularity();
+        this.logicalMetrics = dataApiRequest.getLogicalMetrics();
+    }
+
+    public LogicalTable getLogicalTable() {
+        return logicalTable;
+    }
+
+    public Set<Interval> getIntervals() {
+        return intervals;
+    }
+
+    public Set<LogicalMetric> getLogicalMetrics() {
+        return logicalMetrics;
+    }
+
+    public Set<String> getLogicalMetricNames() {
+        return getLogicalMetrics().stream().map(LogicalMetric::getName).collect(Collectors.toSet());
+    }
+
+    public Granularity getMinimumGranularity() {
+        return minimumGranularity;
+    }
+
+    public Granularity getRequestGranularity() {
+        return requestGranularity;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraint.java
@@ -10,6 +10,7 @@ import com.yahoo.bard.webservice.web.DataApiRequest;
 
 import org.joda.time.Interval;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -23,6 +24,7 @@ public class QueryPlanningConstraint extends DataSourceConstraint {
     private final Set<LogicalMetric> logicalMetrics;
     private final Granularity minimumGranularity;
     private final Granularity requestGranularity;
+    private final Set<String> logicalMetricNames;
 
     /**
      * Constructor.
@@ -34,10 +36,12 @@ public class QueryPlanningConstraint extends DataSourceConstraint {
         super(dataApiRequest, templateDruidQuery);
 
         this.logicalTable = dataApiRequest.getTable();
-        this.intervals = dataApiRequest.getIntervals();
+        this.intervals = Collections.unmodifiableSet(dataApiRequest.getIntervals());
+        this.logicalMetrics = Collections.unmodifiableSet(dataApiRequest.getLogicalMetrics());
         this.minimumGranularity = new RequestQueryGranularityResolver().apply(dataApiRequest, templateDruidQuery);
         this.requestGranularity = dataApiRequest.getGranularity();
-        this.logicalMetrics = dataApiRequest.getLogicalMetrics();
+        this.logicalMetricNames = Collections.unmodifiableSet(
+                logicalMetrics.stream().map(LogicalMetric::getName).collect(Collectors.toSet()));
     }
 
     public LogicalTable getLogicalTable() {
@@ -53,7 +57,7 @@ public class QueryPlanningConstraint extends DataSourceConstraint {
     }
 
     public Set<String> getLogicalMetricNames() {
-        return getLogicalMetrics().stream().map(LogicalMetric::getName).collect(Collectors.toSet());
+        return logicalMetricNames;
     }
 
     public Granularity getMinimumGranularity() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcher.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcher.java
@@ -1,17 +1,11 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver;
 
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.TABLE_SCHEMA_UNDEFINED;
 
-import com.yahoo.bard.webservice.data.dimension.Dimension;
-import com.yahoo.bard.webservice.data.metric.LogicalMetric;
-import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
-import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.table.Column;
 import com.yahoo.bard.webservice.table.PhysicalTable;
-import com.yahoo.bard.webservice.util.TableUtils;
-import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 
 import org.slf4j.Logger;
@@ -30,26 +24,20 @@ public class SchemaPhysicalTableMatcher implements PhysicalTableMatcher {
 
     public static final ErrorMessageFormat MESSAGE_FORMAT = TABLE_SCHEMA_UNDEFINED;
 
-    private final DataApiRequest request;
-    private final Granularity granularity;
-    private final TemplateDruidQuery query;
+    private final QueryPlanningConstraint requestConstraints;
 
     /**
      * Constructor saves metrics, dimensions, coarsest time grain, and logical table name (for logging).
      *
-     * @param request  The request whose dimensions are being matched on
-     * @param query  The query whose columns are being matched
-     * @param granularity  The granularity that tables under test must satisfy
+     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      */
-    public SchemaPhysicalTableMatcher(DataApiRequest request, TemplateDruidQuery query, Granularity granularity) {
-        this.request = request;
-        this.granularity = granularity;
-        this.query = query;
+    public SchemaPhysicalTableMatcher(QueryPlanningConstraint requestConstraints) {
+        this.requestConstraints = requestConstraints;
     }
 
     @Override
     public boolean test(PhysicalTable table) {
-        if (!granularity.satisfiedBy(table.getSchema().getTimeGrain())) {
+        if (!requestConstraints.getMinimumGranularity().satisfiedBy(table.getSchema().getTimeGrain())) {
             return false;
         }
 
@@ -57,24 +45,22 @@ public class SchemaPhysicalTableMatcher implements PhysicalTableMatcher {
                 .map(Column::getName)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        Set<String> columnNames = TableUtils.getColumnNames(request, query.getInnermostQuery());
+        Set<String> columnNames = requestConstraints.getAllColumnNames();
 
         return supplyNames.containsAll(columnNames);
     }
 
     @Override
     public NoMatchFoundException noneFoundException() {
-        String logicalTableName = request.getTable().getName();
-        Set<String> logicalMetrics = request.getLogicalMetrics().stream()
-                .map(LogicalMetric::getName)
-                .collect(Collectors.toSet());
-        Set<String> dimensions = request.getDimensions().stream()
-                .map(Dimension::getApiName)
-                .collect(Collectors.toSet());
-
-        LOG.error(MESSAGE_FORMAT.logFormat(logicalTableName, dimensions, logicalMetrics, granularity.getName()));
+        String logicalTableName = requestConstraints.getLogicalTable().getName();
+        Set<String> logicalMetrics = requestConstraints.getLogicalMetricNames();
+        Set<String> dimensions = requestConstraints.getRequestDimensionNames();
+        String grainName = requestConstraints.getMinimumGranularity().getName();
+        LOG.error(
+                MESSAGE_FORMAT.logFormat(logicalTableName, dimensions, logicalMetrics, grainName)
+        );
         return new NoMatchFoundException(
-                MESSAGE_FORMAT.format(logicalTableName, dimensions, logicalMetrics, granularity.getName())
+                MESSAGE_FORMAT.format(logicalTableName, dimensions, logicalMetrics, grainName)
         );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcher.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcher.java
@@ -54,7 +54,7 @@ public class SchemaPhysicalTableMatcher implements PhysicalTableMatcher {
     public NoMatchFoundException noneFoundException() {
         String logicalTableName = requestConstraints.getLogicalTable().getName();
         Set<String> logicalMetrics = requestConstraints.getLogicalMetricNames();
-        Set<String> dimensions = requestConstraints.getRequestDimensionNames();
+        Set<String> dimensions = requestConstraints.getAllDimensionNames();
         String grainName = requestConstraints.getMinimumGranularity().getName();
         LOG.error(
                 MESSAGE_FORMAT.logFormat(logicalTableName, dimensions, logicalMetrics, grainName)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/TimeAlignmentPhysicalTableMatcher.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/TimeAlignmentPhysicalTableMatcher.java
@@ -1,11 +1,10 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver;
 
 import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.availability.IsTableAligned;
 import com.yahoo.bard.webservice.table.availability.IsTableStartAlignedWithIntervals;
-import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 
 import org.joda.time.Interval;
@@ -31,15 +30,15 @@ public class TimeAlignmentPhysicalTableMatcher implements PhysicalTableMatcher {
      * Stores the request table name and intervals and creates a predicate to test a physical table based on request
      * intervals.
      *
-     * @param request  The Api Request being matched against
+     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      */
-    public TimeAlignmentPhysicalTableMatcher(DataApiRequest request) {
-        if (request.getIntervals().isEmpty()) {
+    public TimeAlignmentPhysicalTableMatcher(QueryPlanningConstraint requestConstraints) {
+        if (requestConstraints.getIntervals().isEmpty()) {
             throw new IllegalStateException("Intervals cannot be empty");
         }
-        logicalTableName = request.getTable().getName();
-        requestIntervals = request.getIntervals();
-        isTableAligned = new IsTableStartAlignedWithIntervals(request.getIntervals());
+        logicalTableName = requestConstraints.getLogicalTable().getName();
+        requestIntervals = requestConstraints.getIntervals();
+        isTableAligned = new IsTableStartAlignedWithIntervals(requestConstraints.getIntervals());
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/TimeAlignmentPhysicalTableMatcher.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/TimeAlignmentPhysicalTableMatcher.java
@@ -30,7 +30,7 @@ public class TimeAlignmentPhysicalTableMatcher implements PhysicalTableMatcher {
      * Stores the request table name and intervals and creates a predicate to test a physical table based on request
      * intervals.
      *
-     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
+     * @param requestConstraints  Contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      */
     public TimeAlignmentPhysicalTableMatcher(QueryPlanningConstraint requestConstraints) {
         if (requestConstraints.getIntervals().isEmpty()) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/VolatileTimeComparator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/VolatileTimeComparator.java
@@ -24,7 +24,7 @@ public class VolatileTimeComparator implements Comparator<PhysicalTable> {
     /**
      * Builds a table comparator that compares tables based on how much data there is in their volatile intervals.
      *
-     * @param requestConstraints contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
+     * @param requestConstraints  Contains the request constraints extracted from DataApiRequest and TemplateDruidQuery
      * @param partialDataHandler  A service for computing partial data information
      * @param volatileIntervalsService  A service to extract the intervals in a query that are volatile with respect
      * to a given table

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
@@ -1,4 +1,4 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.handlers;
 
@@ -11,6 +11,7 @@ import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
+import com.yahoo.bard.webservice.util.TableUtils;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.responseprocessors.MappingResponseProcessor;
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseContext;
@@ -73,8 +74,7 @@ public class PartialDataRequestHandler implements DataRequestHandler {
 
         // Gather the missing intervals
         SimplifiedIntervalList missingIntervals = partialDataHandler.findMissingTimeGrainIntervals(
-                request,
-                druidQuery,
+                TableUtils.getColumnNames(request, druidQuery),
                 physicalTables,
                 new SimplifiedIntervalList(request.getIntervals()),
                 request.getGranularity()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/DimensionToDefaultDimensionSpecSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/DimensionToDefaultDimensionSpecSpec.groovy
@@ -51,6 +51,7 @@ class DimensionToDefaultDimensionSpecSpec extends Specification {
         apiRequest.getTopN() >> OptionalInt.empty()
         apiRequest.getSorts() >> ([])
         apiRequest.getCount() >> OptionalInt.empty()
+        apiRequest.getFilters() >> Collections.emptyMap()
     }
 
     def "Serialize to apiName when apiName and physicalName of a dimension is the same"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/LookupDimensionToDimensionSpecSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/LookupDimensionToDimensionSpecSpec.groovy
@@ -52,6 +52,7 @@ class LookupDimensionToDimensionSpecSpec extends Specification{
         apiRequest.getTopN() >> OptionalInt.empty()
         apiRequest.getSorts() >> ([])
         apiRequest.getCount() >> OptionalInt.empty()
+        apiRequest.getFilters() >> Collections.emptyMap()
     }
 
     def "Given lookup dimension with no namespace serialize using dimension serializer"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/RegisteredLookupDimensionToDimensionSpecSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/RegisteredLookupDimensionToDimensionSpecSpec.groovy
@@ -52,6 +52,7 @@ class RegisteredLookupDimensionToDimensionSpecSpec extends Specification{
         apiRequest.getTopN() >> OptionalInt.empty()
         apiRequest.getSorts() >> ([])
         apiRequest.getCount() >> OptionalInt.empty()
+        apiRequest.getFilters() >> Collections.emptyMap()
     }
 
     def "Given registered lookup dimension with no lookup serialize using dimension serializer"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolverSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolverSpec.groovy
@@ -1,72 +1,44 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver
 
-import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
-import static org.joda.time.DateTimeZone.UTC
-
-import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
-import com.yahoo.bard.webservice.druid.model.query.AllGranularity
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
-import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable
-import com.yahoo.bard.webservice.table.TableGroup
-import com.yahoo.bard.webservice.web.DataApiRequest
-
-import com.google.common.collect.Sets
 
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.util.function.BinaryOperator
+
 /**
  *  Tests for methods in BasePhysicalResolverSpec
  */
 class BasePhysicalTableResolverSpec extends Specification {
 
-    List<PhysicalTable> tables
+    @Shared PhysicalTable one, two, three
     @Shared PhysicalTableMatcher matchAllButTablesNamedOne, matchThree, matchAll
-    @Shared BinaryOperator<PhysicalTable> pickFirst
-    @Shared BinaryOperator<PhysicalTable> pickLast
-    @Shared PhysicalTable one = Mock(PhysicalTable)
-    @Shared PhysicalTable two = Mock(PhysicalTable)
-    @Shared PhysicalTable three = Mock(PhysicalTable)
+    @Shared BinaryOperator<PhysicalTable> pickFirst, pickLast
+    @Shared NoMatchFoundException noMatchNotAny, noMatchNotOne, noMatchThree
 
-    @Shared NoMatchFoundException noMatchNotAny = new NoMatchFoundException("notAny")
-    @Shared NoMatchFoundException noMatchNotOne = new NoMatchFoundException("notOne")
-    @Shared NoMatchFoundException noMatchThree = new NoMatchFoundException("three")
-
-    DataApiRequest request = Mock(DataApiRequest)
-    TemplateDruidQuery query = Mock(TemplateDruidQuery)
-
-    BasePhysicalTableResolver physicalTableResolver = new BasePhysicalTableResolver() {
-
-        List<PhysicalTableMatcher> matchers
-        BinaryOperator<PhysicalTable> betterTable
-
-        @Override
-        List<PhysicalTableMatcher> getMatchers(DataApiRequest apiRequest, TemplateDruidQuery query) {
-            return matchers
-        }
-
-        @Override
-        BinaryOperator<PhysicalTable> getBetterTableOperator(DataApiRequest apiRequest, TemplateDruidQuery query) {
-            return betterTable
-        }
-    }
-
+    BasePhysicalTableResolver physicalTableResolver
+    QueryPlanningConstraint dataSourceConstraint
 
     def setupSpec() {
+        one = Mock(PhysicalTable)
+        two = Mock(PhysicalTable)
+        three = Mock(PhysicalTable)
+
         one.getName() >> "one"
-        one.toString() >> "one"
         two.getName() >> "two"
-        two.toString() >> "two"
         three.getName() >> "three"
-        three.toString() >> "three"
 
         pickFirst = { PhysicalTable table1, PhysicalTable table2 -> table1 } as BinaryOperator<PhysicalTable>
         pickLast  = { PhysicalTable table1, PhysicalTable table2 -> table2 } as BinaryOperator<PhysicalTable>
+
+        noMatchNotAny = new NoMatchFoundException("No Match Found: notAny")
+        noMatchNotOne = new NoMatchFoundException("No Match Found: notOne")
+        noMatchThree = new NoMatchFoundException("No Match Found: three")
+
         matchAll = new PhysicalTableMatcher() {
             @Override
             boolean test(PhysicalTable table) {
@@ -120,28 +92,32 @@ class BasePhysicalTableResolverSpec extends Specification {
     }
 
     def setup() {
-        request.getGranularity() >> AllGranularity.INSTANCE
-        query.getInnermostQuery() >> query
-        query.getDimensions() >> []
-        query.getMetricDimensions() >> ([] as Set)
-        query.getDependentFieldNames() >> ([] as Set)
-        request.getFilterDimensions() >> []
-        request.getDimensions() >> ([] as Set)
+        dataSourceConstraint = Mock(QueryPlanningConstraint)
 
-        LogicalTable logical = Mock(LogicalTable.class)
-        TableGroup group = Mock(TableGroup.class)
-        logical.getTableGroup() >> group
-        PhysicalTable table = new ConcretePhysicalTable("table_name", DAY.buildZonedTimeGrain(UTC), [] as Set, [:])
-        group.getPhysicalTables() >> Sets.newHashSet(table)
-        request.getTable() >> logical
+        physicalTableResolver = new BasePhysicalTableResolver() {
+
+            List<PhysicalTableMatcher> matchers
+            BinaryOperator<PhysicalTable> betterTable
+
+            @Override
+            List<PhysicalTableMatcher> getMatchers(QueryPlanningConstraint requestConstraints) {
+                return matchers
+            }
+
+            @Override
+            BinaryOperator<PhysicalTable> getBetterTableOperator(QueryPlanningConstraint requestConstraints) {
+                return betterTable
+            }
+        }
     }
+
     @Unroll
     def "Test matchers with no empties to #expected"() {
         setup:
-        physicalTableResolver.matchers = matchers as List
+        physicalTableResolver.matchers = matchers
 
         expect:
-        physicalTableResolver.filter( [one, two, three] as List, request, query) ==  expected as Set
+        physicalTableResolver.filter([one, two, three], dataSourceConstraint) ==  expected.toSet()
 
         where:
         matchers                                | expected
@@ -154,13 +130,15 @@ class BasePhysicalTableResolverSpec extends Specification {
     @Unroll
     def "Test matchers with throw no match exception with #matchers and #supply"() {
         setup:
-        physicalTableResolver.matchers = matchers as List
+        physicalTableResolver.matchers = matchers
 
         when:
-        physicalTableResolver.filter( supply as List, request, query)
+        physicalTableResolver.filter( supply, dataSourceConstraint)
 
         then:
-        thrown(NoMatchFoundException)
+        NoMatchFoundException noMatchFoundException = thrown()
+        noMatchFoundException.message.startsWith('No Match Found: ')
+
 
         where:
         matchers                                | supply       | noMatch
@@ -178,7 +156,7 @@ class BasePhysicalTableResolverSpec extends Specification {
         physicalTableResolver.betterTable = better
 
         expect:
-        physicalTableResolver.resolve([one, two, three], request, query) == expected
+        physicalTableResolver.resolve([one, two, three], dataSourceConstraint) == expected
 
         where:
         matchers                                | better    | expected

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DefaultPhysicalTableResolverSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DefaultPhysicalTableResolverSpec.groovy
@@ -1,4 +1,4 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver
 
@@ -161,7 +161,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect:
-        resolver.filter([table], apiRequest, query) == [table] as Set
+        resolver.filter([table], new QueryPlanningConstraint(apiRequest, query)) == [table] as Set
 
         where:
         grain | dimensions | table
@@ -193,7 +193,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect:
-        resolver.filter([table], apiRequest, query) == [table] as Set
+        resolver.filter([table], new QueryPlanningConstraint(apiRequest, query)) == [table] as Set
 
         where:
         grainName              | dimensions | table
@@ -224,7 +224,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         when:
-        resolver.filter([table], apiRequest, query)
+        resolver.filter([table], new QueryPlanningConstraint(apiRequest, query))
 
         then:
         thrown(NoMatchFoundException)
@@ -251,7 +251,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect:
-        resolver.filter([table], apiRequest, query) == [table] as Set
+        resolver.filter([table], new QueryPlanningConstraint(apiRequest, query)) == [table] as Set
 
         where:
         dimensions | table
@@ -275,7 +275,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         when:
-        resolver.filter([table], apiRequest, query)
+        resolver.filter([table], new QueryPlanningConstraint(apiRequest, query))
 
         then:
         thrown(NoMatchFoundException)
@@ -300,7 +300,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect:
-        resolver.filter([table], apiRequest, query) == [table] as Set
+        resolver.filter([table], new QueryPlanningConstraint(apiRequest, query)) == [table] as Set
 
         where:
         grain | metrics           | table
@@ -326,7 +326,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         when:
-        resolver.filter([table], apiRequest, query)
+        resolver.filter([table], new QueryPlanningConstraint(apiRequest, query))
 
         then:
         thrown(NoMatchFoundException)
@@ -351,7 +351,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect:
-        resolver.filter([table], apiRequest, query) == [table] as Set
+        resolver.filter([table], new QueryPlanningConstraint(apiRequest, query)) == [table] as Set
 
         where:
         grain | metrics           | table
@@ -378,7 +378,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         when:
-        resolver.filter([table], apiRequest, query)
+        resolver.filter([table], new QueryPlanningConstraint(apiRequest, query))
 
         then:
         thrown(NoMatchFoundException)
@@ -401,7 +401,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         apiRequestPrototype['logicalMetrics'] = metricsForNameSet(queryPrototype['dependantFieldNames'] as Set)
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
-        BinaryOperator betterTable = resolver.getBetterTableOperator(apiRequest, query)
+        BinaryOperator betterTable = resolver.getBetterTableOperator(new QueryPlanningConstraint(apiRequest, query))
 
         expect:
         [table1, table2].stream().reduce(betterTable).get() == expected
@@ -427,7 +427,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         apiRequestPrototype['logicalMetrics'] = metricsForNameSet(queryPrototype['dependantFieldNames'] as Set)
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
-        BinaryOperator betterTable = resolver.getBetterTableOperator(apiRequest, query)
+        BinaryOperator betterTable = resolver.getBetterTableOperator(new QueryPlanningConstraint(apiRequest, query))
 
         expect:
         [(PhysicalTable) table1, (PhysicalTable) table2].stream().reduce(betterTable).get() == [table1, table1, table2].get(which)
@@ -482,7 +482,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect:
-        resolver.resolve(resources.tg1All.physicalTables, apiRequest, query) == expected
+        resolver.resolve(resources.tg1All.physicalTables, new QueryPlanningConstraint(apiRequest, query)) == expected
 
         where:
         intervals                  | grain || expected
@@ -512,7 +512,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect:
-        resolver.resolve(resources.tg1All.physicalTables, apiRequest, query) == expected
+        resolver.resolve(resources.tg1All.physicalTables, new QueryPlanningConstraint(apiRequest, query)) == expected
 
         where:
         interval    | grain || expected
@@ -551,7 +551,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect: "The table with more data available is preferred"
-        localResolver.resolve([resources.volatileHourTable, resources.volatileDayTable], apiRequest, query) == expected
+        localResolver.resolve([resources.volatileHourTable, resources.volatileDayTable], new QueryPlanningConstraint(apiRequest, query)) == expected
 
         where:
         hourAvailable           | hourVolatile            | dayAvailable            | dayVolatile             | grain || expected
@@ -579,7 +579,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect:
-        resolver.resolve(tablegroup.physicalTables, apiRequest, query) == expected
+        resolver.resolve(tablegroup.physicalTables, new QueryPlanningConstraint(apiRequest, query)) == expected
 
         where:
         grain | dimensions | tablegroup     | metrics             | expected
@@ -607,7 +607,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         when:
-        resolver.resolve(tablegroup.physicalTables, apiRequest, query)
+        resolver.resolve(tablegroup.physicalTables, new QueryPlanningConstraint(apiRequest, query))
 
         then:
         thrown(NoMatchFoundException)
@@ -632,7 +632,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         DataApiRequest apiRequest = buildDataApiRequest(apiRequestPrototype)
 
         expect:
-        resolver.resolve(tablegroup.physicalTables, apiRequest, query) == table
+        resolver.resolve(tablegroup.physicalTables, new QueryPlanningConstraint(apiRequest, query)) == table
 
         where:
         grain | dimensions | tablegroup     | table

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DefaultPhysicalTableResolverSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DefaultPhysicalTableResolverSpec.groovy
@@ -138,6 +138,7 @@ class DefaultPhysicalTableResolverSpec  extends Specification {
         apiRequest.granularity >> granularity
         apiRequest.filterDimensions >> prototype['filterDimensions']
         apiRequest.logicalMetrics >> prototype['logicalMetrics']
+        apiRequest.getFilters() >> Collections.emptyMap()
         return apiRequest
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcherSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcherSpec.groovy
@@ -1,4 +1,4 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver
 
@@ -71,14 +71,6 @@ class SchemaPhysicalTableMatcherSpec extends Specification {
                 ['dimA':'druidDimA', 'dimCommon': 'druidDimC', 'dimB': 'dimCommon']
         )
 
-
-        dimensionDictionary = new DimensionDictionary(dimSet)
-        schemaPhysicalTableMatcher = new SchemaPhysicalTableMatcher(
-                request,
-                query,
-                DAY.buildZonedTimeGrain(UTC)
-        )
-
         request.getGranularity() >> DAY.buildZonedTimeGrain(UTC)
         query.getInnermostQuery() >> query
         query.getDimensions() >> (['dimB'] as Set)
@@ -86,6 +78,11 @@ class SchemaPhysicalTableMatcherSpec extends Specification {
         query.getDependentFieldNames() >> ([] as Set)
         request.getFilterDimensions() >> []
         request.getDimensions() >> (dimSet)
+
+        dimensionDictionary = new DimensionDictionary(dimSet)
+        schemaPhysicalTableMatcher = new SchemaPhysicalTableMatcher(
+                new QueryPlanningConstraint(request, query)
+        )
     }
 
     def "schema matcher resolves table containing a logical name for a dimension same as physical name for other dimension"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcherSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcherSpec.groovy
@@ -78,6 +78,9 @@ class SchemaPhysicalTableMatcherSpec extends Specification {
         query.getDependentFieldNames() >> ([] as Set)
         request.getFilterDimensions() >> []
         request.getDimensions() >> (dimSet)
+        request.getFilters() >> Collections.emptyMap()
+        request.getIntervals() >> []
+        request.getLogicalMetrics() >> []
 
         dimensionDictionary = new DimensionDictionary(dimSet)
         schemaPhysicalTableMatcher = new SchemaPhysicalTableMatcher(

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/VolatileTimeComparatorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/VolatileTimeComparatorSpec.groovy
@@ -1,9 +1,10 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver
 
 import com.yahoo.bard.webservice.data.PartialDataHandler
 import com.yahoo.bard.webservice.data.QueryBuildingTestingResources
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery
 import com.yahoo.bard.webservice.druid.model.query.Granularity
@@ -40,13 +41,14 @@ class VolatileTimeComparatorSpec extends Specification {
                 DefaultTimeGrain.YEAR
         )
         and: "The query of interest"
-        DruidAggregationQuery query = Stub(DruidAggregationQuery)
+        TemplateDruidQuery query = Stub(TemplateDruidQuery)
+        query.getInnermostQuery() >> query
+        query.getTimeGrain() >> null
         query.getIntervals() >> (request.getIntervals() as List)
 
         and: "The volatile time comparator under test"
         VolatileTimeComparator comparator = new VolatileTimeComparator(
-                request,
-                query,
+                new QueryPlanningConstraint(request, query),
                 new PartialDataHandler(),
                 resources.volatileIntervalsService
         )
@@ -93,13 +95,14 @@ class VolatileTimeComparatorSpec extends Specification {
                 requestGranularity
         )
         and: "The query of interest"
-        DruidAggregationQuery query = Stub(DruidAggregationQuery)
+        TemplateDruidQuery query = Stub(TemplateDruidQuery)
+        query.getInnermostQuery() >> query
+        query.getTimeGrain() >> null
         query.getIntervals() >> (request.getIntervals() as List)
 
         and: "The volatile time comparator under test"
         VolatileTimeComparator comparator = new VolatileTimeComparator(
-                request,
-                query,
+                new QueryPlanningConstraint(request, query),
                 new PartialDataHandler(),
                 resources.volatileIntervalsService
         )

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandlerSpec.groovy
@@ -1,4 +1,4 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.handlers
 
@@ -13,6 +13,7 @@ import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
+import com.yahoo.bard.webservice.util.TableUtils
 import com.yahoo.bard.webservice.web.DataApiRequest
 import com.yahoo.bard.webservice.web.responseprocessors.MappingResponseProcessor
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseContext
@@ -47,6 +48,10 @@ class PartialDataRequestHandlerSpec extends Specification {
     )
 
     def setup() {
+        apiRequest.getDimensions() >> Collections.emptySet()
+        apiRequest.getFilterDimensions() >> Collections.emptySet()
+        groupByQuery.getMetricDimensions() >> Collections.emptySet()
+        groupByQuery.getDependentFieldNames() >> Collections.emptySet()
         groupByQuery.getInnermostQuery() >> groupByQuery
         groupByQuery.getDataSource() >> dataSource
         physicalTableDictionary.get(_) >> physicalTables[0]
@@ -61,7 +66,6 @@ class PartialDataRequestHandlerSpec extends Specification {
         setup:
         PARTIAL_DATA.setOn(true)
         boolean success
-        ResponseProcessor capture
         Set intervals = [] as TreeSet
         apiRequest.intervals >> []
 
@@ -71,8 +75,7 @@ class PartialDataRequestHandlerSpec extends Specification {
         then:
         success
         1 * partialDataHandler.findMissingTimeGrainIntervals(
-                apiRequest,
-                groupByQuery,
+                TableUtils.getColumnNames(apiRequest, groupByQuery),
                 physicalTables,
                 new SimplifiedIntervalList(apiRequest.intervals),
                 apiRequest.granularity
@@ -104,8 +107,7 @@ class PartialDataRequestHandlerSpec extends Specification {
         then:
         success
         1 * partialDataHandler.findMissingTimeGrainIntervals(
-                apiRequest,
-                groupByQuery,
+                TableUtils.getColumnNames(apiRequest, groupByQuery),
                 physicalTables,
                 new SimplifiedIntervalList(apiRequest.intervals),
                 apiRequest.granularity
@@ -135,7 +137,7 @@ class PartialDataRequestHandlerSpec extends Specification {
         PARTIAL_DATA.setOn(false)
         boolean success
         Interval i = new Interval(0, 1)
-        SimplifiedIntervalList nonEmptyIntervals = new SimplifiedIntervalList([i]);
+        SimplifiedIntervalList nonEmptyIntervals = new SimplifiedIntervalList([i])
         apiRequest.intervals >> [new Interval(0, 2)]
 
         ResponseContext responseContext = new ResponseContext([:])
@@ -150,8 +152,7 @@ class PartialDataRequestHandlerSpec extends Specification {
         then:
         success
         1 * partialDataHandler.findMissingTimeGrainIntervals(
-                apiRequest,
-                groupByQuery,
+                TableUtils.getColumnNames(apiRequest, groupByQuery),
                 physicalTables,
                 new SimplifiedIntervalList(apiRequest.intervals),
                 apiRequest.granularity


### PR DESCRIPTION
* Added `QueryPlanningConstraint` to replace current interface of Matchers and Resolvers arguments during query planning
* Added `DataSourceConstraint` to allow implementation of `PartitionedFactTable`'s availability in the near future
* Modified `findMissingTimeGrainIntervals` method in `PartialDataHandler` to take a set of columns instead of `DataApiRequest` and `DruidAggregationQuery`