### PR TITLE
Support underscores in request ids.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Current
 
 ### Changed:
 
+-- [Request IDS now supports underscores.](https://github.com/yahoo/fili/pull/176)
+
 - Added support for extensions defining new Query types
     * TestDruidWebService assumes unknown query types behave like GroupBy, TimeSeries, and TopN
     * ResultSetResponseProcessor delegates to DruidResponseProcessor to build expected query schema, 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/BardLoggingFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/BardLoggingFilter.java
@@ -69,7 +69,7 @@ public class BardLoggingFilter implements ContainerRequestFilter, ContainerRespo
     private static final String PROPERTY_NANOS = LoggingFilter.class.getName() + ".nanos";
     private static final String PROPERTY_REQ_LEN = LoggingFilter.class.getName() + ".reqlen";
     private static final String PROPERTY_OUTPUT_STREAM = LoggingFilter.class.getName() + ".ostream";
-    private static final Pattern VALID_REQUEST_ID = Pattern.compile("[a-zA-Z0-9+/=-]+");
+    private static final Pattern VALID_REQUEST_ID = Pattern.compile("[a-zA-Z0-9+/=\\-_]+");
 
     public static final double MILLISECONDS_PER_NANOSECOND = 1000000.0;
     public static final String TOTAL_TIMER = "TotalTime";

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/BardLoggingFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/BardLoggingFilterSpec.groovy
@@ -1,0 +1,93 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.filters
+
+import com.yahoo.bard.webservice.logging.RequestLog
+
+import spock.lang.Specification
+import org.slf4j.MDC
+
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import javax.ws.rs.container.ContainerRequestContext
+import javax.ws.rs.core.MultivaluedHashMap
+import javax.ws.rs.core.UriInfo
+
+class BardLoggingFilterSpec extends Specification {
+
+    @Subject BardLoggingFilter filter = new BardLoggingFilter()
+
+    MultivaluedHashMap<String, String> fakeHeaders = new MultivaluedHashMap<>()
+    ContainerRequestContext requestContext = Stub(ContainerRequestContext) {
+            getHeaders() >> fakeHeaders
+            getUriInfo() >> Stub(UriInfo) {
+                getRequestUri() >> new URI(
+                        "https://bard.bard.com/v1/public/table/grain?metrics=blah&dateTime=2017-01-01/2018-01-01"
+                )
+            }
+    }
+
+    def cleanup() {
+        MDC.remove(RequestLog.ID_KEY)
+        fakeHeaders.clear()
+    }
+
+    @Unroll
+    def "The BardLoggingFilter successfully adds #requestId to MDC"() {
+        given: "A ContainerRequestContext with the specified requestId"
+        fakeHeaders.put(BardLoggingFilter.X_REQUEST_ID_HEADER, [requestId])
+
+        when:
+        filter.filter(requestContext)
+
+        then:
+        MDC.get(RequestLog.ID_KEY).startsWith(requestId)
+
+        where:
+        requestId << [
+                "5",
+                "a",
+                "requestId",
+                "5requestId",
+                "a",
+                "5",
+                "5".multiply(200),
+                "5+a-b=6",
+                "5_little_monkeys"
+        ]
+    }
+
+    def "The BardLoggingFilter is null safe"() {
+        given: "A ContainerRequestContext with a null requestId"
+        fakeHeaders.put(BardLoggingFilter.X_REQUEST_ID_HEADER, [null])
+
+        when:
+        filter.filter(requestContext)
+
+        then:
+        notThrown(NullPointerException)
+    }
+
+    @Unroll
+    def "The BardLoggingFilter does not add a malformed requestId '#requestId' to MDC"() {
+        given: "A ContainerRequestContext with the specified malformed requestId"
+        fakeHeaders.put(BardLoggingFilter.X_REQUEST_ID_HEADER, [requestId])
+
+        when:
+        filter.filter(requestContext)
+
+        then:
+        !MDC.get(RequestLog.ID_KEY)?.startsWith(requestId)
+
+        where:
+        requestId << [
+                "",
+                "##",
+                "arequest#",
+                "5rreques!id",
+                "5".multiply(201),
+                "5+a-b!=6"
+        ]
+    }
+}


### PR DESCRIPTION
--Some clients want to have underscores in their unique request ids.
Since it's kind of arbitrary what characters we allow or don't allow in
the request header, we've added it.