### PR TITLE
[WIP] Assert1test config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,11 @@ Current
 - [Make `TemplateDruidQuery::getMetricField` get the first field instead of any field](https://github.com/yahoo/fili/pull/210)
     * Previously, order was by luck, now it's by the contract of `findFirst`
 
+- [Clean up config loading and add more logs and checks]()
+    * Assert no more than 1 `testApplicationConfig` on classpath
+      - Assertion already existed for `userConfig` and `applicationConfig`)
+    * Add error / logging messages for too many test application configs
+
 - [Restore non-default query support in TestDruidWebservice](https://github.com/yahoo/fili/pull/202)
 
 - [Base TableDataSource serialization on ConcretePhysicalTable fact name](https://github.com/yahoo/fili/pull/202)

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigMessageFormat.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigMessageFormat.java
@@ -32,6 +32,11 @@ public enum ConfigMessageFormat implements MessageFormatter {
             "Test application config from jar found at classpath location '%s'.  Only non jar test application configurations are allowed."
     ),
 
+    TOO_MANY_TEST_APPLICATION_CONFIGS(
+            "Only zero or one test application configurations is allowed, found %d",
+            "Only zero or one test application configurations is allowed, found resources: %s"
+    ),
+
     TOO_MANY_APPLICATION_CONFIGS(
             "Only zero or one application configurations is allowed, found %d",
             "Only zero or one application configurations is allowed, found resources: %s"

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/LayeredFileSystemConfig.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/LayeredFileSystemConfig.java
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.config;
 
 import static com.yahoo.bard.webservice.config.ConfigMessageFormat.TOO_MANY_APPLICATION_CONFIGS;
+import static com.yahoo.bard.webservice.config.ConfigMessageFormat.TOO_MANY_TEST_APPLICATION_CONFIGS;
 import static com.yahoo.bard.webservice.config.ConfigMessageFormat.TOO_MANY_USER_CONFIGS;
 
 import org.apache.commons.configuration.CompositeConfiguration;
@@ -88,6 +89,12 @@ public class LayeredFileSystemConfig implements SystemConfig {
 
             // Test application configuration provides overrides for configuration in a testing environment
             List<Configuration> testApplicationConfig = loader.loadConfigurationsNoJars(TEST_CONFIG_FILE_NAME);
+            if (testApplicationConfig.size() > 1) {
+                List<Resource> resources = loader.loadResourcesWithName(TEST_CONFIG_FILE_NAME)
+                        .collect(Collectors.toList());
+                LOG.error(TOO_MANY_TEST_APPLICATION_CONFIGS.logFormat(resources.toString()));
+                throw new SystemConfigException(TOO_MANY_TEST_APPLICATION_CONFIGS.format(resources.size()));
+            }
 
             // Application configuration defines configuration at an application level for a bard instance
             List<Configuration> applicationConfig = loader.loadConfigurations(APPLICATION_CONFIG_FILE_NAME);


### PR DESCRIPTION
Having more than 1 `testApplicationConfig` on the classpath when running tests wasn't alerted, and made debugging something hard recently. There should only ever be 1 `testApplicationConfig` at a time, so this change asserts that to be true and blows up if it isn't.

This also cleans up some of the logging and information the config loading process spits out as it does it's thing, especially in error scenarios.