### PR TITLE
Expose the durations stored in the RequestLog.

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -127,7 +127,6 @@ public class RequestLog {
         MDC.put(ID_KEY, logId);
     }
 
-
     /**
      * Get the aggregate durations for this request.
      *
@@ -146,7 +145,6 @@ public class RequestLog {
     private Map<String, Long> durations() {
         return times.values().stream().collect(Collectors.toMap(TimedPhase::getName, TimedPhase::getDuration));
     }
-
 
     /**
      * Get the aggregate durations for this request.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -130,7 +130,7 @@ public class RequestLog {
     /**
      * Get the aggregate durations for this request.
      *
-     * @return A map of phase -> duration (ns)
+     * @return A map of phase to duration (ns)
      */
     public static Map<String, Long> getDurations() {
         RequestLog log = RLOG.get();
@@ -149,7 +149,7 @@ public class RequestLog {
     /**
      * Get the aggregate durations for this request.
      *
-     * @return A map of phase -> duration (ms)
+     * @return A map of phase to duration (ms)
      */
     public static Map<String, Float> getAggregateDurations() {
         return RLOG.get().aggregateDurations();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -127,13 +127,34 @@ public class RequestLog {
         MDC.put(ID_KEY, logId);
     }
 
+
+    /**
+     * Get the aggregate durations for this request.
+     *
+     * @return A map of phase -> duration (ns)
+     */
+    public static Map<String, Long> getDurations() {
+        RequestLog log = RLOG.get();
+        return log.durations();
+    }
+
     /**
      * Adds the durations in milliseconds of all the recorded timed phases to a map.
      *
      * @return the map containing all the recorded times per phase in milliseconds
      */
-    private Map<String, Long> getDurations() {
+    private Map<String, Long> durations() {
         return times.values().stream().collect(Collectors.toMap(TimedPhase::getName, TimedPhase::getDuration));
+    }
+
+
+    /**
+     * Get the aggregate durations for this request.
+     *
+     * @return A map of phase -> duration (ms)
+     */
+    public static Map<String, Float> getAggregateDurations() {
+        return RLOG.get().aggregateDurations();
     }
 
     /**
@@ -142,7 +163,7 @@ public class RequestLog {
      * @return the map containing all the recorded times per phase in milliseconds
      */
     private Map<String, Float> aggregateDurations() {
-        Map<String, Long> durations = getDurations();
+        Map<String, Long> durations = durations();
 
         OptionalLong max = durations.entrySet()
                 .stream()
@@ -166,15 +187,14 @@ public class RequestLog {
      *
      * @param caller  the caller to name this stopwatch with its class's simple name
      *
-     * @return whether this stopwatch is started
+     * @return whether this stopwatch is currently running
      */
-
     public static boolean isRunning(Object caller) {
         return isRunning(caller.getClass().getSimpleName());
     }
 
     /**
-     * Check if a stopwatch is started.
+     * Check if a stopwatch is currently running.
      *
      * @param timePhaseName  the name of this stopwatch
      *


### PR DESCRIPTION
--Some customers may have their own custom logging format that differs
significantly from how the `BardLoggingFilter` logs the `RequestLog`.
However, they may still want access to the many timings that the
`RequestLog` tracks.

The ideal solution is to rearchitect the
`RequestLog` to make it easy to replace with a custom logging scheme
and/or make it truly a-la carte. However, as a stopgap, simply
providing a means of getting at the durations is sufficient.