### PR TITLE
Better support for extensible query types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Current
 
 ### Changed:
 
+- Added support for extensions defining new Query types
+    * TestDruidWebService assumes unknown query types behave like GroupBy, TimeSeries, and TopN
+    * ResultSetResponseProcessor delegates to DruidResponseProcessor to build expected query schema, 
+      allowing subclasses to override and extend the schema behavior
 - [Add dimension fields to fullView table format](https://github.com/yahoo/fili/pull/155)
 
 ### Deprecated:
@@ -23,6 +27,7 @@ Current
 
 
 ### Fixed:
+- Correcting error message logged when no table schema match is found
 - Setting readTimeout on DefaultAsyncHttpClientConfig when building AsyncDruidWebServiceImpl
 
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidResponseParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidResponseParser.java
@@ -46,9 +46,11 @@ public class DruidResponseParser {
      * @param dateTimeZone The timezone for the schema
      * @return The schema for the query
      */
-    public ZonedSchema buildSchema(DruidAggregationQuery<?> druidQuery,
-                                    Granularity granularity,
-                                    DateTimeZone dateTimeZone) {
+    public ZonedSchema buildSchema(
+                    DruidAggregationQuery<?> druidQuery,
+                    Granularity granularity,
+                    DateTimeZone dateTimeZone
+    ) {
         ZonedSchema resultSetSchema = new ZonedSchema(granularity, dateTimeZone);
 
         for (Aggregation aggregation : druidQuery.getAggregations()) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidResponseParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidResponseParser.java
@@ -4,10 +4,15 @@ package com.yahoo.bard.webservice.data;
 
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.RESULT_SET_ERROR;
 
+import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.data.dimension.DimensionColumn;
 import com.yahoo.bard.webservice.data.dimension.DimensionRow;
 import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.druid.model.QueryType;
+import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
+import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation;
+import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
+import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.druid.model.DefaultQueryType;
 import com.yahoo.bard.webservice.table.ZonedSchema;
 
@@ -33,6 +38,33 @@ import javax.inject.Singleton;
 public class DruidResponseParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(DruidResponseParser.class);
+
+    /**
+     * Build the schema that should be expected for the specified query.
+     * @param druidQuery The query
+     * @param granularity The granularity for the schema
+     * @param dateTimeZone The timezone for the schema
+     * @return The schema for the query
+     */
+    public ZonedSchema buildSchema(DruidAggregationQuery<?> druidQuery,
+                                    Granularity granularity,
+                                    DateTimeZone dateTimeZone) {
+        ZonedSchema resultSetSchema = new ZonedSchema(granularity, dateTimeZone);
+
+        for (Aggregation aggregation : druidQuery.getAggregations()) {
+            MetricColumn.addNewMetricColumn(resultSetSchema, aggregation.getName());
+        }
+
+        for (PostAggregation postAggregation : druidQuery.getPostAggregations()) {
+            MetricColumn.addNewMetricColumn(resultSetSchema, postAggregation.getName());
+        }
+
+        for (Dimension dimension : druidQuery.getDimensions()) {
+            DimensionColumn.addNewDimensionColumn(resultSetSchema, dimension);
+        }
+
+        return resultSetSchema;
+    }
 
     /**
      * Parse Druid GroupBy result into ResultSet.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidResponseParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidResponseParser.java
@@ -41,9 +41,11 @@ public class DruidResponseParser {
 
     /**
      * Build the schema that should be expected for the specified query.
+     *
      * @param druidQuery The query
      * @param granularity The granularity for the schema
      * @param dateTimeZone The timezone for the schema
+     *
      * @return The schema for the query
      */
     public ZonedSchema buildSchema(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -13,8 +13,8 @@ public enum ErrorMessageFormat implements MessageFormatter {
     TABLE_ALIGNMENT_UNDEFINED("Table '%s' cannot be aligned to a request with intervals: %s."),
     TABLE_SCHEMA_UNDEFINED(
             "Table '%s' is incompatible with the dimensions '%s', metrics '%s' and granularity '%s' requested.",
-            "No PhysicalTable with the availability-based dimensions '%s', metrics '%s', and granularity '%s' found " +
-                    "for Logical Table '%s'"
+            "No PhysicalTable for Logical Table '%s' with the availability-based dimensions '%s', " +
+                            "metrics '%s', and granularity '%s' found "
     ),
 
     EMPTY_DICTIONARY("%s Dictionary is empty."),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessor.java
@@ -10,20 +10,14 @@ import com.yahoo.bard.webservice.application.ObjectMappersSuite;
 import com.yahoo.bard.webservice.data.DruidResponseParser;
 import com.yahoo.bard.webservice.data.HttpResponseMaker;
 import com.yahoo.bard.webservice.data.ResultSet;
-import com.yahoo.bard.webservice.data.dimension.Dimension;
-import com.yahoo.bard.webservice.data.dimension.DimensionColumn;
 import com.yahoo.bard.webservice.data.dimension.DimensionField;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
-import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.druid.client.FailureCallback;
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
-import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
-import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.async.ResponseException;
 import com.yahoo.bard.webservice.logging.RequestLog;
-import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.ZonedSchema;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.PageNotFoundException;
@@ -31,7 +25,6 @@ import com.yahoo.bard.webservice.web.PreResponse;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,7 +87,10 @@ public class ResultSetResponseProcessor extends MappingResponseProcessor impleme
     public void processResponse(JsonNode json, DruidAggregationQuery<?> druidQuery, LoggingContext metadata) {
         try {
             RequestLog.restore(metadata.getRequestLog());
-            ResultSet resultSet = buildResultSet(json, druidQuery, apiRequest.getTimeZone());
+            ZonedSchema resultSetSchema = druidResponseParser.buildSchema(
+                            druidQuery, granularity, apiRequest.getTimeZone());
+            ResultSet resultSet =  druidResponseParser.parse(json, resultSetSchema, druidQuery.getQueryType());
+
             resultSet = mapResultSet(resultSet);
 
             LinkedHashSet<String> apiMetricColumnNames = apiRequest.getLogicalMetrics().stream()
@@ -133,35 +129,5 @@ public class ResultSetResponseProcessor extends MappingResponseProcessor impleme
                     getObjectMappers().getMapper().writer()
             ));
         }
-    }
-
-    /**
-     * Build a result set using the api request time grain.
-     *
-     * @param json  The json representing the druid response.
-     * @param druidQuery  The druid query being processed
-     * @param dateTimeZone  The date time zone for parsing result rows
-     *
-     * @return The initial result set from the json node.
-     */
-    public ResultSet buildResultSet(JsonNode json, DruidAggregationQuery<?> druidQuery, DateTimeZone dateTimeZone) {
-        ZonedSchema resultSetSchema = new ZonedSchema(granularity, dateTimeZone);
-
-        // TODO: There are plans to clean this up rather than using iterator().next()
-        PhysicalTable physicalTable = druidQuery.getDataSource().getPhysicalTables().iterator().next();
-
-        for (Aggregation aggregation : druidQuery.getAggregations()) {
-            MetricColumn.addNewMetricColumn(resultSetSchema, aggregation.getName());
-        }
-
-        for (PostAggregation postAggregation : druidQuery.getPostAggregations()) {
-            MetricColumn.addNewMetricColumn(resultSetSchema, postAggregation.getName());
-        }
-
-        for (Dimension dimension : druidQuery.getDimensions()) {
-            DimensionColumn.addNewDimensionColumn(resultSetSchema, dimension);
-        }
-
-        return druidResponseParser.parse(json, resultSetSchema, druidQuery.getQueryType());
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
@@ -157,7 +157,7 @@ class ResultSetResponseProcessorSpec extends Specification {
         Schema captureSchema = null
         JsonNode captureJson = null
         ResultSet actual = null
-        ZonedSchema z
+        ZonedSchema zonedSchema
         ResultSetResponseProcessor resultSetResponseProcessor = new ResultSetResponseProcessor(
                 apiRequest,
                 responseEmitter,
@@ -167,9 +167,8 @@ class ResultSetResponseProcessorSpec extends Specification {
         ) {
             @Override
             protected ResultSet mapResultSet(ResultSet resultSet) { 
-                actual = resultSet; 
-                resultSet.getSchema(); 
-                return resultSet 
+                actual = resultSet
+                resultSet
             }
         }
 
@@ -182,26 +181,26 @@ class ResultSetResponseProcessorSpec extends Specification {
 
         then:
         1 * druidResponseParser.buildSchema(_, _, _) >> { DruidAggregationQuery<?> q, Granularity g, DateTimeZone tz -> 
-            z = new ZonedSchema(g, tz)
+            zonedSchema = new ZonedSchema(g, tz)
             for (Aggregation aggregation : q.getAggregations()) {
-                MetricColumn.addNewMetricColumn(z, aggregation.getName())
+                MetricColumn.addNewMetricColumn(zonedSchema, aggregation.getName())
             }
     
             for (PostAggregation postAggregation : q.getPostAggregations()) {
-                MetricColumn.addNewMetricColumn(z, postAggregation.getName())
+                MetricColumn.addNewMetricColumn(zonedSchema, postAggregation.getName())
             }
     
             for (Dimension dimension : q.getDimensions()) {
-                DimensionColumn.addNewDimensionColumn(z, dimension)
+                DimensionColumn.addNewDimensionColumn(zonedSchema, dimension)
             }
-            z
+            zonedSchema
         }
         1 * druidResponseParser.parse(_,_,_) >> { JsonNode json, Schema schema, DefaultQueryType type -> 
             captureSchema = schema
             captureJson = json
             resultSetMock
         }
-        2 * resultSetMock.getSchema() >> { z }
+        1 * resultSetMock.getSchema() >> { zonedSchema }
         captureSchema.granularity == DAY
         captureSchema.getColumn("dimension1").dimension == d1
         captureSchema.getColumn("agg1") != null

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/models/druid/client/impl/TestDruidWebService.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/models/druid/client/impl/TestDruidWebService.java
@@ -115,26 +115,27 @@ public class TestDruidWebService implements DruidWebService {
         }
 
         // Set the response to use based on the type of the query we're processing
-        if (!(lastQuery.getQueryType() instanceof DefaultQueryType)) {
-            throw new IllegalArgumentException("Illegal query type : " + lastQuery.getQueryType());
-        }
-
-        DefaultQueryType defaultQueryType = (DefaultQueryType) lastQuery.getQueryType();
-        switch (defaultQueryType) {
-            case GROUP_BY:
-            case TOP_N:
-            case TIMESERIES:
-            case LOOKBACK:
-                // default response is groupBy response
-                break;
-            case SEGMENT_METADATA:
-                jsonResponse = () -> segmentMetadataResponse;
-                break;
-            case TIME_BOUNDARY:
-                jsonResponse = () -> timeBoundaryResponse;
-                break;
-            default:
-                throw new IllegalArgumentException("Illegal query type : " + lastQuery.getQueryType());
+        if (lastQuery.getQueryType() instanceof DefaultQueryType) {
+            DefaultQueryType defaultQueryType = (DefaultQueryType) lastQuery.getQueryType();
+            switch (defaultQueryType) {
+                case GROUP_BY:
+                case TOP_N:
+                case TIMESERIES:
+                case LOOKBACK:
+                    // default response is groupBy response
+                    break;
+                case SEGMENT_METADATA:
+                    jsonResponse = () -> segmentMetadataResponse;
+                    break;
+                case TIME_BOUNDARY:
+                    jsonResponse = () -> timeBoundaryResponse;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Illegal query type : " + lastQuery.getQueryType());
+            }
+        } else {
+            // not a default query type. Assume the response is the default groupBy response
+            // initialized above. Don't need to do anything else here.
         }
 
         try {


### PR DESCRIPTION
Solving a couple of problems that prevented extending query types in fili-based project
- TestDruidWebService hard coded the set of supported query types based on the DefaultQueryType enum even though other implementations of the QueryType interface are allowed.
- Moving Schema creation from ResultSetResponseProcessor down to DruidResponseParser to allow subclasses to modify the schema 
- Fixing a minor error message when no physical table is found for a schema