### PR TITLE
Added 'isValidFor' that takes a Logical Metric to the ApiMetricName i…

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/ApiMetricName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/ApiMetricName.java
@@ -36,7 +36,7 @@ public interface ApiMetricName extends FieldName {
      * This version only takes the time grain into account.  The default implementation simply sets a required minimum
      * grain for the metric.
      * <p>
-     * An example of this is a DailyAverage metric than doesn't make sense to query by the HOUR grain, but does at WEEK.
+     * An example of this is a DailyAverage metric that doesn't make sense to query by the HOUR grain, but does at WEEK.
      *
      * @param granularity  TimeGrain to determine validity for
      *
@@ -56,14 +56,14 @@ public interface ApiMetricName extends FieldName {
      * LogicalTable instances at configuration time.  This version allows the logical metric itself to be used for
      * filtering.
      * <p>
-     * An example of this is a DailyAverage metric than doesn't make sense to query by the HOUR grain, but does at WEEK.
+     * An example of this is a DailyAverage metric that doesn't make sense to query by the HOUR grain, but does at WEEK.
      *
-     * @param logicalMetric  The metric whose validity is being tested.
      * @param granularity  TimeGrain to determine validity for
+     * @param logicalMetric  The metric whose validity is being tested.
      *
      * @return True if the ApiMetricName is valid for the time grain
      */
-    default boolean isValidFor(LogicalMetric logicalMetric, Granularity granularity) {
+    default boolean isValidFor(Granularity granularity, LogicalMetric logicalMetric) {
         return isValidFor(granularity);
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/ApiMetricName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/ApiMetricName.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.names;
 
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.time.TimeGrain;
 import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
@@ -29,6 +30,11 @@ public interface ApiMetricName extends FieldName {
 
     /**
      * Determine if this API Metric Name is valid for the given time grain.
+     * This capability is provided as a convenience for configurers to filter metrics from a TableGroup onto a set of
+     * LogicalTable instances at configuration time.
+     * <p>
+     * This version only takes the time grain into account.  The default implementation simply sets a required minimum
+     * grain for the metric.
      * <p>
      * An example of this is a DailyAverage metric than doesn't make sense to query by the HOUR grain, but does at WEEK.
      *
@@ -42,6 +48,23 @@ public interface ApiMetricName extends FieldName {
         } else {
             return granularity instanceof AllGranularity;
         }
+    }
+
+    /**
+     * Determine if this API Metric Name is valid for the given time grain.
+     * This capability is provided as a convenience for configurers to filter metrics from a TableGroup onto a set of
+     * LogicalTable instances at configuration time.  This version allows the logical metric itself to be used for
+     * filtering.
+     * <p>
+     * An example of this is a DailyAverage metric than doesn't make sense to query by the HOUR grain, but does at WEEK.
+     *
+     * @param logicalMetric  The metric whose validity is being tested.
+     * @param granularity  TimeGrain to determine validity for
+     *
+     * @return True if the ApiMetricName is valid for the time grain
+     */
+    default boolean isValidFor(LogicalMetric logicalMetric, Granularity granularity) {
+        return isValidFor(granularity);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/LogicalTableSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/LogicalTableSchema.java
@@ -5,14 +5,11 @@ package com.yahoo.bard.webservice.table;
 import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.dimension.DimensionColumn;
 import com.yahoo.bard.webservice.data.metric.LogicalMetricColumn;
-import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -48,7 +45,7 @@ public class LogicalTableSchema extends BaseSchema {
     ) {
         return Stream.concat(
                 tableGroup.getDimensions().stream()
-                .map(DimensionColumn::new),
+                        .map(DimensionColumn::new),
                 buildMetricColumns(tableGroup.getApiMetricNames(), granularity, metricDictionary)
         ).collect(Collectors.toCollection(LinkedHashSet::new));
     }
@@ -63,16 +60,15 @@ public class LogicalTableSchema extends BaseSchema {
      *
      * @return A stream of metric columns, filtered for compatibility with the grain.
      */
-    private static Stream<MetricColumn> buildMetricColumns(
+    private static Stream<LogicalMetricColumn> buildMetricColumns(
             Collection<ApiMetricName> apiMetricNames,
             Granularity granularity,
             MetricDictionary metricDictionary
     ) {
         return apiMetricNames.stream()
-                .collect(Collectors.toMap(Function.identity(), entry -> metricDictionary.get(entry.getApiName())))
-                .entrySet().stream()
-                .filter(entry -> entry.getKey().isValidFor(entry.getValue(), granularity))
-                .map(Map.Entry::getValue)
+                .filter(name -> name.isValidFor(granularity, metricDictionary.get(name.asName())))
+                .map(ApiMetricName::asName)
+                .map(metricDictionary::get)
                 .map(LogicalMetricColumn::new);
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/LogicalTableSchemaSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/LogicalTableSchemaSpec.groovy
@@ -1,0 +1,39 @@
+package com.yahoo.bard.webservice.table
+
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
+import com.yahoo.bard.webservice.data.metric.LogicalMetric
+import com.yahoo.bard.webservice.data.metric.LogicalMetricColumn
+import com.yahoo.bard.webservice.data.metric.MetricDictionary
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
+
+import spock.lang.Specification
+
+class LogicalTableSchemaSpec extends Specification {
+
+    def "Build metric called the apiMetricName is Valid and filters metrics as indicated" () {
+        String metricName1 = "name1"
+        String metricName2 = "name2"
+
+        LogicalMetric logicalMetric1 = Mock(LogicalMetric)
+        LogicalMetric logicalMetric2 = Mock(LogicalMetric)
+
+        ApiMetricName apiName1 = Mock(ApiMetricName) {
+            getApiName() >> metricName1
+        }
+        ApiMetricName apiName2 = Mock(ApiMetricName) {
+            getApiName() >> metricName2
+        }
+        1 * apiName1.isValidFor(logicalMetric1, _) >> true
+        1 * apiName2.isValidFor(logicalMetric2, _) >> false
+        0 * apiName1.isValidFor(_)
+        0 * apiName2.isValidFor(_)
+
+        List<LogicalMetricColumn> columns = [new LogicalMetricColumn(logicalMetric1)]
+        MetricDictionary metricDictionary = new MetricDictionary()
+        metricDictionary.put(metricName1, logicalMetric1)
+        metricDictionary.put(metricName2, logicalMetric2)
+
+        expect:
+        LogicalTableSchema.buildMetricColumns([apiName1, apiName2], DefaultTimeGrain.DAY, metricDictionary).collect() {it} == columns
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/LogicalTableSchemaSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/LogicalTableSchemaSpec.groovy
@@ -11,29 +11,35 @@ import spock.lang.Specification
 class LogicalTableSchemaSpec extends Specification {
 
     def "Build metric called the apiMetricName is Valid and filters metrics as indicated" () {
-        String metricName1 = "name1"
-        String metricName2 = "name2"
+        String metricNameGood = "nameGood"
+        String metricNameBad = "nameBad"
 
-        LogicalMetric logicalMetric1 = Mock(LogicalMetric)
-        LogicalMetric logicalMetric2 = Mock(LogicalMetric)
-
-        ApiMetricName apiName1 = Mock(ApiMetricName) {
-            getApiName() >> metricName1
+        LogicalMetric logicalMetricGood = Mock(LogicalMetric) {
+            getName() >> metricNameGood
         }
-        ApiMetricName apiName2 = Mock(ApiMetricName) {
-            getApiName() >> metricName2
+        LogicalMetric logicalMetricBad = Mock(LogicalMetric) {
+            getName() >> metricNameBad
         }
-        1 * apiName1.isValidFor(logicalMetric1, _) >> true
-        1 * apiName2.isValidFor(logicalMetric2, _) >> false
-        0 * apiName1.isValidFor(_)
-        0 * apiName2.isValidFor(_)
 
-        List<LogicalMetricColumn> columns = [new LogicalMetricColumn(logicalMetric1)]
+        ApiMetricName apiNameGood = Mock(ApiMetricName) {
+            getApiName() >> metricNameGood
+            asName() >> metricNameGood
+        }
+        ApiMetricName apiNameBad = Mock(ApiMetricName) {
+            getApiName() >> metricNameBad
+            asName() >> metricNameBad
+        }
+        1 * apiNameGood.isValidFor(_, logicalMetricGood) >> true
+        1 * apiNameBad.isValidFor(_, logicalMetricBad) >> false
+        0 * apiNameGood.isValidFor(_)
+        0 * apiNameBad.isValidFor(_)
+
+        List<LogicalMetricColumn> columns = [new LogicalMetricColumn(logicalMetricGood)]
         MetricDictionary metricDictionary = new MetricDictionary()
-        metricDictionary.put(metricName1, logicalMetric1)
-        metricDictionary.put(metricName2, logicalMetric2)
+        metricDictionary.put(metricNameGood, logicalMetricGood)
+        metricDictionary.put(metricNameBad, logicalMetricBad)
 
         expect:
-        LogicalTableSchema.buildMetricColumns([apiName1, apiName2], DefaultTimeGrain.DAY, metricDictionary).collect() {it} == columns
+        LogicalTableSchema.buildMetricColumns([apiNameGood, apiNameBad], DefaultTimeGrain.DAY, metricDictionary).collect() {it} == columns
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
@@ -191,9 +191,6 @@ class SketchIntersectionReportingResources extends Specification {
     }
 
     ApiMetricName buildMockName(String name) {
-        Stub(ApiMetricName) {
-            getApiName() >> name
-            isValidFor(_, _) >> true
-        }
+        return ApiMetricName.of(name)
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
@@ -193,7 +193,7 @@ class SketchIntersectionReportingResources extends Specification {
     ApiMetricName buildMockName(String name) {
         Stub(ApiMetricName) {
             getApiName() >> name
-            isValidFor(_) >> true
+            isValidFor(_, _) >> true
         }
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingSpec.groovy
@@ -193,7 +193,7 @@ class SketchIntersectionReportingSpec extends Specification {
         LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
 
         when:
-        new DataApiRequest().validateMetrics(logicalMetrics,resources.table)
+        new DataApiRequest().validateMetrics(logicalMetrics, resources.table)
 
         then:
         noExceptionThrown()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
@@ -192,7 +192,7 @@ class ThetaSketchIntersectionReportingResources extends Specification {
     ApiMetricName buildMockName(String name) {
         Stub(ApiMetricName) {
             getApiName() >> name
-            isValidFor(_) >> true
+            isValidFor(_, _) >> true
         }
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
@@ -190,9 +190,6 @@ class ThetaSketchIntersectionReportingResources extends Specification {
     }
 
     ApiMetricName buildMockName(String name) {
-        Stub(ApiMetricName) {
-            getApiName() >> name
-            isValidFor(_, _) >> true
-        }
+        return ApiMetricName.of(name)
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingSpec.groovy
@@ -176,7 +176,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
         LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("regFoos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
 
         when:
-        new DataApiRequest().validateMetrics(logicalMetrics,resources.table)
+        new DataApiRequest().validateMetrics(logicalMetrics, resources.table)
 
         then:
         String expectedMessage = "Requested metric(s) '[regFoos]' are not supported by the table 'NETWORK'."
@@ -189,7 +189,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
         LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
 
         when:
-        new DataApiRequest().validateMetrics(logicalMetrics,resources.table)
+        new DataApiRequest().validateMetrics(logicalMetrics, resources.table)
 
         then:
         noExceptionThrown()

--- a/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/application/ConfigurationLoaderSpec.groovy
+++ b/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/application/ConfigurationLoaderSpec.groovy
@@ -57,9 +57,9 @@ class ConfigurationLoaderSpec extends Specification {
 
     def "test table keys"() {
         setup:
-        TableIdentifier ti1 = new TableIdentifier( "table", DAY )
-        TableIdentifier ti2 = new TableIdentifier( "table", DAY )
-        TableIdentifier ti3 = new TableIdentifier( "table", HOUR )
+        TableIdentifier ti1 = new TableIdentifier("table", DAY)
+        TableIdentifier ti2 = new TableIdentifier("table", DAY)
+        TableIdentifier ti3 = new TableIdentifier("table", HOUR)
 
         expect:
         ti1 == ti2


### PR DESCRIPTION
…nterface.  Move LogicalTableSchema to use that to filter metrics instead of the granularity only one.