### PR TITLE
Refactor PhysicalTableDefinition and Update BaseTableLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ Current
     * `PhysicalTableDefinition` now requires a `build` methods to be implemented that builds a physical table
     * `BaseTableLoader` now constructs physical tables by calling `build` method on `PhysicalTableDefinition`s in `buildPhysicalTablesWithDependency`
     * `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now uses `loadPhysicalTablesWithDependency` instead of removed `loadPhysicalTables`
-    * `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now does not take druid metric as arguments, instead `PhysicalTableDefinition` does
+    * `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now does not take druid metrics as arguments, instead `PhysicalTableDefinition` does
 
 - [Fix to use physical name instead of logical name to retrieve available interval](https://github.com/yahoo/fili/pull/226)
     * `getAllAvailbleIntervals` in `ConcreteAvailability` no longer filters out un-configured columns, instead table's `getAllAvailbleIntervals` does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Current
 - [CompositePhysicalTable Core Components Refactor](https://github.com/yahoo/fili/pull/179)
     * Added `ConcretePhysicalTable` and `ConcreteAvailability` to model table in druid datasource and its availabillity in the new table availability structure
     * Added class variable for `DataSourceMetadataService` and `ConfigurationLoader` into `AbstractBinderFactory` for application to access
+    * Added `loadPhsycialTablesWithDependency` into `BaseTableLoader` to load physical tables with dependencies
 
 - [PermissiveAvailability and PermissiveConcretePhysicalTable](https://github.com/yahoo/fili/pull/190)
     * Added `PermissiveConcretePhysicalTable` and `PermissiveAvailability` to model table in druid datasource and its availability in the new table availability structure.
@@ -79,6 +80,13 @@ Current
 - [Support timeouts for lucene search provider](https://github.com/yahoo/fili/pull/183)
 
 ### Changed:
+
+- [Refactor Physical Table Definition and Update Table Loader](https://github.com/yahoo/fili/pull/207)
+    * `PhysicalTableDefinition` is now an abstract class, construct using `ConcretePhysicalTableDefinition` instead
+    * `PhysicalTableDefinition` now requires a `build` methods to be implemented that builds a physical table
+    * `BaseTableLoader` now constructs physical tables by calling `build` method on `PhysicalTableDefinition`s in `buildPhysicalTablesWithDependency`
+    * `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now uses `loadPhysicalTablesWithDependency` instead of removed `loadPhysicalTables`
+    * `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now does not take druid metric as arguments, instead `PhysicalTableDefinition` does
 
 - [Fix to use physical name instead of logical name to retrieve available interval](https://github.com/yahoo/fili/pull/226)
     * `getAllAvailbleIntervals` in `ConcreteAvailability` no longer filters out un-configured columns, instead table's `getAllAvailbleIntervals` does
@@ -151,6 +159,7 @@ Current
 - [CompositePhsyicalTable Core Components Refactor](https://github.com/yahoo/fili/pull/179)
     * `TableLoader` now takes an additional constructor argument `DataSourceMetadataService` for creating tables     
     * `findMissingRequestTimeGrainIntervals` method in `PartialDataHandler` now takes `DataSourceConstraint`
+    * Renamed `buildTableGroup` method to `buildDimensionSpanningTableGroup`
  
 - [Restored flexibility about columns for query from DruidResponseParser](https://github.com/yahoo/fili/pull/198)
     * Immutable schemas prevented custom query types from changing `ResultSetSchema` columns.
@@ -257,6 +266,12 @@ Current
 
 
 ### Removed:
+
+- [Refactor Physical Table Definition and Update Table Loader](https://github.com/yahoo/fili/pull/207)
+    * Removed deprecated `PhysicalTableDefinition` constructor that takes an `ZonlessTimeGrain`, use `ZonedTimeGrain` instead
+    * Removed `loadPhysicalTable` in `BaseTableLoader`, use `loadPhysicalTablesWithDependency` instead
+    * Removed `buildPhysicalTable` in `BaseTableLoader`, building table logic is pushed into `PhysicalTableDefinition`
+
 - [CompositePhsyicalTable Core Components Refactor](https://github.com/yahoo/fili/pull/179)
     * Removed deprecated method `findMissingRequestTimeGrainIntervals` from `PartialDataHandler`
     * Removed `permissive_column_availability_enabled` feature flag support and corresponding functionality in `PartialDataHandler`, permissive availability will be a table configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Current
     * `PhysicalTableDefinition` is now an abstract class, construct using `ConcretePhysicalTableDefinition` instead
     * `PhysicalTableDefinition` now requires a `build` methods to be implemented that builds a physical table
     * `BaseTableLoader` now constructs physical tables by calling `build` method on `PhysicalTableDefinition`s in `buildPhysicalTablesWithDependency`
-    * `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now uses `loadPhysicalTablesWithDependency` instead of removed `loadPhysicalTables`
+    * `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now uses `loadPhysicalTablesWithDependency` instead of deprecated `loadPhysicalTables`
     * `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now does not take druid metrics as arguments, instead `PhysicalTableDefinition` does
 
 - [Fix to use physical name instead of logical name to retrieve available interval](https://github.com/yahoo/fili/pull/226)
@@ -223,6 +223,9 @@ Current
 
 ### Deprecated:
 
+- [Refactor Physical Table Definition and Update Table Loader](https://github.com/yahoo/fili/pull/207)
+    * Deprecated `loadPhysicalTable` in `BaseTableLoader`, use `loadPhysicalTablesWithDependency` instead
+
 - [CompositePhsyicalTable Core Components Refactor](https://github.com/yahoo/fili/pull/179)
     * Deprecated `setAvailability` method on `BasePhysicalTable` to discourage using it for testing, should refine testing strategy to avoid it
 
@@ -269,7 +272,6 @@ Current
 
 - [Refactor Physical Table Definition and Update Table Loader](https://github.com/yahoo/fili/pull/207)
     * Removed deprecated `PhysicalTableDefinition` constructor that takes an `ZonlessTimeGrain`, use `ZonedTimeGrain` instead
-    * Removed `loadPhysicalTable` in `BaseTableLoader`, use `loadPhysicalTablesWithDependency` instead
     * Removed `buildPhysicalTable` in `BaseTableLoader`, building table logic is pushed into `PhysicalTableDefinition`
 
 - [CompositePhsyicalTable Core Components Refactor](https://github.com/yahoo/fili/pull/179)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
@@ -177,7 +177,7 @@ public abstract class BaseTableLoader implements TableLoader {
      * <p>
      * note: current physical table not loaded into physical table dictionary, only dependencies will
      *
-     * @param currentTableName  Iterator for the mutable definition
+     * @param currentTableName  Table name of the table being built
      * @param availableTableDefinitions  A map of table name to table definition that are available globally
      * @param dictionaries  Contains both dimension and physical table dictionary for building and dependency resolution
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
@@ -252,7 +252,7 @@ public abstract class BaseTableLoader implements TableLoader {
      *
      * @return The physical table created
      *
-     * @deprecated use buildPhysicalTableWithDependency instead, which supports building table with dependencies
+     * @deprecated use buildPhysicalTableWithDependency instead, which also supports building table with dependencies
      */
     @Deprecated
     protected PhysicalTable loadPhysicalTable(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
@@ -1,0 +1,60 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.table;
+
+import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.names.FieldName;
+import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
+import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
+import com.yahoo.bard.webservice.table.ConcretePhysicalTable;
+import com.yahoo.bard.webservice.table.PhysicalTable;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Holds the fields needed to define a Concrete Physical Table.
+ */
+public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
+
+    /**
+     * Define a physical table using a zoned time grain.
+     *
+     * @param name  The table name
+     * @param timeGrain  The zoned time grain
+     * @param metricNames  The Set of metric names on the table
+     * @param dimensionConfigs  The dimension configurations
+     */
+    public ConcretePhysicalTableDefinition(
+            TableName name,
+            ZonedTimeGrain timeGrain,
+            Set<FieldName> metricNames,
+            Set<? extends DimensionConfig> dimensionConfigs
+    ) {
+        super(name, timeGrain, metricNames, dimensionConfigs);
+    }
+
+    @Override
+    public Set<TableName> getDependentTableNames() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Optional<PhysicalTable> build(
+            ResourceDictionaries dictionaries,
+            DataSourceMetadataService metadataService
+    ) {
+        return Optional.of(
+                new ConcretePhysicalTable(
+                        getName(),
+                        getTimeGrain(),
+                        buildColumns(dictionaries.getDimensionDictionary()),
+                        getLogicalToPhysicalNames(),
+                        metadataService
+                )
+        );
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
@@ -12,7 +12,7 @@ import com.yahoo.bard.webservice.table.ConcretePhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 
 import java.util.Collections;
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -37,24 +37,39 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
         super(name, timeGrain, metricNames, dimensionConfigs);
     }
 
+    /**
+     * Define a physical table with provided logical to physical column name mappings.
+     *
+     * @param name  The table name
+     * @param timeGrain  The zoned time grain
+     * @param metricNames  The Set of metric names on the table
+     * @param dimensionConfigs  The dimension configurations
+     * @param logicalToPhysicalNames  A map from logical column names to physical column names
+     */
+    public ConcretePhysicalTableDefinition(
+            TableName name,
+            ZonedTimeGrain timeGrain,
+            Set<FieldName> metricNames,
+            Set<? extends DimensionConfig> dimensionConfigs,
+            Map<String, String> logicalToPhysicalNames
+
+    ) {
+        super(name, timeGrain, metricNames, dimensionConfigs, logicalToPhysicalNames);
+    }
+
     @Override
     public Set<TableName> getDependentTableNames() {
         return Collections.emptySet();
     }
 
     @Override
-    public Optional<PhysicalTable> build(
-            ResourceDictionaries dictionaries,
-            DataSourceMetadataService metadataService
-    ) {
-        return Optional.of(
-                new ConcretePhysicalTable(
+    public PhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
+        return new ConcretePhysicalTable(
                         getName(),
                         getTimeGrain(),
                         buildColumns(dictionaries.getDimensionDictionary()),
                         getLogicalToPhysicalNames(),
                         metadataService
-                )
-        );
+                );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
@@ -1,93 +1,144 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.table;
 
+import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
 import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.names.FieldName;
 import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.dimension.DimensionColumn;
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
-import com.yahoo.bard.webservice.data.time.ZonelessTimeGrain;
+import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
+import com.yahoo.bard.webservice.table.Column;
+import com.yahoo.bard.webservice.table.PhysicalTable;
 
-import com.google.common.collect.ImmutableSet;
-
-import org.joda.time.DateTimeZone;
+import avro.shaded.com.google.common.collect.ImmutableSet;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * Holds the fields needed to define a Physical Table.
+ * Common configurations necessary to build a physical table.
  */
-public class PhysicalTableDefinition {
+public abstract class PhysicalTableDefinition {
+
     private final TableName name;
-    private final ZonedTimeGrain grain;
-    private final ImmutableSet<? extends DimensionConfig> dimensions;
+    private final ZonedTimeGrain timeGrain;
+    private final Set<FieldName> metricNames;
+    private final Set<? extends DimensionConfig> dimensionConfigs;
     private final Map<String, String> logicalToPhysicalNames;
 
     /**
-     * Define a physical table using a zoned time grain.
+     * Constructor for sub-class to call.
      *
-     * @param name  The table name
-     * @param grain  The zoned time grain
-     * @param dimensions  The dimension configurations
+     * @param name  Table name of the physical table
+     * @param timeGrain  Zoned time grain of the table
+     * @param metricNames  The Set of metric names on the table
+     * @param dimensionConfigs  Set of dimensions on the table as dimension configs
      */
-    public PhysicalTableDefinition(
+    protected PhysicalTableDefinition(
             TableName name,
-            ZonedTimeGrain grain,
-            Iterable<? extends DimensionConfig> dimensions
+            ZonedTimeGrain timeGrain,
+            Set<FieldName> metricNames,
+            Set<? extends DimensionConfig> dimensionConfigs
     ) {
         this.name = name;
-        this.grain = grain;
-        this.dimensions = ImmutableSet.copyOf(dimensions);
-        this.logicalToPhysicalNames = Collections.unmodifiableMap(
-                this.dimensions.stream()
-                        .collect(
-                                Collectors.toMap(
-                                        DimensionConfig::getApiName,
-                                        dim -> {
-                                            String physicalName = dim.getPhysicalName();
-                                            if (physicalName == null) {
-                                                throw new RuntimeException("No physical name found for dimension: "
-                                                        + dim.getApiName());
-                                            }
-                                            return physicalName;
-                                        }
-                                )
-                        )
-        );
+        this.timeGrain = timeGrain;
+        this.metricNames = ImmutableSet.copyOf(metricNames);
+        this.dimensionConfigs = ImmutableSet.copyOf(dimensionConfigs);
+        this.logicalToPhysicalNames = Collections.unmodifiableMap(buildLogicalToPhysicalNames(dimensionConfigs));
     }
 
     /**
-     * Define a physical table using a zoneless time grain, defaulting it to UTC.
+     * Get the set of physical tables required to build the current physical table.
      *
-     * @param name  The table name
-     * @param grain  The zoneless time grain
-     * @param dimensions  The dimension configurations
-     *
-     * @deprecated The time zone of a physical table should be set explicitly rather than rely on defaulting to UTC
+     * @return a set of physical table names
      */
-    @Deprecated
-    public PhysicalTableDefinition(
-            TableName name,
-            ZonelessTimeGrain grain,
-            Iterable<? extends DimensionConfig> dimensions
-    ) {
-        this(name, grain.buildZonedTimeGrain(DateTimeZone.UTC), dimensions);
-    }
+    public abstract Set<TableName> getDependentTableNames();
+
+    /**
+     * Given a set of metric names and a data source metadata service, build the corresponding physical table.
+     *
+     * @param dictionaries  Dictionary containing dimension dictionary and physical table dictionary
+     * @param metadataService  Service containing column available interval information
+     *
+     * @return optional of the corresponding type of physical table, empty optional if could not be build.
+     */
+    public abstract Optional<PhysicalTable> build(
+            ResourceDictionaries dictionaries,
+            DataSourceMetadataService metadataService
+    );
 
     public TableName getName() {
         return name;
     }
 
-    public ZonedTimeGrain getGrain() {
-        return grain;
+    public ZonedTimeGrain getTimeGrain() {
+        return timeGrain;
     }
 
-    public ImmutableSet<? extends DimensionConfig> getDimensions() {
-        return dimensions;
+    public Set<FieldName> getMetricNames() {
+        return metricNames;
+    }
+
+    public Set<? extends DimensionConfig> getDimensionConfigs() {
+        return dimensionConfigs;
     }
 
     public Map<String, String> getLogicalToPhysicalNames() {
         return logicalToPhysicalNames;
+    }
+
+    /**
+     * Builds the dimension logical name to physical name mapping from dimension configs.
+     *
+     * @param dimensionConfigs  Dimension config containing both logical and physical names
+     *
+     * @return the dimension logical name to physical name mapping
+     */
+    protected Map<String, String> buildLogicalToPhysicalNames(Set<? extends DimensionConfig> dimensionConfigs) {
+        return dimensionConfigs.stream()
+                .collect(
+                        Collectors.toMap(
+                                DimensionConfig::getApiName,
+                                config -> {
+                                    String physicalName = config.getPhysicalName();
+                                    if (physicalName == null) {
+                                        throw new RuntimeException("No physical name found for dimension: "
+                                                + config.getApiName());
+                                    }
+                                    return physicalName;
+                                }
+                        )
+
+                );
+    }
+
+    /**
+     * Helper method for sub-classes to convert dimension configs into dimension columns and create metric columns.
+     *
+     * @param dimensionDictionary  Dictionary for dimension name to dimension columns
+     *
+     * @return all columns including dimension columns and metric columns
+     */
+    protected Set<Column> buildColumns(DimensionDictionary dimensionDictionary) {
+        return Stream.concat(
+                // Load the dimension columns
+                getDimensionConfigs().stream()
+                        .map(DimensionConfig::getApiName)
+                        .map(dimensionDictionary::findByApiName)
+                        .map(DimensionColumn::new),
+                // And the metric columns
+                getMetricNames().stream()
+                        .map(FieldName::asName)
+                        .map(MetricColumn::new)
+        ).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
@@ -14,7 +14,7 @@ import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.Column;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 
-import avro.shaded.com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -61,7 +61,7 @@ public abstract class BasePhysicalTable implements PhysicalTable {
 
     @Override
     public String getName() {
-        return name.asName();
+        return getTableName().asName();
     }
 
     @Override

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
@@ -1,4 +1,4 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.table
 
@@ -8,31 +8,78 @@ import com.yahoo.bard.webservice.data.config.ResourceDictionaries
 import com.yahoo.bard.webservice.data.config.dimension.TestDimensions
 import com.yahoo.bard.webservice.data.config.names.ApiMetricName
 import com.yahoo.bard.webservice.data.config.names.FieldName
+import com.yahoo.bard.webservice.data.config.names.TableName
 import com.yahoo.bard.webservice.data.config.names.TestApiDimensionName
 import com.yahoo.bard.webservice.data.config.names.TestApiMetricName
 import com.yahoo.bard.webservice.data.config.names.TestDruidMetricName
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
+import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.TableGroup
+
+import org.joda.time.DateTimeZone
 
 import spock.lang.Specification
 
 /**
- * Testing basic table loader functionality
+ * Testing basic table loader functionality.
  */
 class BaseTableLoaderSpec extends Specification {
-    static class SimpleBaseTableLoader extends BaseTableLoader {
+    private static class SimpleBaseTableLoader extends BaseTableLoader {
 
-        public SimpleBaseTableLoader(DataSourceMetadataService metadataService) {
+        SimpleBaseTableLoader(DataSourceMetadataService metadataService) {
             super(metadataService)
         }
 
         @Override
-        public void loadTableDictionary(ResourceDictionaries dictionaries) {
+        void loadTableDictionary(ResourceDictionaries dictionaries) {
             // stub to allow testing of abstract class in unit tests
+        }
+    }
+
+    private static class SimpleDependencyPhysicalTableDefinition extends PhysicalTableDefinition {
+        String dependentTableName
+        PhysicalTable physicalTable
+
+        SimpleDependencyPhysicalTableDefinition(String tableName, String dependentTableName) {
+            super(TableName.of(tableName), DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC), [] as Set, [] as Set)
+            this.dependentTableName = dependentTableName
+        }
+
+        SimpleDependencyPhysicalTableDefinition(String tableName, PhysicalTable physicalTable) {
+            super(TableName.of(tableName), DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC), [] as Set, [] as Set)
+            this.physicalTable = physicalTable
+        }
+
+        @Override
+        Set<TableName> getDependentTableNames() {
+            if (Objects.isNull(dependentTableName)) {
+                return Collections.emptySet()
+            }
+            return Collections.singleton(TableName.of(dependentTableName));
+        }
+
+        @Override
+        Optional<PhysicalTable> build(
+                ResourceDictionaries dictionaries,
+                DataSourceMetadataService metadataService
+        ) {
+            if (!Objects.isNull(physicalTable)) {
+                return Optional.of(physicalTable)
+            }
+            return dictionaries.getPhysicalDictionary().containsKey(dependentTableName) ?
+                    Optional.of(
+                            new ConcretePhysicalTable(
+                                    TableName.of(getName().asName()),
+                                    DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC),
+                                    [] as Set,
+                                    [:],
+                                    metadataService
+                            )
+                    ) : Optional.empty()
         }
     }
 
@@ -44,25 +91,43 @@ class BaseTableLoaderSpec extends Specification {
     Set<TestApiDimensionName> dimNames
     Collection<Dimension> dims
 
+    PhysicalTableDefinition definition1
+    PhysicalTableDefinition definition2
+    PhysicalTableDefinition definition3
+    PhysicalTableDefinition definition4
+    PhysicalTableDefinition definition5
+    PhysicalTableDefinition definition6
+
+    PhysicalTable physicalTable
+
     def setup() {
-        loader = new SimpleBaseTableLoader(new TestDataSourceMetadataService())
+        loader = new SimpleBaseTableLoader(Mock(DataSourceMetadataService))
         dicts = new ResourceDictionaries()
         apiNames = TestApiMetricName.getByLogicalTable(SHAPES)
         metricNames = TestDruidMetricName.getByLogicalTable(SHAPES)
-        physDefs = TestPhysicalTableDefinitionUtils.buildShapeTableDefinitions(new TestDimensions())
+        physDefs = TestPhysicalTableDefinitionUtils.buildShapeTableDefinitions(new TestDimensions(), metricNames)
         dimNames = TestApiDimensionName.getByLogicalTable(SHAPES)
 
         dims = dimNames.collect {
             name -> new KeyValueStoreDimension(TestDimensions.buildStandardDimensionConfig(name))
         }
         dicts.getDimensionDictionary().addAll(dims)
+
+        physicalTable = Mock(PhysicalTable)
+        physicalTable.getName() >> 'definition2'
+
+        definition1 = new SimpleDependencyPhysicalTableDefinition('definition1', 'definition2')
+        definition2 = new SimpleDependencyPhysicalTableDefinition('definition2', physicalTable)
+        definition3 = new SimpleDependencyPhysicalTableDefinition('definition3', 'definition1')
+        definition4 = new SimpleDependencyPhysicalTableDefinition('definition4', 'definition4')
+        definition5 = new SimpleDependencyPhysicalTableDefinition('definition5', 'definition6')
+        definition6 = new SimpleDependencyPhysicalTableDefinition('definition6', 'definition5')
     }
 
     def "table group has correct contents after being build"() {
         when:
         TableGroup group = loader.buildDimensionSpanningTableGroup(
                 apiNames,
-                metricNames,
                 physDefs,
                 dicts
         )
@@ -72,31 +137,78 @@ class BaseTableLoaderSpec extends Specification {
         group.apiMetricNames == apiNames
     }
 
-    def "loading distinct physical tables results in correct tables in dictionary"() {
-        setup:
+
+    def "loading distinct physical tables without dependency results in correct tables in dictionary"() {
+        given:
         List<PhysicalTableDefinition> allDefs = physDefs as List
 
         when:
-        PhysicalTable t1 = loader.loadPhysicalTable(allDefs[0], metricNames, dicts)
-        PhysicalTable t2 = loader.loadPhysicalTable(allDefs[1], metricNames, dicts)
+        Set<PhysicalTable> tables = loader.loadPhysicalTablesWithDependency(allDefs as Set, dicts)
 
         then:
-        dicts.physicalDictionary.size() == 2
-        dicts.physicalDictionary.containsValue(t1)
-        dicts.physicalDictionary.containsValue(t2)
+        dicts.physicalDictionary.size() == 6
+        dicts.physicalDictionary.values() as Set == tables
+    }
+
+    def "loading physical tables with dependency loads all satisfied dependency physical tables"() {
+        given:
+        Set<PhysicalTableDefinition> tableDefinitions = [definition1, definition2, definition3]
+        LinkedHashSet<PhysicalTable> tables = loader.loadPhysicalTablesWithDependency(tableDefinitions, dicts)
+
+        expect:
+        dicts.physicalDictionary.size() == 3
+        dicts.physicalDictionary.values() as Set == tables as Set
+    }
+
+    def "unsatisfied dependency physical table definition loading will throw an exception"() {
+        given:
+        Set<PhysicalTableDefinition> tableDefinitions = [definition2, definition3]
+
+        when:
+        loader.loadPhysicalTablesWithDependency(tableDefinitions, dicts)
+
+        then:
+        RuntimeException e = thrown()
+        e.message == 'Unable to resolve physical table dependency for physical table: definition1'
+    }
+
+    def "circular dependency physical table definition loading will throw an exception"() {
+        given:
+        Set<PhysicalTableDefinition> tableDefinitions = [definition1, definition2, definition3, definition5, definition6]
+
+        when:
+        loader.loadPhysicalTablesWithDependency(tableDefinitions, dicts)
+
+        then:
+        RuntimeException e = thrown()
+        e.message == 'Unable to resolve physical table dependency for physical table: definition5'
+    }
+
+    def "self dependency physical table definition loading will throw an exception"() {
+        given:
+        Set<PhysicalTableDefinition> tableDefinitions = [definition1, definition2, definition3, definition4]
+
+        when:
+        loader.loadPhysicalTablesWithDependency(tableDefinitions, dicts)
+
+        then:
+        RuntimeException e = thrown()
+        e.message == 'Unable to resolve physical table dependency for physical table: definition4'
     }
 
     def "load duplicate physical tables results in sharing definitions"() {
-        setup:
+        given:
         List<PhysicalTableDefinition> allDefs = physDefs as List
 
         when:
-        PhysicalTable t1 = loader.loadPhysicalTable(allDefs[0], metricNames, dicts)
-        PhysicalTable t2 = loader.loadPhysicalTable(allDefs[0], metricNames, dicts)
+        loader.loadPhysicalTablesWithDependency([allDefs[0], allDefs[4]] as Set, dicts)
+        LinkedHashSet<PhysicalTable> tables = loader.loadPhysicalTablesWithDependency(
+                allDefs as Set,
+                dicts
+        )
 
         then:
-        dicts.physicalDictionary.size() == 1
-        dicts.physicalDictionary.containsValue(t1)
-        t1.is(t2)
+        dicts.physicalDictionary.size() == 6
+        dicts.physicalDictionary.values() as Set == tables
     }
 }

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/table/TestPhysicalTableDefinitionUtils.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/table/TestPhysicalTableDefinitionUtils.java
@@ -24,11 +24,15 @@ import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.HOUR;
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.MONTH;
 
 import com.yahoo.bard.webservice.data.config.dimension.TestDimensions;
+import com.yahoo.bard.webservice.data.config.names.FieldName;
+import com.yahoo.bard.webservice.data.config.names.TestDruidMetricName;
 import com.yahoo.bard.webservice.util.Utils;
 
 import org.joda.time.DateTimeZone;
 
+import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -40,14 +44,19 @@ public class TestPhysicalTableDefinitionUtils {
      * Build the hourly table definitions.
      *
      * @param testDimensions  Dimensions to build the tables with
+     * @param metricNames  The field name of metrics to build with
      *
      * @return the hourly table definitions
      */
-    public static LinkedHashSet<PhysicalTableDefinition> buildHourlyTableDefinitions(TestDimensions testDimensions) {
+    public static LinkedHashSet<PhysicalTableDefinition> buildHourlyTableDefinitions(
+            TestDimensions testDimensions,
+            Set<FieldName> metricNames
+    ) {
         return Utils.asLinkedHashSet(
-                new PhysicalTableDefinition(
+                new ConcretePhysicalTableDefinition(
                         HOURLY,
                         HOUR.buildZonedTimeGrain(DateTimeZone.UTC),
+                        new LinkedHashSet<>(Arrays.asList(TestDruidMetricName.values())),
                         testDimensions.getDimensionConfigurationsByApiName(OTHER)
                 )
         );
@@ -57,14 +66,19 @@ public class TestPhysicalTableDefinitionUtils {
      * Build the monthly table definitions.
      *
      * @param testDimensions  Dimensions to build the tables with
+     * @param metricNames  The field name of metrics to build with
      *
      * @return the monthly table definitions
      */
-    public static LinkedHashSet<PhysicalTableDefinition> buildMonthlyTableDefinitions(TestDimensions testDimensions) {
+    public static LinkedHashSet<PhysicalTableDefinition> buildMonthlyTableDefinitions(
+            TestDimensions testDimensions,
+            Set<FieldName> metricNames
+    ) {
         return Utils.asLinkedHashSet(
-                new PhysicalTableDefinition(
+                new ConcretePhysicalTableDefinition(
                         MONTHLY,
                         MONTH.buildZonedTimeGrain(DateTimeZone.UTC),
+                        new LinkedHashSet<>(Arrays.asList(TestDruidMetricName.values())),
                         testDimensions.getDimensionConfigurationsByApiName(OTHER)
                 )
         );
@@ -74,15 +88,17 @@ public class TestPhysicalTableDefinitionUtils {
      * Build hourly monthly table definitions.
      *
      * @param testDimensions  Dimensions to load in the tables
+     * @param metricNames  The field name of metrics to build with
      *
      * @return the hourly monthly table definitions
      */
     public static LinkedHashSet<PhysicalTableDefinition> buildHourlyMonthlyTableDefinitions(
-            TestDimensions testDimensions
+            TestDimensions testDimensions,
+            Set<FieldName> metricNames
     ) {
         return Stream.concat(
-                buildHourlyTableDefinitions(testDimensions).stream(),
-                buildMonthlyTableDefinitions(testDimensions).stream()
+                buildHourlyTableDefinitions(testDimensions, metricNames).stream(),
+                buildMonthlyTableDefinitions(testDimensions, metricNames).stream()
         ).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
@@ -91,14 +107,19 @@ public class TestPhysicalTableDefinitionUtils {
      * Build the pet table definitions.
      *
      * @param testDimensions  Dimensions to build the tables with
+     * @param metricNames  The field name of metrics to build with
      *
      * @return the pet table definitions
      */
-    public static LinkedHashSet<PhysicalTableDefinition> buildPetTableDefinitions(TestDimensions testDimensions) {
+    public static LinkedHashSet<PhysicalTableDefinition> buildPetTableDefinitions(
+            TestDimensions testDimensions,
+            Set<FieldName> metricNames
+    ) {
         return Utils.asLinkedHashSet(
-                new PhysicalTableDefinition(
+                new ConcretePhysicalTableDefinition(
                         ALL_PETS,
                         DAY.buildZonedTimeGrain(DateTimeZone.UTC),
+                        metricNames,
                         testDimensions.getDimensionConfigurationsByApiName(BREED, SEX, SPECIES)
                 )
         );
@@ -108,39 +129,49 @@ public class TestPhysicalTableDefinitionUtils {
      * Build the shape table definitions.
      *
      * @param testDimensions  Dimensions to build the tables with
+     * @param metricNames  The field name of metrics to build with
      *
      * @return the shape table definitions
      */
-    public static LinkedHashSet<PhysicalTableDefinition> buildShapeTableDefinitions(TestDimensions testDimensions) {
+    public static LinkedHashSet<PhysicalTableDefinition> buildShapeTableDefinitions(
+            TestDimensions testDimensions,
+            Set<FieldName> metricNames
+    ) {
         return Utils.asLinkedHashSet(
-                new PhysicalTableDefinition(
+                new ConcretePhysicalTableDefinition(
                         ALL_SHAPES,
                         DAY.buildZonedTimeGrain(DateTimeZone.UTC),
+                        metricNames,
                         testDimensions.getDimensionConfigurationsByApiName(COLOR, SIZE, SHAPE, OTHER, MODEL)
                 ),
-                new PhysicalTableDefinition(
+                new ConcretePhysicalTableDefinition(
                         COLOR_SHAPES_HOURLY,
                         HOUR.buildZonedTimeGrain(DateTimeZone.UTC),
+                        metricNames,
                         testDimensions.getDimensionConfigurationsByApiName(COLOR)
                 ),
-                new PhysicalTableDefinition(
+                new ConcretePhysicalTableDefinition(
                         COLOR_SHAPES,
                         DAY.buildZonedTimeGrain(DateTimeZone.UTC),
+                        metricNames,
                         testDimensions.getDimensionConfigurationsByApiName(COLOR)
                 ),
-                new PhysicalTableDefinition(
+                new ConcretePhysicalTableDefinition(
                         COLOR_SHAPES_MONTHLY,
                         MONTH.buildZonedTimeGrain(DateTimeZone.UTC),
+                        metricNames,
                         testDimensions.getDimensionConfigurationsByApiName(COLOR)
                 ),
-                new PhysicalTableDefinition(
+                new ConcretePhysicalTableDefinition(
                         COLOR_SIZE_SHAPES,
                         DAY.buildZonedTimeGrain(DateTimeZone.UTC),
+                        metricNames,
                         testDimensions.getDimensionConfigurationsByApiName(COLOR, SIZE)
                 ),
-                new PhysicalTableDefinition(
+                new ConcretePhysicalTableDefinition(
                         COLOR_SIZE_SHAPE_SHAPES,
                         DAY.buildZonedTimeGrain(DateTimeZone.UTC),
+                        metricNames,
                         testDimensions.getDimensionConfigurationsByApiName(COLOR, SIZE, SHAPE)
                 )
         );

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/table/TestTableLoader.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/table/TestTableLoader.java
@@ -62,23 +62,38 @@ public class TestTableLoader extends BaseTableLoader {
         // Set up the table definitions
         logicalTableTableDefinitions.put(
                 TestLogicalTableName.SHAPES,
-                TestPhysicalTableDefinitionUtils.buildShapeTableDefinitions(testDimensions)
+                TestPhysicalTableDefinitionUtils.buildShapeTableDefinitions(
+                        testDimensions,
+                        TestDruidMetricName.getByLogicalTable(TestLogicalTableName.SHAPES)
+                )
         );
         logicalTableTableDefinitions.put(
                 TestLogicalTableName.PETS,
-                TestPhysicalTableDefinitionUtils.buildPetTableDefinitions(testDimensions)
+                TestPhysicalTableDefinitionUtils.buildPetTableDefinitions(
+                        testDimensions,
+                        TestDruidMetricName.getByLogicalTable(TestLogicalTableName.PETS)
+                )
         );
         logicalTableTableDefinitions.put(
                 TestLogicalTableName.MONTHLY,
-                TestPhysicalTableDefinitionUtils.buildMonthlyTableDefinitions(testDimensions)
+                TestPhysicalTableDefinitionUtils.buildMonthlyTableDefinitions(
+                        testDimensions,
+                        TestDruidMetricName.getByLogicalTable(TestLogicalTableName.MONTHLY)
+                )
         );
         logicalTableTableDefinitions.put(
                 TestLogicalTableName.HOURLY,
-                TestPhysicalTableDefinitionUtils.buildHourlyTableDefinitions(testDimensions)
+                TestPhysicalTableDefinitionUtils.buildHourlyTableDefinitions(
+                        testDimensions,
+                        TestDruidMetricName.getByLogicalTable(TestLogicalTableName.HOURLY)
+                )
         );
         logicalTableTableDefinitions.put(
                 TestLogicalTableName.HOURLY_MONTHLY,
-                TestPhysicalTableDefinitionUtils.buildHourlyMonthlyTableDefinitions(testDimensions)
+                TestPhysicalTableDefinitionUtils.buildHourlyMonthlyTableDefinitions(
+                        testDimensions,
+                        TestDruidMetricName.getByLogicalTable(TestLogicalTableName.HOURLY_MONTHLY)
+                )
         );
     }
 
@@ -88,7 +103,6 @@ public class TestTableLoader extends BaseTableLoader {
         for (TestLogicalTableName logicalTableName : TestLogicalTableName.values()) {
             TableGroup tableGroup = buildDimensionSpanningTableGroup(
                     TestApiMetricName.getByLogicalTable(logicalTableName),
-                    TestDruidMetricName.getByLogicalTable(logicalTableName),
                     logicalTableTableDefinitions.get(logicalTableName),
                     dictionaries
             );
@@ -111,6 +125,5 @@ public class TestTableLoader extends BaseTableLoader {
                 logicalTableTableGroup.get(TestLogicalTableName.HOURLY_MONTHLY.asName())
         );
         loadLogicalTablesWithGranularities(hourlyMonthlyGroup, Utils.asLinkedHashSet(HOUR, MONTH), dictionaries);
-
     }
 }

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/table/TestTableLoader.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/table/TestTableLoader.java
@@ -103,6 +103,7 @@ public class TestTableLoader extends BaseTableLoader {
         for (TestLogicalTableName logicalTableName : TestLogicalTableName.values()) {
             TableGroup tableGroup = buildDimensionSpanningTableGroup(
                     TestApiMetricName.getByLogicalTable(logicalTableName),
+                    TestDruidMetricName.getByLogicalTable(logicalTableName),
                     logicalTableTableDefinitions.get(logicalTableName),
                     dictionaries
             );

--- a/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/WikiTableLoader.java
+++ b/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/WikiTableLoader.java
@@ -10,6 +10,7 @@ import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
 import com.yahoo.bard.webservice.data.config.names.ApiMetricName;
 import com.yahoo.bard.webservice.data.config.names.FieldName;
 import com.yahoo.bard.webservice.data.config.table.BaseTableLoader;
+import com.yahoo.bard.webservice.data.config.table.ConcretePhysicalTableDefinition;
 import com.yahoo.bard.webservice.data.config.table.PhysicalTableDefinition;
 import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
@@ -22,6 +23,8 @@ import com.yahoo.wiki.webservice.data.config.names.WikiApiMetricName;
 import com.yahoo.wiki.webservice.data.config.names.WikiDruidMetricName;
 import com.yahoo.wiki.webservice.data.config.names.WikiDruidTableName;
 import com.yahoo.wiki.webservice.data.config.names.WikiLogicalTableName;
+
+import org.joda.time.DateTimeZone;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -70,17 +73,6 @@ public class WikiTableLoader extends BaseTableLoader {
             WikiApiDimensionConfigInfo.values()
         );
 
-        // Physical Tables
-        Set<PhysicalTableDefinition> samplePhysicalTableDefinition = Utils.asLinkedHashSet(
-                new PhysicalTableDefinition(
-                        WikiDruidTableName.WIKITICKER,
-                        HOUR,
-                        dimsBasefactDruidTableName
-                )
-        );
-
-        tableDefinitions.put(WikiLogicalTableName.WIKIPEDIA, samplePhysicalTableDefinition);
-
         druidMetricNames.put(
                 WikiLogicalTableName.WIKIPEDIA,
                 Utils.<FieldName>asLinkedHashSet(WikiDruidMetricName.values())
@@ -91,6 +83,18 @@ public class WikiTableLoader extends BaseTableLoader {
                 Utils.<ApiMetricName>asLinkedHashSet(WikiApiMetricName.values())
         );
 
+        // Physical Tables
+        Set<PhysicalTableDefinition> samplePhysicalTableDefinition = Utils.asLinkedHashSet(
+                new ConcretePhysicalTableDefinition(
+                        WikiDruidTableName.WIKITICKER,
+                        HOUR.buildZonedTimeGrain(DateTimeZone.UTC),
+                        druidMetricNames.get(WikiLogicalTableName.WIKIPEDIA),
+                        dimsBasefactDruidTableName
+                )
+        );
+
+        tableDefinitions.put(WikiLogicalTableName.WIKIPEDIA, samplePhysicalTableDefinition);
+
         validGrains.put(WikiLogicalTableName.WIKIPEDIA, Utils.asLinkedHashSet(HOUR, DAY, AllGranularity.INSTANCE));
     }
 
@@ -99,7 +103,6 @@ public class WikiTableLoader extends BaseTableLoader {
         for (WikiLogicalTableName table : WikiLogicalTableName.values()) {
             TableGroup tableGroup = buildDimensionSpanningTableGroup(
                     apiMetricNames.get(table),
-                    druidMetricNames.get(table),
                     tableDefinitions.get(table),
                     dictionaries
             );

--- a/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/WikiTableLoader.java
+++ b/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/WikiTableLoader.java
@@ -103,6 +103,7 @@ public class WikiTableLoader extends BaseTableLoader {
         for (WikiLogicalTableName table : WikiLogicalTableName.values()) {
             TableGroup tableGroup = buildDimensionSpanningTableGroup(
                     apiMetricNames.get(table),
+                    druidMetricNames.get(table),
                     tableDefinitions.get(table),
                     dictionaries
             );


### PR DESCRIPTION
* `PhysicalTableDefinition` is now an abstract class, construct using `ConcretePhysicalTableDefinition` instead
* `PhysicalTableDefinition` now requires a `build` methods to be implemented that builds a physical table
* `BaseTableLoader` now constructs physical tables by calling `build` method on `PhysicalTableDefinition`s in `buildPhysicalTablesWithDependency`
* `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now uses `loadPhysicalTablesWithDependency` instead of removed `loadPhysicalTables`
* `buildDimensionSpanningTableGroup` method in `BaseTableLoader` now does not take druid metric as arguments, instead `PhysicalTableDefinition` does