### PR TITLE
Fix to prevent NPE when attempting to bind segment file columns not c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ Current
 
 ### Fixed:
 
-- [Fixed Segment Metadata Loader Unconfigured Dimension Bug]()
+- [Fixed Segment Metadata Loader Unconfigured Dimension Bug](https://github.com/yahoo/fili/pull/197)
     * Immutable availability was failing when attempting to bind segment dimension columns not configured in dimension dictionary.
     * Fix to filter irrelevant column names. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ Current
 
 ### Fixed:
 
+- [Fixed Segment Metadata Loader Unconfigured Dimension Bug]()
+    * Immutable availability was failing when attempting to bind segment dimension columns not configured in dimension dictionary.
+    * Fix to filter irrelevant column names. 
+
 - [Major refactor for availability and schemas and tables](https://github.com/yahoo/fili/pull/165)
     * Ordering of fields on serialization could be inconsistent if intermediate stages used `HashSet` or `HashMap`.
     * Several constructors switched to accept `Iterable` and return `LinkedHashSet` to emphasize importance of ordering/prevent `HashSet` intermediates which disrupt ordering.

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ImmutableAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ImmutableAvailabilitySpec.groovy
@@ -32,7 +32,7 @@ class ImmutableAvailabilitySpec extends Specification {
         Map<String, List<Interval>> segmentMetricData = [:]
 
         expect: "segment availability is passed to be bound to dimension and metric columns"
-        (ImmutableAvailability.buildAvailabilityMap(segmentDimensionData, segmentMetricData, dictionary)).size() == 0
+        ImmutableAvailability.buildAvailabilityMap("testTable", segmentDimensionData, segmentMetricData, dictionary).size() == 0
     }
 
     def "Availability loads and binds dimension and metric columns from String maps"() {
@@ -45,7 +45,7 @@ class ImmutableAvailabilitySpec extends Specification {
         List<MetricColumn> metricColumns = segmentMetricData.collect { new MetricColumn(it.getKey())}
 
         when: "segment availability is passed to be bound to dimension and metric columns"
-        Map<Column, List<Interval>> result = ImmutableAvailability.buildAvailabilityMap(segmentDimensionData, segmentMetricData, dictionary)
+        Map<Column, List<Interval>> result = ImmutableAvailability.buildAvailabilityMap("testTable", segmentDimensionData, segmentMetricData, dictionary)
 
         then: "all configured dimension columns and all metric columns now have associated availability"
         columns.every() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ImmutableAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ImmutableAvailabilitySpec.groovy
@@ -1,0 +1,58 @@
+package com.yahoo.bard.webservice.table.availability
+
+import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.data.dimension.DimensionColumn
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
+import com.yahoo.bard.webservice.data.metric.MetricColumn
+import com.yahoo.bard.webservice.table.Column
+
+import org.joda.time.DateTime
+import org.joda.time.Interval
+import org.joda.time.Period
+
+import spock.lang.Specification
+
+class ImmutableAvailabilitySpec extends Specification {
+
+    List<Interval> lastYear = [new Interval(new DateTime("2015"), new Period("P1Y"))]
+
+    Dimension dimension1 = Mock(Dimension) {
+        getApiName() >> "d1"
+    }
+    Dimension dimension2 = Mock(Dimension) {
+        getApiName() >> "d2"
+    }
+
+    Set<Dimension> dimensions = [dimension1, dimension2] as Set
+    DimensionDictionary dictionary = new DimensionDictionary(dimensions)
+
+    def "Empty segment data does not create an error"() {
+        setup:
+        Map<String, List<Interval>> segmentDimensionData = [:]
+        Map<String, List<Interval>> segmentMetricData = [:]
+
+        expect: "segment availability is passed to be bound to dimension and metric columns"
+        (ImmutableAvailability.buildAvailabilityMap(segmentDimensionData, segmentMetricData, dictionary)).size() == 0
+    }
+
+    def "Availability loads and binds dimension and metric columns from String maps"() {
+        setup: "Two configured dimensions are defined"
+        List<Column> columns = dimensions.collect {new DimensionColumn(it)}
+
+        and: "Segment metadata produces some configured and some unconfigured dimension names"
+        Map<String, List<Interval>> segmentDimensionData = ["d1": lastYear, "d2": lastYear, "bad": lastYear]
+        Map<String, List<Interval>> segmentMetricData = ["m1": lastYear, "m2": lastYear]
+        List<MetricColumn> metricColumns = segmentMetricData.collect { new MetricColumn(it.getKey())}
+
+        when: "segment availability is passed to be bound to dimension and metric columns"
+        Map<Column, List<Interval>> result = ImmutableAvailability.buildAvailabilityMap(segmentDimensionData, segmentMetricData, dictionary)
+
+        then: "all configured dimension columns and all metric columns now have associated availability"
+        columns.every() {
+            result.get(it) == lastYear
+        }
+        metricColumns.every() {
+            result.get(it) == lastYear
+        }
+    }
+}


### PR DESCRIPTION
…onfigured in the dimension dictionary.

(Columns in segment files don't all need to be configured, unused columns should be skipped)
Also, warn if NO columns are resolved.