### PR TITLE
More substantive api metric name change

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/AggregationAverageMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/AggregationAverageMaker.java
@@ -83,7 +83,7 @@ public class AggregationAverageMaker extends MetricMaker {
         TemplateDruidQuery innerQuery = buildInnerQuery(sourceMetric, dependentMetric.getTemplateDruidQuery());
         TemplateDruidQuery outerQuery = buildOuterQuery(metricName.asName(), sourceMetric, innerQuery);
 
-        return new LogicalMetric(outerQuery, NO_OP_MAPPER, metricName.asName());
+        return new LogicalMetric(outerQuery, NO_OP_MAPPER, metricName.asName(), metricName::isValidFor);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/AggregationAverageMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/AggregationAverageMaker.java
@@ -6,6 +6,7 @@ import static com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPo
         .ArithmeticPostAggregationFunction.DIVIDE;
 import static com.yahoo.bard.webservice.druid.util.FieldConverterSupplier.sketchConverter;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
@@ -71,7 +72,7 @@ public class AggregationAverageMaker extends MetricMaker {
     }
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
         // Get the Metric that is being averaged over
         LogicalMetric dependentMetric = metrics.get(dependentMetrics.get(0));
 
@@ -80,9 +81,9 @@ public class AggregationAverageMaker extends MetricMaker {
 
         // Build the TemplateDruidQuery for the metric
         TemplateDruidQuery innerQuery = buildInnerQuery(sourceMetric, dependentMetric.getTemplateDruidQuery());
-        TemplateDruidQuery outerQuery = buildOuterQuery(metricName, sourceMetric, innerQuery);
+        TemplateDruidQuery outerQuery = buildOuterQuery(metricName.asName(), sourceMetric, innerQuery);
 
-        return new LogicalMetric(outerQuery, NO_OP_MAPPER, metricName);
+        return new LogicalMetric(outerQuery, NO_OP_MAPPER, metricName.asName());
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ArithmeticMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ArithmeticMaker.java
@@ -106,7 +106,12 @@ public class ArithmeticMaker extends MetricMaker {
         ));
 
         TemplateDruidQuery query = getMergedQuery(dependentMetrics).withPostAggregations(postAggregations);
-        return new LogicalMetric(query, resultSetMapperSupplier.apply(metricName.asName()), metricName.asName());
+        return new LogicalMetric(
+                query,
+                resultSetMapperSupplier.apply(metricName.asName()),
+                metricName.asName(),
+                metricName::isValidFor
+        );
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ArithmeticMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ArithmeticMaker.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
@@ -89,7 +90,7 @@ public class ArithmeticMaker extends MetricMaker {
     }
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
         // Get the ArithmeticPostAggregation operands from the dependent metrics
         List<PostAggregation> operands = dependentMetrics.stream()
                 .map(metrics::get)
@@ -99,13 +100,13 @@ public class ArithmeticMaker extends MetricMaker {
 
         // Create the ArithmeticPostAggregation
         Set<PostAggregation> postAggregations = Collections.singleton(new ArithmeticPostAggregation(
-                metricName,
+                metricName.asName(),
                 function,
                 operands
         ));
 
         TemplateDruidQuery query = getMergedQuery(dependentMetrics).withPostAggregations(postAggregations);
-        return new LogicalMetric(query, resultSetMapperSupplier.apply(metricName), metricName);
+        return new LogicalMetric(query, resultSetMapperSupplier.apply(metricName.asName()), metricName.asName());
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/CardinalityMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/CardinalityMaker.java
@@ -81,7 +81,8 @@ public class CardinalityMaker extends MetricMaker {
         return new LogicalMetric(
                 new TemplateDruidQuery(aggs, Collections.emptySet()),
                 NO_OP_MAPPER,
-                metricName.asName()
+                metricName.asName(),
+                metricName::isValidFor
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/CardinalityMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/CardinalityMaker.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
@@ -66,14 +67,22 @@ public class CardinalityMaker extends MetricMaker {
     }
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentDimensions) {
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentDimensions) {
         Set<Dimension> dimensions = dependentDimensions.stream()
                 .map(dimensionDictionary::findByApiName)
                 .collect(Collectors.toSet());
 
-        Set<Aggregation> aggs = Collections.singleton(new CardinalityAggregation(metricName, dimensions, byRow));
+        Set<Aggregation> aggs = Collections.singleton(new CardinalityAggregation(
+                metricName.asName(),
+                dimensions,
+                byRow
+        ));
 
-        return new LogicalMetric(new TemplateDruidQuery(aggs, Collections.emptySet()), NO_OP_MAPPER, metricName);
+        return new LogicalMetric(
+                new TemplateDruidQuery(aggs, Collections.emptySet()),
+                NO_OP_MAPPER,
+                metricName.asName()
+        );
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMaker.java
@@ -53,7 +53,8 @@ public class ConstantMaker extends MetricMaker {
             return new LogicalMetric(
                     new TemplateDruidQuery(Collections.emptySet(), postAggregations),
                     NO_OP_MAPPER,
-                    metricName.asName()
+                    metricName.asName(),
+                    (ignored) -> true
             );
         } catch (NumberFormatException nfe) {
             String message = String.format(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMaker.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
@@ -33,26 +34,26 @@ public class ConstantMaker extends MetricMaker {
     }
 
     @Override
-    public LogicalMetric make(String metricName, List<String> dependentMetrics) {
+    public LogicalMetric make(ApiMetricName metricName, List<String> dependentMetrics) {
         // Check that we have the right number of metrics
-        assertRequiredDependentMetricCount(metricName, dependentMetrics);
+        assertRequiredDependentMetricCount(metricName.asName(), dependentMetrics);
 
         // Actually build the metric.
         return makeInner(metricName, dependentMetrics);
     }
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
         try {
             Set<PostAggregation> postAggregations = Collections.singleton(new ConstantPostAggregation(
-                    metricName,
+                    metricName.asName(),
                     new Double(dependentMetrics.get(0))
             ));
 
             return new LogicalMetric(
                     new TemplateDruidQuery(Collections.emptySet(), postAggregations),
                     NO_OP_MAPPER,
-                    metricName
+                    metricName.asName()
             );
         } catch (NumberFormatException nfe) {
             String message = String.format(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/CountMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/CountMaker.java
@@ -34,7 +34,7 @@ public class CountMaker extends MetricMaker {
                 Collections.emptySet()
         );
 
-        return new LogicalMetric(query, NO_OP_MAPPER, metricName.asName());
+        return new LogicalMetric(query, NO_OP_MAPPER, metricName.asName(), (ignored) -> true);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/CountMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/CountMaker.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
@@ -27,13 +28,13 @@ public class CountMaker extends MetricMaker {
     }
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
         TemplateDruidQuery query = new TemplateDruidQuery(
-                Collections.singleton(new CountAggregation(metricName)),
+                Collections.singleton(new CountAggregation(metricName.asName())),
                 Collections.emptySet()
         );
 
-        return new LogicalMetric(query, NO_OP_MAPPER, metricName);
+        return new LogicalMetric(query, NO_OP_MAPPER, metricName.asName());
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMaker.java
@@ -3,6 +3,7 @@
 
 package com.yahoo.bard.webservice.data.config.metric.makers;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
@@ -51,13 +52,13 @@ public class FilteredAggregationMaker extends MetricMaker {
     }
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
         LogicalMetric sourceMetric = metricDictionary.get(dependentMetrics.get(0));
 
         Aggregation sourceAggregation = assertDependentIsAggregationMetric(sourceMetric);
 
         FilteredAggregation filteredAggregation = new FilteredAggregation(
-                metricName,
+                metricName.asName(),
                 sourceAggregation,
                 filter
         );
@@ -69,7 +70,7 @@ public class FilteredAggregationMaker extends MetricMaker {
                         sourceMetric.getTemplateDruidQuery().getInnerQuery()
                 ),
                 sourceMetric.getCalculation(),
-                metricName
+                metricName.asName()
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMaker.java
@@ -70,7 +70,8 @@ public class FilteredAggregationMaker extends MetricMaker {
                         sourceMetric.getTemplateDruidQuery().getInnerQuery()
                 ),
                 sourceMetric.getCalculation(),
-                metricName.asName()
+                metricName.asName(),
+                metricName::isValidFor
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RawAggregationMetricMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RawAggregationMetricMaker.java
@@ -54,7 +54,8 @@ public abstract class RawAggregationMetricMaker extends MetricMaker {
         return new LogicalMetric(
                 new TemplateDruidQuery(Collections.singleton(aggregation), Collections.emptySet()),
                 getResultSetMapper(metricName.asName()),
-                metricName.asName()
+                metricName.asName(),
+                metricName::isValidFor
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RawAggregationMetricMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RawAggregationMetricMaker.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
@@ -48,12 +49,12 @@ public abstract class RawAggregationMetricMaker extends MetricMaker {
 
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
-        Aggregation aggregation = aggregationFactory.apply(metricName, dependentMetrics.get(0));
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
+        Aggregation aggregation = aggregationFactory.apply(metricName.asName(), dependentMetrics.get(0));
         return new LogicalMetric(
                 new TemplateDruidQuery(Collections.singleton(aggregation), Collections.emptySet()),
-                getResultSetMapper(metricName),
-                metricName
+                getResultSetMapper(metricName.asName()),
+                metricName.asName()
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMaker.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.metric.mappers.RowNumMapper;
@@ -27,11 +28,11 @@ public class RowNumMaker extends MetricMaker {
     }
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
         return new LogicalMetric(
                 null,
                 ROW_NUM_MAPPER,
-                metricName,
+                metricName.asName(),
                 "Generator for Row Numbers"
         );
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMaker.java
@@ -33,7 +33,8 @@ public class RowNumMaker extends MetricMaker {
                 null,
                 ROW_NUM_MAPPER,
                 metricName.asName(),
-                "Generator for Row Numbers"
+                "Generator for Row Numbers",
+                metricName::isValidFor
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/SketchSetOperationMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/SketchSetOperationMaker.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
@@ -42,7 +43,7 @@ public class SketchSetOperationMaker extends MetricMaker {
     }
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
 
         TemplateDruidQuery mergedQuery = getMergedQuery(dependentMetrics);
 
@@ -53,12 +54,12 @@ public class SketchSetOperationMaker extends MetricMaker {
         // Create the SketchSetOperationPostAggregation
         SketchSetOperationPostAggregation setPostAggregation;
         setPostAggregation = new SketchSetOperationPostAggregation(
-                metricName,
+                metricName.asName(),
                 function,
                 Arrays.asList(operandOne, operandTwo)
         );
 
-        PostAggregation estimate = new SketchEstimatePostAggregation(metricName, setPostAggregation);
+        PostAggregation estimate = new SketchEstimatePostAggregation(metricName.asName(), setPostAggregation);
         Set<PostAggregation> postAggs = Collections.singleton(estimate);
 
         TemplateDruidQuery query = new TemplateDruidQuery(
@@ -68,7 +69,7 @@ public class SketchSetOperationMaker extends MetricMaker {
                 mergedQuery.getTimeGrain()
         );
 
-        return new LogicalMetric(query, new SketchRoundUpMapper(metricName), metricName);
+        return new LogicalMetric(query, new SketchRoundUpMapper(metricName.asName()), metricName.asName());
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/SketchSetOperationMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/SketchSetOperationMaker.java
@@ -69,7 +69,12 @@ public class SketchSetOperationMaker extends MetricMaker {
                 mergedQuery.getTimeGrain()
         );
 
-        return new LogicalMetric(query, new SketchRoundUpMapper(metricName.asName()), metricName.asName());
+        return new LogicalMetric(
+                query,
+                new SketchRoundUpMapper(metricName.asName()),
+                metricName.asName(),
+                metricName::isValidFor
+        );
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchSetOperationMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchSetOperationMaker.java
@@ -56,7 +56,12 @@ public class ThetaSketchSetOperationMaker extends MetricMaker {
 
         PostAggregation estimate = new ThetaSketchEstimatePostAggregation(metricName.asName(), setPostAggregation);
         TemplateDruidQuery query = mergedQuery.withPostAggregations(Collections.singleton(estimate));
-        return new LogicalMetric(query, new SketchRoundUpMapper(metricName.asName()), metricName.asName());
+        return new LogicalMetric(
+                query,
+                new SketchRoundUpMapper(metricName.asName()),
+                metricName.asName(),
+                metricName::isValidFor
+        );
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchSetOperationMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchSetOperationMaker.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers;
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
@@ -37,7 +38,7 @@ public class ThetaSketchSetOperationMaker extends MetricMaker {
     }
 
     @Override
-    protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+    protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
 
         TemplateDruidQuery mergedQuery = getMergedQuery(dependentMetrics);
 
@@ -48,14 +49,14 @@ public class ThetaSketchSetOperationMaker extends MetricMaker {
 
         // Create the ThetaSketchSetOperationPostAggregation
         ThetaSketchSetOperationPostAggregation setPostAggregation = new ThetaSketchSetOperationPostAggregation(
-                metricName,
+                metricName.asName(),
                 function,
                 sketchPostAggregations
         );
 
-        PostAggregation estimate = new ThetaSketchEstimatePostAggregation(metricName, setPostAggregation);
+        PostAggregation estimate = new ThetaSketchEstimatePostAggregation(metricName.asName(), setPostAggregation);
         TemplateDruidQuery query = mergedQuery.withPostAggregations(Collections.singleton(estimate));
-        return new LogicalMetric(query, new SketchRoundUpMapper(metricName), metricName);
+        return new LogicalMetric(query, new SketchRoundUpMapper(metricName.asName()), metricName.asName());
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/LogicalMetric.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/LogicalMetric.java
@@ -4,8 +4,10 @@ package com.yahoo.bard.webservice.data.metric;
 
 import com.yahoo.bard.webservice.data.metric.mappers.ResultSetMapper;
 import com.yahoo.bard.webservice.druid.model.MetricField;
+import com.yahoo.bard.webservice.druid.model.query.Granularity;
 
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * A LogicalMetric is a set of its TemplateQueries, Mapper, and its name.
@@ -21,6 +23,8 @@ public class LogicalMetric {
     private final String category;
     private final String description;
 
+    private final Predicate<Granularity> isValidFor;
+
     /**
      * Build a fully specified Logical Metric.
      *
@@ -30,7 +34,39 @@ public class LogicalMetric {
      * @param longName Long name of the metric
      * @param category  Category of the metric
      * @param description  Description of the metric
+     * @param isValidFor  A predicate defining which granularities this metric is valid for
      */
+    public LogicalMetric(
+            TemplateDruidQuery templateDruidQuery,
+            ResultSetMapper calculation,
+            String name,
+            String longName,
+            String category,
+            String description,
+            Predicate<Granularity> isValidFor
+    ) {
+        this.calculation = calculation;
+        this.name = name;
+        this.longName = longName;
+        this.category = category;
+        this.description = description;
+        this.query = templateDruidQuery;
+        this.isValidFor = isValidFor;
+    }
+
+    /**
+     * Build a fully specified Logical Metric.
+     *
+     * @param templateDruidQuery  Query the metric needs
+     * @param calculation  Mapper for the metric
+     * @param name  Name of the metric
+     * @param longName Long name of the metric
+     * @param category  Category of the metric
+     * @param description  Description of the metric
+     *
+     * @deprecated use explicit Predicates for validity checks
+     */
+    @Deprecated
     public LogicalMetric(
             TemplateDruidQuery templateDruidQuery,
             ResultSetMapper calculation,
@@ -39,12 +75,29 @@ public class LogicalMetric {
             String category,
             String description
     ) {
-        this.calculation = calculation;
-        this.name = name;
-        this.longName = longName;
-        this.category = category;
-        this.description = description;
-        this.query = templateDruidQuery;
+        this(templateDruidQuery, calculation, name, longName, category, description, (Predicate<Granularity>) null);
+    }
+
+    /**
+     * Build a slightly more specified Logical Metric.
+     * <p>
+     * Note: The description is set to the same as the name.
+     *
+     * @param templateDruidQuery  Query the metric needs
+     * @param calculation  Mapper for the metric
+     * @param name  Name of the metric
+     * @param description  Description of the metric
+     * @param isValidFor  A predicate defining which granularities this metric is valid for
+     *
+     */
+    public LogicalMetric(
+            TemplateDruidQuery templateDruidQuery,
+            ResultSetMapper calculation,
+            String name,
+            String description,
+            Predicate<Granularity> isValidFor
+    ) {
+        this(templateDruidQuery, calculation, name, name, DEFAULT_CATEGORY, description, isValidFor);
     }
 
     /**
@@ -57,14 +110,16 @@ public class LogicalMetric {
      * @param name  Name of the metric
      * @param description  Description of the metric
      *
+     * @deprecated use explicit Predicates for validity checks
      */
+    @Deprecated
     public LogicalMetric(
             TemplateDruidQuery templateDruidQuery,
             ResultSetMapper calculation,
             String name,
             String description
     ) {
-        this(templateDruidQuery, calculation, name, name, DEFAULT_CATEGORY, description);
+        this(templateDruidQuery, calculation, name, name, DEFAULT_CATEGORY, description, (Predicate<Granularity>) null);
     }
 
     /**
@@ -75,9 +130,31 @@ public class LogicalMetric {
      * @param templateDruidQuery  Query the metric needs
      * @param calculation  Mapper for the metric
      * @param name  Name of the metric
+     * @param isValidFor  A predicate defining which granularities this metric is valid for
      */
+    public LogicalMetric(
+            TemplateDruidQuery templateDruidQuery,
+            ResultSetMapper calculation,
+            String name,
+            Predicate<Granularity> isValidFor
+    ) {
+        this(templateDruidQuery, calculation, name, name, DEFAULT_CATEGORY, name, isValidFor);
+    }
+
+    /**
+     * Build a partly specified Logical Metric.
+     * <p>
+     * Note: The description is set to the same as the name.
+     *
+     * @param templateDruidQuery  Query the metric needs
+     * @param calculation  Mapper for the metric
+     * @param name  Name of the metric
+     *
+     * @deprecated use explicit Predicates for validity checks
+     */
+    @Deprecated
     public LogicalMetric(TemplateDruidQuery templateDruidQuery, ResultSetMapper calculation, String name) {
-        this(templateDruidQuery, calculation, name, name, DEFAULT_CATEGORY, name);
+        this(templateDruidQuery, calculation, name, name, DEFAULT_CATEGORY, name, (Predicate<Granularity>) null);
     }
 
     public String getName() {
@@ -115,6 +192,10 @@ public class LogicalMetric {
 
     public String getLongName() {
         return longName;
+    }
+
+    public Predicate<Granularity> getIsValidFor() {
+        return isValidFor;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/LogicalTableSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/LogicalTableSchema.java
@@ -44,8 +44,7 @@ public class LogicalTableSchema extends BaseSchema {
             MetricDictionary metricDictionary
     ) {
         return Stream.concat(
-                tableGroup.getDimensions().stream()
-                        .map(DimensionColumn::new),
+                tableGroup.getDimensions().stream().map(DimensionColumn::new),
                 buildMetricColumns(tableGroup.getApiMetricNames(), granularity, metricDictionary)
         ).collect(Collectors.toCollection(LinkedHashSet::new));
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/FilteredSketchMetricsHelper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/FilteredSketchMetricsHelper.java
@@ -121,7 +121,12 @@ public class FilteredSketchMetricsHelper implements MetricsFilterSetBuilder {
             );
         }
         //build new LogicalMetric and return
-        return new LogicalMetric(templateDruidQuery, logicalMetric.getCalculation(), logicalMetric.getName());
+        return new LogicalMetric(
+                templateDruidQuery,
+                logicalMetric.getCalculation(),
+                logicalMetric.getName(),
+                logicalMetric.getIsValidFor()
+        );
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/FilteredThetaSketchMetricsHelper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/FilteredThetaSketchMetricsHelper.java
@@ -118,7 +118,12 @@ public class FilteredThetaSketchMetricsHelper implements MetricsFilterSetBuilder
             );
         }
         //build new LogicalMetric and return
-        return new LogicalMetric(templateDruidQuery, logicalMetric.getCalculation(), logicalMetric.getName());
+        return new LogicalMetric(
+                templateDruidQuery,
+                logicalMetric.getCalculation(),
+                logicalMetric.getName(),
+                logicalMetric.getIsValidFor()
+        );
     }
 
     @Override

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
@@ -91,7 +91,7 @@ class DruidQueryBuilderSpec extends Specification {
             druidFilters.put(it.key, FILTER_BUILDER.buildFilters([(resources.d3): [it.value as ApiFilter] as Set]))
         }
 
-        LogicalMetric metric = new LogicalMetric(null, null, "m1")
+        LogicalMetric metric = new LogicalMetric(null, null, "m1", {true})
         Set<OrderByColumn> orderByColumns = [new OrderByColumn(metric, SortDirection.DESC)]
         limitSpec = new LimitSpec(orderByColumns)
         topNMetric = new TopNMetric("m1", SortDirection.DESC)
@@ -328,7 +328,7 @@ class DruidQueryBuilderSpec extends Specification {
         apiRequest = Mock(DataApiRequest)
 
         apiRequest.getTopN() >> OptionalInt.of(5)
-        apiRequest.getSorts() >> ([new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC)] as Set)
+        apiRequest.getSorts() >> ([new OrderByColumn(new LogicalMetric(null, null, "m1", {true}), SortDirection.DESC)] as Set)
         apiRequest.getHavings() >> havingMap
         apiRequest.getHaving() >> { DruidHavingBuilder.buildHavings(havingMap) }
 
@@ -353,7 +353,7 @@ class DruidQueryBuilderSpec extends Specification {
 
         apiRequest.getDimensions() >> ([resources.d1, resources.d2] as Set)
         apiRequest.getTopN() >> OptionalInt.of(5)
-        apiRequest.getSorts() >> ([new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC)] as Set)
+        apiRequest.getSorts() >> ([new OrderByColumn(new LogicalMetric(null, null, "m1", {true}), SortDirection.DESC)] as Set)
 
         initDefault(apiRequest)
 
@@ -370,8 +370,8 @@ class DruidQueryBuilderSpec extends Specification {
 
         apiRequest.getTopN() >> OptionalInt.of(5)
         apiRequest.getSorts() >> ([
-                new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC),
-                new OrderByColumn(new LogicalMetric(null, null, "m2"), SortDirection.ASC)
+                new OrderByColumn(new LogicalMetric(null, null, "m1", {true}), SortDirection.DESC),
+                new OrderByColumn(new LogicalMetric(null, null, "m2", {true}), SortDirection.ASC)
         ] as Set)
 
         initDefault(apiRequest)
@@ -391,8 +391,8 @@ class DruidQueryBuilderSpec extends Specification {
 
         apiRequest.getTopN() >> OptionalInt.of(5)
         apiRequest.getSorts() >> ([
-                new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.ASC),
-                new OrderByColumn(new LogicalMetric(null, null, "m2"), SortDirection.DESC)
+                new OrderByColumn(new LogicalMetric(null, null, "m1", {true}), SortDirection.ASC),
+                new OrderByColumn(new LogicalMetric(null, null, "m2", {true}), SortDirection.DESC)
         ] as Set)
 
         initDefault(apiRequest)
@@ -439,10 +439,10 @@ havingMap:#havingMap"""() {
         apiRequest.getTopN() >> OptionalInt.of(5)
         apiRequest.getSorts() >> {
             nSorts > 1 ? [
-                    new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC),
-                    new OrderByColumn(new LogicalMetric(null, null, "m2"), SortDirection.ASC)
+                    new OrderByColumn(new LogicalMetric(null, null, "m1", {true}), SortDirection.DESC),
+                    new OrderByColumn(new LogicalMetric(null, null, "m2", {true}), SortDirection.ASC)
             ] as Set :
-                    [new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC)] as Set
+                    [new OrderByColumn(new LogicalMetric(null, null, "m1", {true}), SortDirection.DESC)] as Set
         }
         apiRequest.getHavings() >> havingMap
         apiRequest.getHaving() >> { DruidHavingBuilder.buildHavings(havingMap) }
@@ -478,7 +478,7 @@ havingMap:#havingMap"""() {
 
         apiRequest.getSorts() >> {
             nSorts > 0 ?
-                    [new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC)] as Set :
+                    [new OrderByColumn(new LogicalMetric(null, null, "m1", {true}), SortDirection.DESC)] as Set :
                     [] as Set
         }
         apiRequest.getHavings() >> havingMap

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
@@ -194,12 +194,12 @@ public class QueryBuildingTestingResources {
         dimensionDictionary = new DimensionDictionary()
         dimensionDictionary.addAll([d1, d2, d3, d4, d5, d6, d7, d8, d9, d10])
 
-        m1 = new LogicalMetric(null, null, "metric1")
-        m2 = new LogicalMetric(null, null, "metric2")
-        m3 = new LogicalMetric(null, null, "metric3")
-        m4 = new LogicalMetric(null, null, "metric4")
-        m5 = new LogicalMetric(null, null, "metric5")
-        m6 = new LogicalMetric(null, null, "metric6")
+        m1 = new LogicalMetric(null, null, "metric1", {true})
+        m2 = new LogicalMetric(null, null, "metric2", {true})
+        m3 = new LogicalMetric(null, null, "metric3", {true})
+        m4 = new LogicalMetric(null, null, "metric4", {true})
+        m5 = new LogicalMetric(null, null, "metric5", {true})
+        m6 = new LogicalMetric(null, null, "metric6", {true})
 
         metricDictionary = new MetricDictionary()
         [m1, m2, m3, m4, m5, m6].each {
@@ -213,53 +213,53 @@ public class QueryBuildingTestingResources {
         TimeGrain utcHour = HOUR.buildZonedTimeGrain(UTC)
         TimeGrain utcDay = DAY.buildZonedTimeGrain(UTC)
 
-        volatileHourTable = new ConcretePhysicalTable("hour", HOUR.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)}.toSet(), [:], metadataService)
-        volatileDayTable = new ConcretePhysicalTable("day", DAY.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)}.toSet(), [:], metadataService)
+        volatileHourTable = new ConcretePhysicalTable("hour", HOUR.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
+        volatileDayTable = new ConcretePhysicalTable("day", DAY.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t1h = new ConcretePhysicalTable("table1h", utcHour, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)}.toSet(), ["ageBracket":"age_bracket"], metadataService)
-        t1d = new ConcretePhysicalTable("table1d", utcDay, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)}.toSet(), ["ageBracket":"age_bracket"], metadataService)
-        t1hShort = new ConcretePhysicalTable("table1Short", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
+        t1h = new ConcretePhysicalTable("table1h", utcHour, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        t1d = new ConcretePhysicalTable("table1d", utcDay, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        t1hShort = new ConcretePhysicalTable("table1Short", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t2h = new ConcretePhysicalTable("table2", utcHour, [d1, d2, d4, m1, m4, m5].collect{toColumn(it)}.toSet(), [:], metadataService)
-        t3d = new ConcretePhysicalTable("table3", utcDay, [d1, d2, d5, m6].collect{toColumn(it)}.toSet(), [:], metadataService)
+        t2h = new ConcretePhysicalTable("table2", utcHour, [d1, d2, d4, m1, m4, m5].collect{toColumn(it)} as Set, [:], metadataService)
+        t3d = new ConcretePhysicalTable("table3", utcDay, [d1, d2, d5, m6].collect{toColumn(it)} as Set, [:], metadataService)
 
-        tna1236d = new ConcretePhysicalTable("tableNA1236", utcDay, [d1, d2, d3, d6].collect{toColumn(it)}.toSet(),["ageBracket":"age_bracket"], metadataService)
-        tna1237d = new ConcretePhysicalTable("tableNA1237", utcDay, [d1, d2, d3, d7].collect{toColumn(it)}.toSet(), ["ageBracket":"age_bracket"], metadataService)
-        tna167d = new ConcretePhysicalTable("tableNA167", utcDay, [d1, d6, d7].collect{toColumn(it)}.toSet(), ["ageBracket":"age_bracket", "dim7":"dim_7"], metadataService)
-        tna267d = new ConcretePhysicalTable("tableNA267", utcDay, [d2, d6, d7].collect{toColumn(it)}.toSet(), ["dim7":"dim_7"], metadataService)
+        tna1236d = new ConcretePhysicalTable("tableNA1236", utcDay, [d1, d2, d3, d6].collect{toColumn(it)} as Set,["ageBracket":"age_bracket"], metadataService)
+        tna1237d = new ConcretePhysicalTable("tableNA1237", utcDay, [d1, d2, d3, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        tna167d = new ConcretePhysicalTable("tableNA167", utcDay, [d1, d6, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket", "dim7":"dim_7"], metadataService)
+        tna267d = new ConcretePhysicalTable("tableNA267", utcDay, [d2, d6, d7].collect{toColumn(it)} as Set, ["dim7":"dim_7"], metadataService)
 
-        t4h1 = new ConcretePhysicalTable("table4h1", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        t4h2 = new ConcretePhysicalTable("table4h2", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        t4d1 = new ConcretePhysicalTable("table4d1", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        t4d2 = new ConcretePhysicalTable("table4d2", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
+        t4h1 = new ConcretePhysicalTable("table4h1", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4h2 = new ConcretePhysicalTable("table4h2", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4d1 = new ConcretePhysicalTable("table4d1", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4d2 = new ConcretePhysicalTable("table4d2", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
         Map<Column, Set<Interval>> availabilityMap1 = [:]
         Map<Column, Set<Interval>> availabilityMap2 = [:]
 
         [d1, d2, m1, m2, m3].each {
-            availabilityMap1.put(toColumn(it), [interval1].toSet())
-            availabilityMap2.put(toColumn(it), [interval2].toSet())
+            availabilityMap1.put(toColumn(it), [interval1] as Set)
+            availabilityMap2.put(toColumn(it), [interval2] as Set)
         }
 
         t4h1.setAvailability(new ConcreteAvailability(t4h1.getTableName(), t4h1.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap1)))
         t4d1.setAvailability(new ConcreteAvailability(t4d1.getTableName(), t4d1.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap1)))
 
-        t5h = new ConcretePhysicalTable("table5d", utcHour, [d8, d9, d10, d11, d12, d13, m1].collect{toColumn(it)}.toSet(), [:], metadataService)
+        t5h = new ConcretePhysicalTable("table5d", utcHour, [d8, d9, d10, d11, d12, d13, m1].collect{toColumn(it)} as Set, [:], metadataService)
 
         t4h2.setAvailability(new ConcreteAvailability(t4h2.getTableName(), t4h2.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap2)))
         t4d2.setAvailability(new ConcreteAvailability(t4d1.getTableName(), t4d1.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap2)))
 
         setupPartialData()
 
-        tg1h = new TableGroup([t1h, t1d, t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [d1].toSet())
-        tg1d = new TableGroup([t1d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [d1].toSet())
-        tg1Short = new TableGroup([t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg2h = new TableGroup([t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg3d = new TableGroup([t3d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg4h = new TableGroup([t1h, t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg5h = new TableGroup([t2h, t1h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg6h = new TableGroup([t5h] as LinkedHashSet, [].toSet(), [].toSet())
-        tgna = new TableGroup([tna1236d, tna1237d, tna167d, tna267d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
+        tg1h = new TableGroup([t1h, t1d, t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [d1] as Set)
+        tg1d = new TableGroup([t1d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [d1] as Set)
+        tg1Short = new TableGroup([t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg2h = new TableGroup([t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg3d = new TableGroup([t3d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg4h = new TableGroup([t1h, t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg5h = new TableGroup([t2h, t1h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg6h = new TableGroup([t5h] as LinkedHashSet, [] as Set, [] as Set)
+        tgna = new TableGroup([tna1236d, tna1237d, tna167d, tna267d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
 
         lt12 = new LogicalTable("base12", HOUR, tg1h, metricDictionary)
         lt13 = new LogicalTable("base13", DAY, tg1d, metricDictionary)
@@ -314,26 +314,26 @@ public class QueryBuildingTestingResources {
     def setupPartialData() {
         // In the event of partiality on all data, the coarsest table will be selected and the leftmost of the
         // coarsest tables should be selected
-        emptyFirst = new ConcretePhysicalTable("emptyFirst", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        emptyLast = new ConcretePhysicalTable("emptyLast", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        partialSecond = new ConcretePhysicalTable("partialSecond", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        wholeThird = new ConcretePhysicalTable("wholeThird", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
+        emptyFirst = new ConcretePhysicalTable("emptyFirst", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        emptyLast = new ConcretePhysicalTable("emptyLast", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        partialSecond = new ConcretePhysicalTable("partialSecond", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        wholeThird = new ConcretePhysicalTable("wholeThird", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
         Map<Column, Set<Interval>> availabilityMap1 = [:]
         Map<Column, Set<Interval>> availabilityMap2 = [:]
         Map<Column, Set<Interval>> availabilityMap3 = [:]
 
         [d1, d2, m1, m2, m3].each {
-            availabilityMap1.put(toColumn(it), [new Interval("2015/2015")].toSet())
-            availabilityMap2.put(toColumn(it), [new Interval("2015/2016")].toSet())
-            availabilityMap3.put(toColumn(it), [new Interval("2011/2016")].toSet())
+            availabilityMap1.put(toColumn(it), [new Interval("2015/2015")] as Set)
+            availabilityMap2.put(toColumn(it), [new Interval("2015/2016")] as Set)
+            availabilityMap3.put(toColumn(it), [new Interval("2011/2016")] as Set)
         }
         emptyFirst.setAvailability(new ConcreteAvailability(emptyFirst.getTableName(), emptyFirst.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap1)))
         emptyLast.setAvailability(new ConcreteAvailability(emptyLast.getTableName(), emptyLast.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap1)))
         partialSecond.setAvailability(new ConcreteAvailability(partialSecond.getTableName(), partialSecond.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap2)))
         wholeThird.setAvailability(new ConcreteAvailability(wholeThird.getTableName(), wholeThird.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap3)))
 
-        tg1All = new TableGroup([emptyFirst, partialSecond, wholeThird, emptyLast] as LinkedHashSet, [].toSet(), [].toSet())
+        tg1All = new TableGroup([emptyFirst, partialSecond, wholeThird, emptyLast] as LinkedHashSet, [] as Set, [] as Set)
         ti1All = new TableIdentifier("base1All", AllGranularity.INSTANCE)
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/AggregationAverageMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/AggregationAverageMakerSpec.groovy
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.data.config.metric.makers
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
@@ -26,8 +27,8 @@ import spock.lang.Specification
 
 class AggregationAverageMakerSpec extends Specification{
 
-    static final String NAME = "users"
-    static final String DESCRIPTION  = NAME
+    static final ApiMetricName NAME = ApiMetricName.of("users")
+    static final String DESCRIPTION  = NAME.asName()
     static final String ESTIMATE_NAME = "users_estimate"
     static final String ESTIMATE_SUM_NAME = "users_estimate_sum"
     static final int SKETCH_SIZE = 16000
@@ -38,7 +39,7 @@ class AggregationAverageMakerSpec extends Specification{
     Aggregation sketchMerge
 
     def setup(){
-        sketchMerge = new SketchMergeAggregation(NAME, NAME, SKETCH_SIZE)
+        sketchMerge = new SketchMergeAggregation(NAME.asName(), NAME.asName(), SKETCH_SIZE)
         //Initializing the Sketch field converter
         FieldConverterSupplier.sketchConverter = new SketchFieldConverter();
     }
@@ -49,7 +50,7 @@ class AggregationAverageMakerSpec extends Specification{
 
     def "Build a correct LogicalMetric when passed a sketch count aggregation."(){
         given: "a logical metric for counting the number of users each day"
-        Aggregation userSketchCount = new SketchCountAggregation(NAME, NAME, 16000)
+        Aggregation userSketchCount = new SketchCountAggregation(NAME.asName(), NAME.asName(), 16000)
         TemplateDruidQuery sketchQuery = new TemplateDruidQuery(
                 [userSketchCount] as Set,
                 [] as Set
@@ -70,7 +71,7 @@ class AggregationAverageMakerSpec extends Specification{
         LogicalMetric expectedMetric = buildExpectedMetric(sketchEstimate)
 
         expect:
-        maker.make(NAME, NAME).equals(expectedMetric)
+        maker.make(NAME, NAME.asName()).equals(expectedMetric)
     }
 
     def "Build a correct LogicalMetric when passed a sketch merge and sketch estimate"(){
@@ -95,12 +96,12 @@ class AggregationAverageMakerSpec extends Specification{
         LogicalMetric expectedMetric = buildExpectedMetric(sketchEstimate)
 
         expect:
-        maker.make(NAME, NAME).equals(expectedMetric)
+        maker.make(NAME, NAME.asName()).equals(expectedMetric)
     }
 
     def "Build a correct LogicalMetric when passed only a sketch merge."(){
         given: "A Logical Metric containing only a sketch estimate"
-        Aggregation sketchMerge = new SketchMergeAggregation(NAME, NAME, SKETCH_SIZE)
+        Aggregation sketchMerge = new SketchMergeAggregation(NAME.asName(), NAME.asName(), SKETCH_SIZE)
         TemplateDruidQuery sketchEstimateQuery = new TemplateDruidQuery(
                 [sketchMerge] as Set,
                 [] as Set
@@ -120,11 +121,11 @@ class AggregationAverageMakerSpec extends Specification{
         LogicalMetric expectedMetric = buildExpectedMetric(sketchEstimate)
 
         expect:
-        maker.make(NAME, NAME).equals(expectedMetric)
+        maker.make(NAME, NAME.asName()).equals(expectedMetric)
     }
 
     LogicalMetric buildDependentMetric(TemplateDruidQuery dependentQuery){
-        return new LogicalMetric(dependentQuery, new NoOpResultSetMapper(), NAME, DESCRIPTION)
+        return new LogicalMetric(dependentQuery, new NoOpResultSetMapper(), NAME.asName(), DESCRIPTION)
     }
     /**
      * Builds the LogicalMetric expected by the tests.
@@ -164,7 +165,7 @@ class AggregationAverageMakerSpec extends Specification{
         Aggregation outerSum = new DoubleSumAggregation(ESTIMATE_SUM_NAME, ESTIMATE_NAME)
         FieldAccessorPostAggregation outerSumLookup = new FieldAccessorPostAggregation(outerSum)
         PostAggregation average = new ArithmeticPostAggregation(
-                NAME,
+                NAME.asName(),
                 ArithmeticPostAggregation.ArithmeticPostAggregationFunction.DIVIDE,
                 [outerSumLookup, AggregationAverageMaker.COUNT_FIELD_OUTER]
         )
@@ -174,6 +175,6 @@ class AggregationAverageMakerSpec extends Specification{
                 innerQueryTemplate
         )
 
-        return new LogicalMetric(outerQuery, new NoOpResultSetMapper(), NAME, DESCRIPTION)
+        return new LogicalMetric(outerQuery, new NoOpResultSetMapper(), NAME.asName(), DESCRIPTION)
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/AggregationAverageMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/AggregationAverageMakerSpec.groovy
@@ -125,7 +125,13 @@ class AggregationAverageMakerSpec extends Specification{
     }
 
     LogicalMetric buildDependentMetric(TemplateDruidQuery dependentQuery){
-        return new LogicalMetric(dependentQuery, new NoOpResultSetMapper(), NAME.asName(), DESCRIPTION)
+        return new LogicalMetric(
+                dependentQuery,
+                new NoOpResultSetMapper(),
+                NAME.asName(),
+                DESCRIPTION,
+                NAME.&isValidFor
+        );
     }
     /**
      * Builds the LogicalMetric expected by the tests.
@@ -175,6 +181,6 @@ class AggregationAverageMakerSpec extends Specification{
                 innerQueryTemplate
         )
 
-        return new LogicalMetric(outerQuery, new NoOpResultSetMapper(), NAME.asName(), DESCRIPTION)
+        return new LogicalMetric(outerQuery, new NoOpResultSetMapper(), NAME.asName(), DESCRIPTION, NAME.&isValidFor)
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ArithmeticMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ArithmeticMakerSpec.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.data.config.metric.makers
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 
 import com.yahoo.bard.webservice.data.config.metric.MetricInstance
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
@@ -27,10 +28,10 @@ import spock.lang.Unroll
 import java.util.function.Function
 
 class ArithmeticMakerSpec extends Specification {
-    public static final String AGG_AVERAGE_NAME = "aggregationMetric"
-    public static final String METRIC_FIELD_NAME = "aggregationField"
-    public static final String AVERAGE_PER_OTHER_METRIC_NAME = "averagePerOtherMetric"
-    public static final String AVERAGE_PER_OTHER_METRIC_ROUNDED_METRIC_NAME = "averagePerOtherMetricRounded"
+    public static final ApiMetricName AGG_AVERAGE_NAME = ApiMetricName.of("aggregationMetric")
+    public static final ApiMetricName METRIC_FIELD_NAME = ApiMetricName.of("aggregationField")
+    public static final ApiMetricName AVERAGE_PER_OTHER_METRIC_NAME = ApiMetricName.of("averagePerOtherMetric")
+    public static final ApiMetricName AVERAGE_PER_OTHER_METRIC_ROUNDED_METRIC_NAME = ApiMetricName.of("averagePerOtherMetricRounded")
     LogicalMetric unRoundedMetric
     LogicalMetric roundedUpMetric
 
@@ -98,9 +99,9 @@ class ArithmeticMakerSpec extends Specification {
         //The ConstantMaker relies on the dependent metric string being a number, the
         //the SketchCountMaker doesn't care.
         List<LogicalMetric> operands = (1..numOperands).collect{
-            operandMaker.make("metric$it", it as String)
+            operandMaker.make(ApiMetricName.of("metric$it"), it as String)
         }
-        String metricName = "sum"
+        ApiMetricName metricName = ApiMetricName.of("sum")
         List<TemplateDruidQuery> operandQueries = operands*.getTemplateDruidQuery()
         Set<Aggregation> aggregations = operandQueries*.getAggregations().flatten() as Set<Aggregation>
 
@@ -122,7 +123,7 @@ class ArithmeticMakerSpec extends Specification {
 
         and: "the expected LogicalMetric"
         PostAggregation sumPostAggregation = new ArithmeticPostAggregation(
-                metricName,
+                metricName.asName(),
                 OPERATION,
                 postAggregationsForArithmetic
         )
@@ -133,7 +134,7 @@ class ArithmeticMakerSpec extends Specification {
         LogicalMetric expectedMetric = new LogicalMetric(
             expectedQuery,
             MetricMaker.NO_OP_MAPPER,
-            metricName
+            metricName.asName()
         )
 
         and: "a populated metric dictionary for the maker"

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ArithmeticMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ArithmeticMakerSpec.groovy
@@ -134,7 +134,8 @@ class ArithmeticMakerSpec extends Specification {
         LogicalMetric expectedMetric = new LogicalMetric(
             expectedQuery,
             MetricMaker.NO_OP_MAPPER,
-            metricName.asName()
+            metricName.asName(),
+            metricName.&isValidFor
         )
 
         and: "a populated metric dictionary for the maker"

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/CardinalityMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/CardinalityMakerSpec.groovy
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.data.config.metric.makers
 
 import com.yahoo.bard.webservice.data.config.metric.MetricInstance
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
@@ -21,6 +22,7 @@ class CardinalityMakerSpec extends Specification {
 
     Dimension dimension = Mock(Dimension)
     String dimensionApiName = "ApiName"
+    public static final ApiMetricName METRIC_NAME = ApiMetricName.of("metricName")
 
     def setup() {
         dimension.getApiName() >> dimensionApiName
@@ -35,11 +37,11 @@ class CardinalityMakerSpec extends Specification {
                 dimensionDictionary,
                 true
         )
-        LogicalMetric actualMetric = cardinalityMaker.make("metricName", dimensionApiName)
+        LogicalMetric actualMetric = cardinalityMaker.make(METRIC_NAME, dimensionApiName)
         CardinalityAggregation actual = (CardinalityAggregation) actualMetric.getTemplateDruidQuery().getMetricField("metricName")
 
         expect:
-        actual.getName() == "metricName"
+        actual.getName() == METRIC_NAME.asName()
         actual.dependentDimensions == [dimension] as Set
         actual.byRow
         actual.fieldName == ""
@@ -53,12 +55,12 @@ class CardinalityMakerSpec extends Specification {
                 dimensionDictionary,
                 true
         )
-        MetricInstance metricInstance = new MetricInstance("metricName", cardinalityMaker, dimensionApiName)
+        MetricInstance metricInstance = new MetricInstance(METRIC_NAME, cardinalityMaker, dimensionApiName)
         LogicalMetric actualMetric = metricInstance.make()
         CardinalityAggregation actual = (CardinalityAggregation) actualMetric.getTemplateDruidQuery().getMetricField("metricName")
 
         expect:
-        actual.getName() == "metricName"
+        actual.getName() == METRIC_NAME.asName()
         actual.dependentDimensions == [dimension] as Set
         actual.byRow
         actual.fieldName == ""

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMakerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
 import com.yahoo.bard.webservice.data.metric.mappers.NoOpResultSetMapper
@@ -12,12 +13,12 @@ import spock.lang.Specification
 
 class ConstantMakerSpec extends Specification {
 
-    final String AGGREGATION_NAME = "one"
+    final ApiMetricName AGGREGATION_NAME = ApiMetricName.of("one")
     final double CONSTANT_VALUE = 1.0
 
     def "A constant is built correctly when its 'dependent metric' is the string representation of a number."(){
         given: "A Logical Metric representing a constant of value CONSTANT_VALUE"
-        PostAggregation postAggregation = new ConstantPostAggregation(AGGREGATION_NAME, CONSTANT_VALUE)
+        PostAggregation postAggregation = new ConstantPostAggregation(AGGREGATION_NAME.asName(), CONSTANT_VALUE)
         TemplateDruidQuery constantQuery = new TemplateDruidQuery(
             [] as Set,
             [postAggregation] as Set
@@ -25,7 +26,7 @@ class ConstantMakerSpec extends Specification {
         LogicalMetric expectedMetric = new LogicalMetric(
             constantQuery,
             new NoOpResultSetMapper(),
-            AGGREGATION_NAME
+            AGGREGATION_NAME.asName()
         )
 
         and:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMakerSpec.groovy
@@ -26,7 +26,8 @@ class ConstantMakerSpec extends Specification {
         LogicalMetric expectedMetric = new LogicalMetric(
             constantQuery,
             new NoOpResultSetMapper(),
-            AGGREGATION_NAME.asName()
+            AGGREGATION_NAME.asName(),
+            {true}
         )
 
         and:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/CountMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/CountMakerSpec.groovy
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.data.config.metric.makers
 
 import com.yahoo.bard.webservice.data.config.metric.MetricInstance
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.druid.model.aggregation.CountAggregation
@@ -16,26 +17,27 @@ class CountMakerSpec extends Specification {
 
     MetricDictionary metricDictionary = new MetricDictionary()
     CountMaker countMaker = new CountMaker(metricDictionary)
+    ApiMetricName metricName = ApiMetricName.of("metricName")
 
     def "Test building a cardinality metric meets expected values"() {
         setup:
         CountMaker countMaker = new CountMaker(metricDictionary)
-        LogicalMetric actualMetric = countMaker.make("metricName", [])
+        LogicalMetric actualMetric = countMaker.make(metricName, [])
         CountAggregation actual = (CountAggregation) actualMetric.getTemplateDruidQuery().getMetricField("metricName")
 
         expect:
-        actual.getName() == "metricName"
+        actual.getName() == metricName.asName()
         actual.fieldName == ""
     }
 
     def "Test building from MetricInstance"() {
         setup:
-        MetricInstance metricInstance = new MetricInstance("metricName", countMaker)
+        MetricInstance metricInstance = new MetricInstance(metricName, countMaker)
         LogicalMetric actualMetric = metricInstance.make()
         CountAggregation actual = (CountAggregation) actualMetric.getTemplateDruidQuery().getMetricField("metricName")
 
         expect:
-        actual.getName() == "metricName"
+        actual.getName() == metricName.asName()
         actual.fieldName == ""
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMakerSpec.groovy
@@ -43,7 +43,7 @@ public class FilteredAggregationMakerSpec extends Specification{
 
         and: "The expected metric"
         Aggregation expectedAgg = new FilteredAggregation(FILT_METRIC_NAME.asName(), new LongSumAggregation("longSum", DEPENDENT_METRIC_NAME), filter);
-        LogicalMetric expectedMetric = new LogicalMetric(new TemplateDruidQuery([expectedAgg], [] as Set), new NoOpResultSetMapper(), FILT_METRIC_NAME.asName())
+        LogicalMetric expectedMetric = new LogicalMetric(new TemplateDruidQuery([expectedAgg], [] as Set), new NoOpResultSetMapper(), FILT_METRIC_NAME.asName(), {true})
 
         expect:
         maker.make(FILT_METRIC_NAME, [longSum]) == expectedMetric

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/FilteredAggregationMakerSpec.groovy
@@ -3,6 +3,7 @@
 
 package com.yahoo.bard.webservice.data.config.metric.makers
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.KeyValueStore
 import com.yahoo.bard.webservice.data.dimension.SearchProvider
@@ -22,7 +23,10 @@ import spock.lang.Specification
 public class FilteredAggregationMakerSpec extends Specification{
 
     private static final String DEPENDENT_METRIC_NAME = "totalPageViews"
-    private static final String FILT_METRIC_NAME = "filteredPageViews"
+    private static final ApiMetricName FILT_METRIC_NAME = ApiMetricName.of("filteredPageViews")
+
+    public final String longSum = "longSum"
+    public final ApiMetricName longSumApiName = ApiMetricName.of(longSum)
 
     MetricDictionary metricDictionary = new MetricDictionary();
     LongSumMaker longSumMaker = new LongSumMaker(metricDictionary)
@@ -34,14 +38,14 @@ public class FilteredAggregationMakerSpec extends Specification{
         Filter filter = new SelectorFilter(dim, "1")
 
         MetricMaker maker = new FilteredAggregationMaker(metricDictionary, filter)
-        LogicalMetric metric = longSumMaker.make("longSum", DEPENDENT_METRIC_NAME)
-        metricDictionary.put("longSum", metric);
+        LogicalMetric metric = longSumMaker.make(longSumApiName, DEPENDENT_METRIC_NAME)
+        metricDictionary.put(longSum, metric);
 
         and: "The expected metric"
-        Aggregation expectedAgg = new FilteredAggregation(FILT_METRIC_NAME, new LongSumAggregation("longSum", DEPENDENT_METRIC_NAME), filter);
-        LogicalMetric expectedMetric = new LogicalMetric(new TemplateDruidQuery([expectedAgg], [] as Set), new NoOpResultSetMapper(), FILT_METRIC_NAME)
+        Aggregation expectedAgg = new FilteredAggregation(FILT_METRIC_NAME.asName(), new LongSumAggregation("longSum", DEPENDENT_METRIC_NAME), filter);
+        LogicalMetric expectedMetric = new LogicalMetric(new TemplateDruidQuery([expectedAgg], [] as Set), new NoOpResultSetMapper(), FILT_METRIC_NAME.asName())
 
         expect:
-        maker.make(FILT_METRIC_NAME, ["longSum"]) == expectedMetric
+        maker.make(FILT_METRIC_NAME, [longSum]) == expectedMetric
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/LongSumMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/LongSumMakerSpec.groovy
@@ -26,7 +26,7 @@ class LongSumMakerSpec extends Specification{
         Aggregation sumAggregation = new LongSumAggregation(METRIC_NAME, DEPENDENT_METRIC_NAME)
         Set<Aggregation> aggregations = [sumAggregation] as Set
         TemplateDruidQuery query = new TemplateDruidQuery(aggregations, [] as Set)
-        LogicalMetric expectedMetric = new LogicalMetric(query, new NoOpResultSetMapper(), METRIC_NAME)
+        LogicalMetric expectedMetric = new LogicalMetric(query, new NoOpResultSetMapper(), METRIC_NAME, {true})
 
         expect:
         maker.make(METRIC_API_NAME, [DEPENDENT_METRIC_NAME]) == expectedMetric

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/LongSumMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/LongSumMakerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
 import com.yahoo.bard.webservice.data.metric.mappers.NoOpResultSetMapper
@@ -13,6 +14,7 @@ import spock.lang.Specification;
 class LongSumMakerSpec extends Specification{
 
     private static final String METRIC_NAME = "pageViews"
+    private static final ApiMetricName METRIC_API_NAME = ApiMetricName.of(METRIC_NAME)
     private static final String DEPENDENT_METRIC_NAME = "totalPageViews"
 
     def "A long sum logical metric is made correctly"(){
@@ -27,6 +29,6 @@ class LongSumMakerSpec extends Specification{
         LogicalMetric expectedMetric = new LogicalMetric(query, new NoOpResultSetMapper(), METRIC_NAME)
 
         expect:
-        maker.make(METRIC_NAME, [DEPENDENT_METRIC_NAME]) == expectedMetric
+        maker.make(METRIC_API_NAME, [DEPENDENT_METRIC_NAME]) == expectedMetric
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/MetricMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/MetricMakerSpec.groovy
@@ -6,6 +6,7 @@ import static com.yahoo.bard.webservice.data.config.metric.makers.MetricMaker.IN
 import static com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation.ArithmeticPostAggregationFunction.MULTIPLY
 import static com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationPostAggFunction.UNION
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
@@ -32,7 +33,7 @@ import spock.lang.Unroll
  */
 class MetricMakerSpec extends Specification {
 
-    static final String METRIC_NAME = "metric name"
+    static final ApiMetricName METRIC_NAME = ApiMetricName.of("metric name")
     static final int DEPENDENT_METRICS = 3
 
     static final FieldConverters originalConverter = FieldConverterSupplier.sketchConverter
@@ -125,7 +126,7 @@ class MetricMakerSpec extends Specification {
     MetricMaker getMakerInstance(){
         new MetricMaker(dictionary) {
             @Override
-            protected LogicalMetric makeInner(String metricName, List<String> dependentMetrics) {
+            protected LogicalMetric makeInner(ApiMetricName metricName, List<String> dependentMetrics) {
                 DEFAULT_METRIC
             }
 
@@ -185,7 +186,7 @@ class MetricMakerSpec extends Specification {
 
         then:
         Exception exception = thrown(IllegalArgumentException)
-        exception.getMessage() == String.format(INCORRECT_NUMBER_OF_DEPS_FORMAT, METRIC_NAME, DEPENDENT_METRICS+adjustment, DEPENDENT_METRICS)
+        exception.getMessage() == String.format(INCORRECT_NUMBER_OF_DEPS_FORMAT, METRIC_NAME.asName(), DEPENDENT_METRICS+adjustment, DEPENDENT_METRICS)
 
         where:
         adjective | adjustment

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/MetricMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/MetricMakerSpec.groovy
@@ -69,29 +69,29 @@ class MetricMakerSpec extends Specification {
 
         TemplateDruidQuery queryTemplate
         queryTemplate = new TemplateDruidQuery([] as Set, [number] as Set)
-        constantMetric = new LogicalMetric(queryTemplate, new NoOpResultSetMapper(), constantName)
+        constantMetric = new LogicalMetric(queryTemplate, new NoOpResultSetMapper(), constantName, {true})
 
         Aggregation longSum = new LongSumAggregation(sumName, "columnName")
         queryTemplate = new TemplateDruidQuery([longSum] as Set, [] as Set)
-        longSumMetric = new LogicalMetric(queryTemplate, new NoOpResultSetMapper(), longSum.name)
+        longSumMetric = new LogicalMetric(queryTemplate, new NoOpResultSetMapper(), longSum.name, {true})
 
         longSumFieldAccessor = new FieldAccessorPostAggregation(longSum)
         PostAggregation square = new ArithmeticPostAggregation(squareName, MULTIPLY, [longSumFieldAccessor, longSumFieldAccessor])
 
         queryTemplate = new TemplateDruidQuery([longSum] as Set, [square] as Set)
-        squareMetric = new LogicalMetric(queryTemplate, new NoOpResultSetMapper(), square.name)
+        squareMetric = new LogicalMetric(queryTemplate, new NoOpResultSetMapper(), square.name, {true})
 
         // Theta Sketches
         Aggregation sketchAggregation = new ThetaSketchAggregation(sketchName, "columnName", 16000)
         queryTemplate = new TemplateDruidQuery([sketchAggregation] as Set, [] as Set)
-        sketchAggregationMetric = new LogicalMetric(queryTemplate, new SketchRoundUpMapper(sketchAggregation.name), sketchAggregation.name)
+        sketchAggregationMetric = new LogicalMetric(queryTemplate, new SketchRoundUpMapper(sketchAggregation.name), sketchAggregation.name, {true})
 
         PostAggregation sketchEstimateAggregation = CONVERTER.asSketchEstimate(sketchAggregation)
 
         sketchFieldAccessor = sketchEstimateAggregation.getField()
 
         queryTemplate = new TemplateDruidQuery([sketchAggregation] as Set, [sketchEstimateAggregation] as Set)
-        sketchEstimateMetric = new LogicalMetric(queryTemplate, new SketchRoundUpMapper(sketchEstimateAggregation.name), sketchEstimateAggregation.name)
+        sketchEstimateMetric = new LogicalMetric(queryTemplate, new SketchRoundUpMapper(sketchEstimateAggregation.name), sketchEstimateAggregation.name, {true})
 
         PostAggregation sketchSetAggregation = new ThetaSketchSetOperationPostAggregation(
                 sketchUnionName,
@@ -99,11 +99,11 @@ class MetricMakerSpec extends Specification {
                 [sketchFieldAccessor, sketchFieldAccessor]
         )
         queryTemplate = new TemplateDruidQuery([sketchAggregation] as Set, [sketchSetAggregation] as Set)
-        sketchUnionMetric = new LogicalMetric(queryTemplate, new SketchRoundUpMapper(sketchSetAggregation.name), sketchSetAggregation.name)
+        sketchUnionMetric = new LogicalMetric(queryTemplate, new SketchRoundUpMapper(sketchSetAggregation.name), sketchSetAggregation.name, {true})
 
         PostAggregation sketchSetEstimate = CONVERTER.asSketchEstimate(sketchSetAggregation)
         queryTemplate = new TemplateDruidQuery([sketchAggregation] as Set, [sketchSetEstimate] as Set)
-        sketchUnionEstimateMetric = new LogicalMetric(queryTemplate, new SketchRoundUpMapper(sketchSetEstimate.name), sketchSetEstimate.name)
+        sketchUnionEstimateMetric = new LogicalMetric(queryTemplate, new SketchRoundUpMapper(sketchSetEstimate.name), sketchSetEstimate.name, {true})
     }
 
     def cleanupSpec() {
@@ -114,7 +114,8 @@ class MetricMakerSpec extends Specification {
             new TemplateDruidQuery([] as Set, [] as Set),
             new NoOpResultSetMapper(),
             "no name",
-            "no description"
+            "no description",
+            {true}
     )
 
     /**
@@ -156,7 +157,7 @@ class MetricMakerSpec extends Specification {
      */
     Map<String, LogicalMetric> makeEmptyMetrics(List<String> metricNames){
         metricNames.collectEntries {
-            [(it): new LogicalMetric(null, null, it)]
+            [(it): new LogicalMetric(null, null, it, {true})]
         }
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/RawAggregationMetricMakerImplsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/RawAggregationMetricMakerImplsSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
@@ -18,7 +19,6 @@ import com.yahoo.bard.webservice.druid.model.aggregation.ThetaSketchAggregation
 
 import spock.lang.Specification
 import spock.lang.Unroll
-
 /**
  * Tests for raw aggregation makers.
  */
@@ -26,6 +26,7 @@ class RawAggregationMetricMakerImplsSpec extends Specification {
 
     public static String NAME = "FOO"
     public static String FIELD_NAME = "BAR"
+    public static ApiMetricName METRIC_NAME = ApiMetricName.of(NAME)
 
     @Unroll
     def "Expected numeric aggregation is produced for #makerClass.simpleName"() {
@@ -33,7 +34,7 @@ class RawAggregationMetricMakerImplsSpec extends Specification {
         RawAggregationMetricMaker maker = makerClass.newInstance()
 
         expect:
-        maker.make(NAME, FIELD_NAME) == makeNumericMetric(aggregation)
+        maker.make(METRIC_NAME, FIELD_NAME) == makeNumericMetric(aggregation)
 
         where:
         makerClass     | aggregation
@@ -51,7 +52,7 @@ class RawAggregationMetricMakerImplsSpec extends Specification {
         RawAggregationMetricMaker maker = makerClass.newInstance((MetricDictionary) null, 5)
 
         expect:
-        maker.make(NAME, FIELD_NAME) == makeSketchMetric(aggregation)
+        maker.make(METRIC_NAME, FIELD_NAME) == makeSketchMetric(aggregation)
 
         where:
         makerClass     | aggregation

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/RawAggregationMetricMakerImplsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/RawAggregationMetricMakerImplsSpec.groovy
@@ -69,7 +69,8 @@ class RawAggregationMetricMakerImplsSpec extends Specification {
         new LogicalMetric(
                 new TemplateDruidQuery(Collections.singleton(aggregation), Collections.emptySet()),
                 MetricMaker.NO_OP_MAPPER,
-                aggregation.getName()
+                aggregation.getName(),
+                {true}
         );
     }
 
@@ -77,7 +78,8 @@ class RawAggregationMetricMakerImplsSpec extends Specification {
         new LogicalMetric(
                 new TemplateDruidQuery(Collections.singleton(aggregation), Collections.emptySet()),
                 new SketchRoundUpMapper(aggregation.getName()),
-                aggregation.getName()
+                aggregation.getName(),
+                {true}
         );
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMakerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.data.metric.mappers.RowNumMapper
@@ -12,6 +13,7 @@ import spock.lang.Specification
 class RowNumMakerSpec extends Specification {
 
     private static final String METRIC_NAME = "Row Num Generator"
+    private static final ApiMetricName METRIC_API_NAME = ApiMetricName.of(METRIC_NAME)
     private static final String DESCRIPTION = "Generator for Row Numbers"
 
     def "Build a logical metric that generates row numbers"() {
@@ -20,6 +22,6 @@ class RowNumMakerSpec extends Specification {
 
         expect:
         //RowSumMaker does not rely on the metric dictionary.
-        new RowNumMaker(new MetricDictionary()).make(METRIC_NAME, []) == metric
+        new RowNumMaker(new MetricDictionary()).make(METRIC_API_NAME, []) == metric
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMakerSpec.groovy
@@ -18,7 +18,13 @@ class RowNumMakerSpec extends Specification {
 
     def "Build a logical metric that generates row numbers"() {
         given: "A logical metric that generates row numbers"
-        LogicalMetric metric = new LogicalMetric(null, new RowNumMapper(), METRIC_NAME, DESCRIPTION)
+        LogicalMetric metric = new LogicalMetric(
+                null,
+                new RowNumMapper(),
+                METRIC_NAME,
+                DESCRIPTION,
+                METRIC_API_NAME.&isValidFor
+        )
 
         expect:
         //RowSumMaker does not rely on the metric dictionary.

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/SketchCountMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/SketchCountMakerSpec.groovy
@@ -29,7 +29,8 @@ class SketchCountMakerSpec extends Specification {
         LogicalMetric expectedMetric = new LogicalMetric(
                 new TemplateDruidQuery(aggregations, [] as Set),
                 new SketchRoundUpMapper(metricName),
-                metricName
+                metricName,
+                {true}
         )
 
         and:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/SketchCountMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/SketchCountMakerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.config.names.TestApiMetricName
 import com.yahoo.bard.webservice.data.config.names.TestDruidMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
@@ -20,6 +21,7 @@ class SketchCountMakerSpec extends Specification {
     def "A Logical Metric that performs a sketch count is built correctly"() {
         given: "A name for this , and the name of the metric this metric relies on"
         String metricName = TestApiMetricName.A_OTHER_USERS.asName()
+        ApiMetricName metricApiNAme = TestApiMetricName.A_OTHER_USERS
         String dependentMetricName = TestDruidMetricName.USERS.asName()
 
         and: "The logical metric the maker is expected to build"
@@ -34,6 +36,6 @@ class SketchCountMakerSpec extends Specification {
         MetricMaker maker = new SketchCountMaker(new MetricDictionary(), SKETCH_SIZE)
 
         expect:
-        maker.make(metricName, [dependentMetricName]) == expectedMetric
+        maker.make(metricApiNAme, [dependentMetricName]) == expectedMetric
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/SketchSetOperationMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/SketchSetOperationMakerSpec.groovy
@@ -41,19 +41,21 @@ class SketchSetOperationMakerSpec extends Specification {
                 new TemplateDruidQuery([allYahoos] as Set, [] as Set),
                 new NoOpResultSetMapper(),
                 "all_yahoos",
-                "All users from Yahoo"
+                "All users from Yahoo",
+                {true}
         )
         LogicalMetric secondMetric = new LogicalMetric(
                 new TemplateDruidQuery([allNonYahoos] as Set, [] as Set),
                 new NoOpResultSetMapper(),
                 "all_nonyahoos",
-                "All users not from Yahoo"
+                "All users not from Yahoo",
+                {true}
         )
         List<LogicalMetric> allUsers = [firstMetric, secondMetric]
 
         and: "the expected LogicalMetric"
         TemplateDruidQuery expectedQuery = new TemplateDruidQuery([allYahoos, allNonYahoos] as Set, [userNumber] as Set)
-        LogicalMetric metric = new LogicalMetric(expectedQuery, new SketchRoundUpMapper(METRIC_NAME), METRIC_NAME)
+        LogicalMetric metric = new LogicalMetric(expectedQuery, new SketchRoundUpMapper(METRIC_NAME), METRIC_NAME, {true})
 
         and: "the maker with populated metrics."
         MetricMaker maker = new SketchSetOperationMaker(new MetricDictionary(), SET_FUNCTION)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/SketchSetOperationMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/SketchSetOperationMakerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
@@ -21,6 +22,7 @@ class SketchSetOperationMakerSpec extends Specification {
 
     private static final int SKETCH_SIZE = 16000
     private static final String METRIC_NAME = "all users"
+    private static final ApiMetricName METRIC_API_NAME = ApiMetricName.of("all users")
     private static final SketchSetOperationPostAggFunction SET_FUNCTION = SketchSetOperationPostAggFunction.UNION
 
     def """A sketch set operation metric is built correctly when the dependent metrics have both an aggregation
@@ -58,6 +60,6 @@ class SketchSetOperationMakerSpec extends Specification {
         allUsers.each { maker.metrics.add(it) }
 
         expect:
-        maker.make(METRIC_NAME, allUsers*.getName()) == metric
+        maker.make(METRIC_API_NAME, allUsers*.getName()) == metric
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchMakerSpec.groovy
@@ -42,7 +42,8 @@ class ThetaSketchMakerSpec extends Specification {
         LogicalMetric expectedMetric = new LogicalMetric(
                 new TemplateDruidQuery(aggregations, [] as Set),
                 new SketchRoundUpMapper(metricName),
-                metricName
+                metricName,
+                {true}
         )
 
         and:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchMakerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.config.names.TestApiMetricName
 import com.yahoo.bard.webservice.data.config.names.TestDruidMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
@@ -33,6 +34,7 @@ class ThetaSketchMakerSpec extends Specification {
     def "A Logical Metric that performs a sketch count is built correctly"() {
         given: "A name for this , and the name of the metric this metric relies on"
         String metricName = TestApiMetricName.A_OTHER_USERS.asName()
+        ApiMetricName metricApiName = TestApiMetricName.A_OTHER_USERS
         String dependentMetricName = TestDruidMetricName.USERS.asName()
 
         and: "The logical metric the maker is expected to build"
@@ -47,6 +49,6 @@ class ThetaSketchMakerSpec extends Specification {
         MetricMaker maker = new ThetaSketchMaker(new MetricDictionary(), SKETCH_SIZE)
 
         expect:
-        maker.make(metricName, [dependentMetricName]) == expectedMetric
+        maker.make(metricApiName, [dependentMetricName]) == expectedMetric
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchSetOperationMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchSetOperationMakerSpec.groovy
@@ -41,19 +41,21 @@ class ThetaSketchSetOperationMakerSpec extends Specification {
                 new TemplateDruidQuery([allYahoos] as Set, [] as Set),
                 new NoOpResultSetMapper(),
                 "all_yahoos",
-                "All users from Yahoo"
+                "All users from Yahoo",
+                {true}
         )
         LogicalMetric secondMetric = new LogicalMetric(
                 new TemplateDruidQuery([allNonYahoos] as Set, [] as Set),
                 new NoOpResultSetMapper(),
                 "all_nonyahoos",
-                "All users not from Yahoo"
+                "All users not from Yahoo",
+                {true}
         )
         List<LogicalMetric> allUsers = [firstMetric, secondMetric]
 
         and: "the expected LogicalMetric"
         TemplateDruidQuery expectedQuery = new TemplateDruidQuery([allYahoos, allNonYahoos] as Set, [userNumber] as Set)
-        LogicalMetric metric = new LogicalMetric(expectedQuery, new SketchRoundUpMapper(METRIC_NAME), METRIC_NAME)
+        LogicalMetric metric = new LogicalMetric(expectedQuery, new SketchRoundUpMapper(METRIC_NAME), METRIC_NAME, {true})
 
         and: "the maker with populated metrics."
         MetricMaker maker = new ThetaSketchSetOperationMaker(new MetricDictionary(), SET_FUNCTION)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchSetOperationMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchSetOperationMakerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.metric.makers
 
+import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
@@ -21,6 +22,7 @@ class ThetaSketchSetOperationMakerSpec extends Specification {
 
     private static final int SKETCH_SIZE = 16000
     private static final String METRIC_NAME = "all users"
+    private static final ApiMetricName METRIC_API_NAME = ApiMetricName.of(METRIC_NAME)
     private static final SketchSetOperationPostAggFunction SET_FUNCTION = SketchSetOperationPostAggFunction.UNION
 
     def """A sketch set operation metric is built correctly when the dependent metrics have both an aggregation
@@ -58,6 +60,6 @@ class ThetaSketchSetOperationMakerSpec extends Specification {
         allUsers.each { maker.metrics.add(it) }
 
         expect:
-        maker.make(METRIC_NAME, allUsers*.getName()) == metric
+        maker.make(METRIC_API_NAME, allUsers*.getName()) == metric
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/FilteredAggregationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/FilteredAggregationSpec.groovy
@@ -50,8 +50,9 @@ class FilteredAggregationSpec extends Specification{
     def setup() {
         MetricDictionary metricDictionary = new MetricDictionary()
 
-        def filtered_metric_name = "FOO_NO_BAR"
-        Set<ApiMetricName> metricNames = (["FOO", filtered_metric_name].collect { ApiMetricName.of(it)}) as Set
+        String filteredMetricName = "FOO_NO_BAR"
+        ApiMetricName filteredApiName = ApiMetricName.of(filteredMetricName)
+        Set<ApiMetricName> metricNames = (["FOO", filteredMetricName].collect { ApiMetricName.of(it)}) as Set
 
         ageDimension = buildSimpleDimension("age")
         genderDimension = buildSimpleDimension("gender")
@@ -72,9 +73,9 @@ class FilteredAggregationSpec extends Specification{
         )
 
         ThetaSketchMaker sketchCountMaker = new ThetaSketchMaker(new MetricDictionary(), 16384)
-        MetricInstance fooNoBarSketchPm = new MetricInstance(filtered_metric_name,sketchCountMaker,"FOO_NO_BAR_SKETCH")
+        MetricInstance fooNoBarSketchPm = new MetricInstance(filteredApiName, sketchCountMaker,"FOO_NO_BAR_SKETCH")
         LogicalMetric fooNoBarSketch = fooNoBarSketchPm.make()
-        metricDictionary.put(filtered_metric_name, fooNoBarSketch)
+        metricDictionary.put(filteredMetricName, fooNoBarSketch)
 
         metricAgg = fooNoBarSketch.getTemplateDruidQuery().getAggregations().first()
         genderDependentMetricAgg = Mock(Aggregation)
@@ -82,7 +83,7 @@ class FilteredAggregationSpec extends Specification{
         genderDependentMetricAgg.withName(_) >> genderDependentMetricAgg
         genderDependentMetricAgg.withFieldName(_) >> genderDependentMetricAgg
 
-        LogicalMetric logicalMetric = new LogicalMetric(null, null, filtered_metric_name)
+        LogicalMetric logicalMetric = new LogicalMetric(null, null, filteredMetricName)
 
         Set<ApiFilter> filterSet = [new ApiFilter("age|id-in[114,125]", dimensionDictionary)] as Set
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/FilteredAggregationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/FilteredAggregationSpec.groovy
@@ -83,7 +83,7 @@ class FilteredAggregationSpec extends Specification{
         genderDependentMetricAgg.withName(_) >> genderDependentMetricAgg
         genderDependentMetricAgg.withFieldName(_) >> genderDependentMetricAgg
 
-        LogicalMetric logicalMetric = new LogicalMetric(null, null, filteredMetricName)
+        LogicalMetric logicalMetric = new LogicalMetric(null, null, filteredMetricName, {true})
 
         Set<ApiFilter> filterSet = [new ApiFilter("age|id-in[114,125]", dimensionDictionary)] as Set
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ApiHavingSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ApiHavingSpec.groovy
@@ -16,9 +16,9 @@ class ApiHavingSpec extends Specification {
     LogicalMetric metric3
 
     def setup() {
-        metric1 = new LogicalMetric(null, null, "metric1")
-        metric2 = new LogicalMetric(null, null, "metric2")
-        metric3 = new LogicalMetric(null, null, "metric3")
+        metric1 = new LogicalMetric(null, null, "metric1", {true})
+        metric2 = new LogicalMetric(null, null, "metric2", {true})
+        metric3 = new LogicalMetric(null, null, "metric3", {true})
 
         metricStore = new MetricDictionary()
         metricStore.add(metric1)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestFilterSpec.groovy
@@ -53,7 +53,7 @@ class DataApiRequestFilterSpec extends Specification {
 
         metricDict = new MetricDictionary()
         [ "met1", "met2", "met3", "met4" ].each { String name ->
-            metricDict.put(name, new LogicalMetric(null, null, name))
+            metricDict.put(name, new LogicalMetric(null, null, name, {true}))
         }
         TableGroup tg = Mock(TableGroup)
         tg.getApiMetricNames() >> ([] as Set)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestIntervalsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestIntervalsSpec.groovy
@@ -69,7 +69,7 @@ class DataApiRequestIntervalsSpec extends Specification {
 
         metricDict = new MetricDictionary()
         [ "met1", "met2", "met3", "met4" ].each { String name ->
-            metricDict.put(name, new LogicalMetric(null, null, name))
+            metricDict.put(name, new LogicalMetric(null, null, name, {true}))
         }
         TableGroup tg = Mock(TableGroup)
         tg.getDimensions() >> dimensionDict.apiNameToDimension.values()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestSpec.groovy
@@ -76,7 +76,7 @@ class DataApiRequestSpec extends Specification {
 
         metricDict = new MetricDictionary()
         [ "met1", "met2", "met3", "met4" ].each { String name ->
-            metricDict.put(name, new LogicalMetric(null, null, name))
+            metricDict.put(name, new LogicalMetric(null, null, name, {true}))
         }
         TableGroup tg = Mock(TableGroup)
         tg.getApiMetricNames() >> ([] as Set)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/IntersectionReportingFlagOffSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/IntersectionReportingFlagOffSpec.groovy
@@ -41,7 +41,7 @@ class IntersectionReportingFlagOffSpec extends Specification {
 
         metricDict = new MetricDictionary()
         [ "met1", "met2", "met3", "met4" ].each { String name ->
-            metricDict.put(name, new LogicalMetric(null, null, name))
+            metricDict.put(name, new LogicalMetric(null, null, name, {true}))
         }
         TableGroup tg = Mock(TableGroup)
         tg.getApiMetricNames() >> ([] as Set)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ResponseSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ResponseSpec.groovy
@@ -202,7 +202,7 @@ class ResponseSpec extends Specification {
     ResultSet buildTestResultSet(Map<MetricColumn, Object> metricValues, Set<MetricColumn> requestedMetrics) {
         // Setup logical metrics for the API request mock
         testLogicalMetrics = requestedMetrics.collect {
-            new LogicalMetric(null, null, it.name)
+            new LogicalMetric(null, null, it.name, {true})
         } as Set
 
         apiRequest.getLogicalMetrics() >> { return testLogicalMetrics }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
@@ -164,7 +164,7 @@ class SketchIntersectionReportingResources extends Specification {
 
         LogicalMetric foosMetric = metricDictionary.get(FOOS.asName())
 
-        LogicalMetric ratioMetric = new LogicalMetric(foosMetric.templateDruidQuery, foosMetric.calculation, "ratioMetric", "ratioMetric Long Name", "Ratios", "Dummy metric Ratio Metric description")
+        LogicalMetric ratioMetric = new LogicalMetric(foosMetric.templateDruidQuery, foosMetric.calculation, "ratioMetric", "ratioMetric Long Name", "Ratios", "Dummy metric Ratio Metric description", {true})
         metricDictionary.add(ratioMetric)
 
         LogicalMetricColumn lmc = new LogicalMetricColumn(foosMetric);

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingSpec.groovy
@@ -38,7 +38,7 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When the format of the metric filter is invalid, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN]property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN]property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -48,7 +48,7 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When the API query contains duplicate metrics, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequest().generateLogicalMetrics("foos,foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("foos,foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -57,7 +57,7 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When the queried metric is not present in Metric Dictionary, BadApiRequestException is thrown"() {
         when:
-        new DataApiRequest().generateLogicalMetrics("dinga", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("dinga", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -66,7 +66,7 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When metric filter contains 'OR' condition, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequest().generateLogicalMetrics("foos(OR(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("foos(OR(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -74,10 +74,10 @@ class SketchIntersectionReportingSpec extends Specification {
     }
 
     def "When the INTERSECTION_REPORTING flag is enabled and the query contains unfiltered metrics, the Logical Metrics returned are equal to the Logical Metrics from the Metric Dictionary"() {
-        Set<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("pageViews,foos", resources.metricDict, resources.dimensionDict, resources.table)
+        Set<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("pageViews,foos", resources.metricDictionary, resources.dimensionDictionary, resources.table)
         HashSet<Dimension> expected =
                 ["pageViews", "foos"].collect { String name ->
-                    LogicalMetric metric = resources.metricDict.get(name)
+                    LogicalMetric metric = resources.metricDictionary.get(name)
                     assert metric?.name == name
                     metric
                 }
@@ -88,7 +88,7 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When metric filter contains invalid dimension, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequest().generateLogicalMetrics("foos(AND(country1|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("foos(AND(country1|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -97,9 +97,9 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When filtered metric has no post aggs, the estimate of intersection of its Filtered Aggregators is used as its post agg"(){
         TemplateDruidQuery templateDruidQuery = FieldConverterSupplier.metricsFilterSetBuilder.updateTemplateDruidQuery(
-                resources.metricDict.get("regFoos").templateDruidQuery,
+                resources.metricDictionary.get("regFoos").templateDruidQuery,
                 resources.filterObj,
-                resources.dimensionDict,
+                resources.dimensionDictionary,
                 resources.table,
                 new DataApiRequest()
         )
@@ -111,9 +111,9 @@ class SketchIntersectionReportingSpec extends Specification {
     def "updateTemplateDruidQuery replaces the aggs with filteredAggs and postAggs with intersection or union of its filteredAggs"(){
 
         TemplateDruidQuery templateDruidQuery = FieldConverterSupplier.metricsFilterSetBuilder.updateTemplateDruidQuery(
-                resources.metricDict.get("foos").templateDruidQuery,
+                resources.metricDictionary.get("foos").templateDruidQuery,
                 resources.filterObj,
-                resources.dimensionDict,
+                resources.dimensionDictionary,
                 resources.table,
                 new DataApiRequest()
         )
@@ -155,7 +155,7 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When invalid(non-sketch) metric is used for filtering, IllegalArgumentException is thrown "(){
         when:
-        new DataApiRequest().generateLogicalMetrics("pageViews(AND(country|id-in[US,IN],property|id-in[news,sports]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("pageViews(AND(country|id-in[US,IN],property|id-in[news,sports]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(IllegalArgumentException)
@@ -163,11 +163,11 @@ class SketchIntersectionReportingSpec extends Specification {
     }
 
     def "When API request contains filtered metrics, the Logical Metric returned by generateLogicalMetrics is filtered and therefore not equal to the Logical Metric from the Metric dictionary "(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         HashSet<Dimension> expected =
                 ["foos"].collect { String name ->
-                    LogicalMetric metric = resources.metricDict.get(name)
+                    LogicalMetric metric = resources.metricDictionary.get(name)
                     assert metric?.name == name
                     metric
                 }
@@ -177,7 +177,7 @@ class SketchIntersectionReportingSpec extends Specification {
     }
 
     def "An exception is thrown when validateMetrics is passed an intersection expression using invalid metrics"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("regFoos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("regFoos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         when:
         new DataApiRequest().validateMetrics(logicalMetrics,resources.table)
@@ -190,7 +190,7 @@ class SketchIntersectionReportingSpec extends Specification {
     }
 
     def "No exception is thrown when validateMetrics is passed an intersection expression using valid metrics"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         when:
         new DataApiRequest().validateMetrics(logicalMetrics, resources.table)
@@ -200,7 +200,7 @@ class SketchIntersectionReportingSpec extends Specification {
     }
 
     def "The dimensions returned from the filtered logical metric are correct"() {
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         expect:
         logicalMetrics.first().templateDruidQuery.metricDimensions.sort() == [resources.propertyDim, resources.countryDim].sort()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchNestedQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchNestedQuerySpec.groovy
@@ -74,7 +74,7 @@ class SketchNestedQuerySpec extends Specification {
     }
 
     def "Intersection reporting when Logical Metric has nested query"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
         TemplateDruidQuery nestedQuery = logicalMetrics.first().getTemplateDruidQuery().getInnerQuery()
 
         Set<Aggregation> expectedNestedAggs = new HashSet<>()
@@ -98,7 +98,7 @@ class SketchNestedQuerySpec extends Specification {
     }
 
     def "metric filter on viz metric and expect children of unRegFoos have right sketch operation function"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("viz(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("viz(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
         ArithmeticPostAggregation postAggregation = logicalMetrics.first().templateDruidQuery.getPostAggregations().first()
 
         FuzzySetPostAggregation unRegFoo1;
@@ -117,7 +117,7 @@ class SketchNestedQuerySpec extends Specification {
 
     def "When metrics of Ratio category are filtered, BadApiException is thrown"() {
         when:
-        new DataApiRequest().generateLogicalMetrics("ratioMetric(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("ratioMetric(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -125,7 +125,7 @@ class SketchNestedQuerySpec extends Specification {
     }
 
     def "The dimensions returned from the filtered nested logical metric are correct"() {
-        LinkedHashSet<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         expect:
         logicalMetrics.first().templateDruidQuery.getMetricDimensions().sort() == [resources.propertyDim, resources.countryDim].sort()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
@@ -51,8 +51,8 @@ import spock.lang.Specification
  * This class is a resource container for intersection report tests.
  */
 class ThetaSketchIntersectionReportingResources extends Specification {
-    public DimensionDictionary dimensionDict
-    public MetricDictionary metricDict
+    public DimensionDictionary dimensionDictionary
+    public MetricDictionary metricDictionary
     public LogicalTable table
     public JSONObject filterObj
     public PostAggregation fooPostAggregation;
@@ -66,6 +66,18 @@ class ThetaSketchIntersectionReportingResources extends Specification {
     public TemplateDruidQuery dayAvgFoosTdq
     public Dimension propertyDim
     public Dimension countryDim
+
+    public static final ApiMetricName PAGE_VIEWS = ApiMetricName.of("pageViews")
+    public static final ApiMetricName FOO_NO_BAR = ApiMetricName.of("fooNoBar")
+    public static final ApiMetricName FOOS = ApiMetricName.of("foos")
+    public static final ApiMetricName FOO = ApiMetricName.of("foo")
+    public static final ApiMetricName REG_FOOS = ApiMetricName.of("regFoos")
+    public static final ApiMetricName DAY_AVG_FOOS = ApiMetricName.of("dayAvgFoos")
+    public static final ApiMetricName UNREG_FOOS = ApiMetricName.of("unregFoos")
+    public static final ApiMetricName WIZ = ApiMetricName.of("wiz")
+    public static final ApiMetricName WAZ = ApiMetricName.of("waz")
+    public static final ApiMetricName VIZ = ApiMetricName.of("viz")
+    public static final ApiMetricName RATIO_METRIC = ApiMetricName.of("ratioMetric")
 
     ThetaSketchIntersectionReportingResources init() {
         LinkedHashSet<DimensionField> dimensionFields = new LinkedHashSet<>()
@@ -99,10 +111,10 @@ class ThetaSketchIntersectionReportingResources extends Specification {
         countryDim.addDimensionRow(BardDimensionField.makeDimensionRow(countryDim, "IN"))
 
 
-        dimensionDict = new DimensionDictionary()
-        dimensionDict.addAll([propertyDim, countryDim])
+        dimensionDictionary = new DimensionDictionary()
+        dimensionDictionary.addAll([propertyDim, countryDim])
         //Reg foos omitted to make invalid on table
-        Set<ApiMetricName> metrics = [buildMockName("foos"), buildMockName("fooNoBar"), buildMockName("pageViews"), buildMockName("foo"), buildMockName("wiz"), buildMockName("waz"), buildMockName("viz"), buildMockName("unregFoos"), buildMockName("ratioMetric")]
+        Set<ApiMetricName> metrics = [FOOS, FOO_NO_BAR, PAGE_VIEWS, FOO, WIZ, WAZ, VIZ, UNREG_FOOS, RATIO_METRIC]
 
         Set<Column> columns = (Set<? extends Column>) (metrics.collect {
             new MetricColumn(it.apiName)
@@ -112,44 +124,44 @@ class ThetaSketchIntersectionReportingResources extends Specification {
         columns.add(new DimensionColumn(countryDim))
 
 
-        metricDict = new MetricDictionary()
+        metricDictionary = new MetricDictionary()
 
         ThetaSketchSetOperationMaker setUnionMaker = new ThetaSketchSetOperationMaker(
-                metricDict,
+                metricDictionary,
                 SketchSetOperationPostAggFunction.UNION
         )
         ThetaSketchMaker ThetaSketchMaker = new ThetaSketchMaker(new MetricDictionary(), 16384)
-        ArithmeticMaker sumMaker = new ArithmeticMaker(metricDict, ArithmeticPostAggregation.ArithmeticPostAggregationFunction.PLUS);
-        ThetaSketchSetOperationMaker setDifferenceMaker = new ThetaSketchSetOperationMaker(metricDict, SketchSetOperationPostAggFunction.NOT);
-        AggregationAverageMaker simpleDailyAverageMaker = new AggregationAverageMaker(metricDict, DAY)
+        ArithmeticMaker sumMaker = new ArithmeticMaker(metricDictionary, ArithmeticPostAggregation.ArithmeticPostAggregationFunction.PLUS);
+        ThetaSketchSetOperationMaker setDifferenceMaker = new ThetaSketchSetOperationMaker(metricDictionary, SketchSetOperationPostAggFunction.NOT);
+        AggregationAverageMaker simpleDailyAverageMaker = new AggregationAverageMaker(metricDictionary, DAY)
 
-        MetricInstance pageViews = new MetricInstance("pageViews", new LongSumMaker(metricDict), "pageViews")
-        MetricInstance fooNoBarInstance = new MetricInstance("fooNoBar", ThetaSketchMaker, "fooNoBar")
-        MetricInstance regFoosInstance = new MetricInstance("regFoos", ThetaSketchMaker, "regFoos")
-        MetricInstance foos = new MetricInstance("foos", setUnionMaker, "fooNoBar", "regFoos")
-        MetricInstance dayAvgFoos = new MetricInstance("dayAvgFoos", simpleDailyAverageMaker, "foos")
+        MetricInstance pageViews = new MetricInstance(PAGE_VIEWS, new LongSumMaker(metricDictionary), PAGE_VIEWS)
+        MetricInstance fooNoBarInstance = new MetricInstance(FOO_NO_BAR, ThetaSketchMaker, FOO_NO_BAR)
+        MetricInstance regFoosInstance = new MetricInstance(REG_FOOS, ThetaSketchMaker, REG_FOOS)
+        MetricInstance foos = new MetricInstance(FOOS, setUnionMaker, FOO_NO_BAR, REG_FOOS)
+        MetricInstance dayAvgFoos = new MetricInstance(DAY_AVG_FOOS, simpleDailyAverageMaker, FOOS)
 
-        MetricInstance foo = new MetricInstance("foo", ThetaSketchMaker, "foo")
-        MetricInstance wiz = new MetricInstance("wiz", ThetaSketchMaker, "wiz")
-        MetricInstance waz = new MetricInstance("waz", sumMaker, "foo", "wiz")
-        MetricInstance unregFoos = new MetricInstance("unregFoos", setDifferenceMaker, "fooNoBar", "regFoos")
-        MetricInstance viz = new MetricInstance("viz", sumMaker, "waz", "unregFoos")
+        MetricInstance foo = new MetricInstance(FOO, ThetaSketchMaker, FOO)
+        MetricInstance wiz = new MetricInstance(WIZ, ThetaSketchMaker, WIZ)
+        MetricInstance waz = new MetricInstance(WAZ, sumMaker, FOO, WIZ)
+        MetricInstance unregFoos = new MetricInstance(UNREG_FOOS, setDifferenceMaker, FOO_NO_BAR, REG_FOOS)
+        MetricInstance viz = new MetricInstance(VIZ, sumMaker, WAZ, UNREG_FOOS)
 
-        metricDict.add(pageViews.make())
-        metricDict.add(fooNoBarInstance.make())
-        metricDict.add(regFoosInstance.make())
-        metricDict.add(foos.make())
-        metricDict.add(dayAvgFoos.make())
+        metricDictionary.add(pageViews.make())
+        metricDictionary.add(fooNoBarInstance.make())
+        metricDictionary.add(regFoosInstance.make())
+        metricDictionary.add(foos.make())
+        metricDictionary.add(dayAvgFoos.make())
 
-        metricDict.add(foo.make())
-        metricDict.add(wiz.make())
-        metricDict.add(waz.make())
-        metricDict.add(unregFoos.make())
-        metricDict.add(viz.make())
+        metricDictionary.add(foo.make())
+        metricDictionary.add(wiz.make())
+        metricDictionary.add(waz.make())
+        metricDictionary.add(unregFoos.make())
+        metricDictionary.add(viz.make())
 
-        LogicalMetric foosMetric = metricDict.get("foos")
+        LogicalMetric foosMetric = metricDictionary.get(FOOS.asName())
         LogicalMetric ratioMetric = new LogicalMetric(foosMetric.templateDruidQuery, foosMetric.calculation, "ratioMetric", "ratioMetric Long Name", "Ratios", "Dummy metric Ratio Metric description")
-        metricDict.add(ratioMetric)
+        metricDictionary.add(ratioMetric)
 
         LogicalMetricColumn lmc = new LogicalMetricColumn(foosMetric);
 
@@ -165,7 +177,7 @@ class ThetaSketchIntersectionReportingResources extends Specification {
 
         TableGroup tableGroup = new TableGroup([physicalTable] as LinkedHashSet, metrics)
 
-        table = new LogicalTable("NETWORK", DAY, tableGroup, metricDict)
+        table = new LogicalTable("NETWORK", DAY, tableGroup, metricDictionary)
 
         JSONArray metricJsonObjArray = new JSONArray("[{\"filter\":{\"AND\":\"country|id-in[US,IN],property|id-in[114,125]\"},\"name\":\"foo\"},{\"filter\":{},\"name\":\"pageviews\"}]")
         JSONObject jsonobject = metricJsonObjArray.getJSONObject(0)
@@ -178,10 +190,10 @@ class ThetaSketchIntersectionReportingResources extends Specification {
         fooNoBarAggregation = fooNoBarInstance.make().templateDruidQuery.aggregations.first()
         Aggregation regFoosAggregation = regFoosInstance.make().templateDruidQuery.aggregations.first()
 
-        fooNoBarFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(filterObj, fooNoBarAggregation, dimensionDict, table, new DataApiRequest())
+        fooNoBarFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(filterObj, fooNoBarAggregation, dimensionDictionary, table, new DataApiRequest())
         fooNoBarPostAggregationInterim = ThetaSketchSetOperationHelper.makePostAggFromAgg(SketchSetOperationPostAggFunction.INTERSECT, "fooNoBar", new ArrayList<>(fooNoBarFilteredAggregationSet))
 
-        fooRegFoosFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(filterObj, regFoosAggregation, dimensionDict, table, new DataApiRequest())
+        fooRegFoosFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(filterObj, regFoosAggregation, dimensionDictionary, table, new DataApiRequest())
         fooRegFoosPostAggregationInterim = ThetaSketchSetOperationHelper.makePostAggFromAgg(SketchSetOperationPostAggFunction.INTERSECT, "regFoos", new ArrayList<>(fooRegFoosFilteredAggregationSet))
 
         interimPostAggDictionary = [:]
@@ -189,9 +201,5 @@ class ThetaSketchIntersectionReportingResources extends Specification {
         interimPostAggDictionary.put(regFoosAggregation.getName(), fooRegFoosFilteredAggregationSet as List)
 
         return this
-    }
-
-    ApiMetricName buildMockName(String name) {
-        return ApiMetricName.of(name)
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
@@ -160,7 +160,7 @@ class ThetaSketchIntersectionReportingResources extends Specification {
         metricDictionary.add(viz.make())
 
         LogicalMetric foosMetric = metricDictionary.get(FOOS.asName())
-        LogicalMetric ratioMetric = new LogicalMetric(foosMetric.templateDruidQuery, foosMetric.calculation, "ratioMetric", "ratioMetric Long Name", "Ratios", "Dummy metric Ratio Metric description")
+        LogicalMetric ratioMetric = new LogicalMetric(foosMetric.templateDruidQuery, foosMetric.calculation, "ratioMetric", "ratioMetric Long Name", "Ratios", "Dummy metric Ratio Metric description", {true})
         metricDictionary.add(ratioMetric)
 
         LogicalMetricColumn lmc = new LogicalMetricColumn(foosMetric);

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingSpec.groovy
@@ -34,7 +34,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When the format of the metric filter is invalid, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN]property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN]property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -44,7 +44,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When the API query contains duplicate metrics, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequest().generateLogicalMetrics("foos,foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("foos,foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -53,7 +53,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When the queried metric is not present in Metric Dictionary, BadApiRequestException is thrown"() {
         when:
-        new DataApiRequest().generateLogicalMetrics("dinga", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("dinga", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -62,7 +62,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When metric filter contains 'OR' condition, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequest().generateLogicalMetrics("foos(OR(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("foos(OR(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -70,10 +70,10 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     }
 
     def "When the INTERSECTION_REPORTING flag is enabled and the query contains unfiltered metrics, the Logical Metrics returned are equal to the Logical Metrics from the Metric Dictionary"() {
-        Set<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("pageViews,foos", resources.metricDict, resources.dimensionDict, resources.table)
+        Set<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("pageViews,foos", resources.metricDictionary, resources.dimensionDictionary, resources.table)
         HashSet<Dimension> expected =
                 ["pageViews", "foos"].collect { String name ->
-                    LogicalMetric metric = resources.metricDict.get(name)
+                    LogicalMetric metric = resources.metricDictionary.get(name)
                     assert metric?.name == name
                     metric
                 }
@@ -84,7 +84,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When metric filter contains invalid dimension, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequest().generateLogicalMetrics("foos(AND(country1|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("foos(AND(country1|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -93,9 +93,9 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When filtered metric has no post aggs, the estimate of intersection of its Filtered Aggregators is used as its post agg"(){
         TemplateDruidQuery templateDruidQuery = FieldConverterSupplier.metricsFilterSetBuilder.updateTemplateDruidQuery(
-                resources.metricDict.get("regFoos").templateDruidQuery,
+                resources.metricDictionary.get("regFoos").templateDruidQuery,
                 resources.filterObj,
-                resources.dimensionDict,
+                resources.dimensionDictionary,
                 resources.table,
                 new DataApiRequest()
         )
@@ -107,9 +107,9 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     def "updateTemplateDruidQuery replaces the aggs with filteredAggs and postAggs with intersection or union of its filteredAggs"(){
 
         TemplateDruidQuery templateDruidQuery = FieldConverterSupplier.metricsFilterSetBuilder.updateTemplateDruidQuery(
-                resources.metricDict.get("foos").templateDruidQuery,
+                resources.metricDictionary.get("foos").templateDruidQuery,
                 resources.filterObj,
-                resources.dimensionDict,
+                resources.dimensionDictionary,
                 resources.table,
                 new DataApiRequest()
         )
@@ -151,7 +151,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When invalid(non-sketch) metric is used for filtering, IllegalArgumentException is thrown "(){
         when:
-        new DataApiRequest().generateLogicalMetrics("pageViews(AND(country|id-in[US,IN],property|id-in[news,sports]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("pageViews(AND(country|id-in[US,IN],property|id-in[news,sports]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(IllegalArgumentException)
@@ -159,11 +159,11 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     }
 
     def "When API request contains filtered metrics, the Logical Metric returned by generateLogicalMetrics is filtered and therefore not equal to the Logical Metric from the Metric dictionary "(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         HashSet<Dimension> expected =
                 ["foos"].collect { String name ->
-                    LogicalMetric metric = resources.metricDict.get(name)
+                    LogicalMetric metric = resources.metricDictionary.get(name)
                     assert metric?.name == name
                     metric
                 }
@@ -173,7 +173,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     }
 
     def "An exception is thrown when validateMetrics is passed an intersection expression using invalid metrics"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("regFoos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("regFoos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         when:
         new DataApiRequest().validateMetrics(logicalMetrics, resources.table)
@@ -186,7 +186,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     }
 
     def "No exception is thrown when validateMetrics is passed an intersection expression using valid metrics"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         when:
         new DataApiRequest().validateMetrics(logicalMetrics, resources.table)
@@ -196,7 +196,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     }
 
     def "The dimensions returned from the filtered logical metric are correct"() {
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         expect:
         logicalMetrics.first().templateDruidQuery.metricDimensions.sort() == [resources.propertyDim, resources.countryDim].sort()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchNestedQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchNestedQuerySpec.groovy
@@ -69,7 +69,7 @@ class ThetaSketchNestedQuerySpec extends Specification {
     }
 
     def "Intersection reporting when Logical Metric has nested query"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequest().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
         TemplateDruidQuery nestedQuery = logicalMetrics.first().templateDruidQuery.innerQuery
 
         Set<Aggregation> expectedNestedAggs = new HashSet<>()
@@ -93,7 +93,7 @@ class ThetaSketchNestedQuerySpec extends Specification {
     }
 
     def "metric filter on viz metric and expect children of unRegFoos have right sketch operation function"() {
-        LinkedHashSet<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("viz(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("viz(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
         ArithmeticPostAggregation postAggregation = logicalMetrics.first().templateDruidQuery.postAggregations.first()
 
         FuzzySetPostAggregation unRegFoo1;
@@ -113,7 +113,7 @@ class ThetaSketchNestedQuerySpec extends Specification {
 
     def "When metrics of Ratio category are filtered, BadApiException is thrown"() {
         when:
-        new DataApiRequest().generateLogicalMetrics("ratioMetric(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new DataApiRequest().generateLogicalMetrics("ratioMetric(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -121,7 +121,7 @@ class ThetaSketchNestedQuerySpec extends Specification {
     }
 
     def "The dimensions returned from the filtered nested logical metric are correct"() {
-        LinkedHashSet<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics = new DataApiRequest().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDictionary, resources.dimensionDictionary, resources.table)
 
         expect:
         logicalMetrics.first().templateDruidQuery.metricDimensions.sort() == [resources.propertyDim, resources.countryDim].sort()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/MetricsServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/MetricsServletSpec.groovy
@@ -29,7 +29,7 @@ class MetricsServletSpec extends Specification {
         //Rather than use the default TestMetricLoader data, throw it out and load a simpler data set
         jtb.configurationLoader.dictionaries.metricDictionary.clearLocal()
         ["metricA", "metricB", "metricC"].each { String metricName ->
-            jtb.configurationLoader.metricDictionary.put(metricName, new LogicalMetric(null, mapper, metricName))
+            jtb.configurationLoader.metricDictionary.put(metricName, new LogicalMetric(null, mapper, metricName, {true}))
         }
     }
 

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/metric/NonNumericMetrics.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/metric/NonNumericMetrics.java
@@ -50,7 +50,8 @@ public class NonNumericMetrics {
                     ),
                     new StringMetricMapper(),
                     A_STRING_METRIC.getApiName(),
-                    "ImAStringISwear"
+                    "ImAStringISwear",
+                    (ignored) -> true
             ),
             new LogicalMetric(
                     new TemplateDruidQuery(
@@ -59,7 +60,9 @@ public class NonNumericMetrics {
                     ),
                     new BooleanMetricMapper(),
                     A_BOOLEAN_METRIC.getApiName(),
-                    "ImBooleanISwear"
+                    "ImBooleanISwear",
+                    (ignored) -> true
+
             ),
             new LogicalMetric(
                     new TemplateDruidQuery(
@@ -70,7 +73,9 @@ public class NonNumericMetrics {
                     ),
                     new JsonNodeMetricMapper(),
                     A_JSON_NODE_METRIC.getApiName(),
-                    "ImAJsonNodeISwear"
+                    "ImAJsonNodeISwear",
+                    (ignored) -> true
+
             ),
             new LogicalMetric(
                     new TemplateDruidQuery(
@@ -79,7 +84,8 @@ public class NonNumericMetrics {
                     ),
                     new NullMetricMapper(),
                     A_NULL_METRIC.getApiName(),
-                    "ImNullISwear"
+                    "ImNullISwear",
+                    (ignored) -> true
             )
         );
     }


### PR DESCRIPTION
This is motivated by the desire to make embedding metric dependencies into metrics more ubiquitous.
Right now metrics don't retain their dependent metrics which makes it impossible to understand how they were created and to regenerate them with modifications based on their initialization state.