### PR TITLE
Remove duplicate method in ErrorMessageFormat

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -235,17 +235,6 @@ public enum ErrorMessageFormat implements MessageFormatter {
         this.loggingFormat = loggingFormat;
     }
 
-    /**
-     * Format a log message for reporting to a user/client.
-     *
-     * @param values The values to populate the format string
-     *
-     * @return The user message
-     */
-    public String format(Object...values) {
-        return String.format(messageFormat, values);
-    }
-
     @Override
     public String getMessageFormat() {
         return messageFormat;


### PR DESCRIPTION
Since `format(Object...values)` in `ErrorMessageFormat` is doing the same thing that the default method in `MessageFormatter` interface is doing, we drop the method