### PR TITLE
Deprecation unusingness

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
@@ -281,7 +281,7 @@ public abstract class BaseTableLoader implements TableLoader {
             // Add the table to the dictionary
             LOG.debug("Physical table: {} \n\n" + "Cache: {} ",
                             definition.getName().asName(),
-                            existingTable.getColumns());
+                            existingTable.getSchema().getColumns());
             dictionaries.getPhysicalDictionary().put(definition.getName().asName(), existingTable);
         }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/Schema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/Schema.java
@@ -24,7 +24,7 @@ public interface Schema {
     /**
      * Get the time granularity for this Schema.
      *
-     * @return The columns of this schema
+     * @return The time granularity of this schema
      */
     Granularity getGranularity();
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolver.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolver.java
@@ -101,7 +101,9 @@ public abstract class BasePhysicalTableResolver implements PhysicalTableResolver
             PhysicalTable bestTable = physicalTables.stream()
                     .reduce(getBetterTableOperator(requestConstraint)).get();
 
-            REGISTRY.meter("request.physical.table." + bestTable.getName() + "." + bestTable.getTimeGrain()).mark();
+            REGISTRY.meter(
+                    "request.physical.table." + bestTable.getName() + "." + bestTable.getSchema().getTimeGrain()
+            ).mark();
             LOG.trace("Found best Table: {}", bestTable);
             return bestTable;
         } catch (NoMatchFoundException me) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolver.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolver.java
@@ -96,10 +96,9 @@ public abstract class BasePhysicalTableResolver implements PhysicalTableResolver
         );
 
         try {
-            Set<PhysicalTable> physicalTables = filter(candidateTables, requestConstraint);
-
-            PhysicalTable bestTable = physicalTables.stream()
-                    .reduce(getBetterTableOperator(requestConstraint)).get();
+            PhysicalTable bestTable = filter(candidateTables, requestConstraint).stream()
+                    .reduce(getBetterTableOperator(requestConstraint))
+                    .get();
 
             REGISTRY.meter(
                     "request.physical.table." + bestTable.getName() + "." + bestTable.getSchema().getTimeGrain()

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
@@ -123,7 +123,10 @@ public class SlicesApiRequest extends ApiRequest {
                         e -> {
                             Map<String, String> res = new LinkedHashMap<>();
                             res.put("name", e.getKey());
-                            res.put("timeGrain", e.getValue().getTimeGrain().getName().toLowerCase(Locale.ENGLISH));
+                            res.put(
+                                    "timeGrain",
+                                    e.getValue().getSchema().getTimeGrain().getName().toLowerCase(Locale.ENGLISH)
+                            );
                             res.put("uri", SlicesServlet.getSliceDetailUrl(e.getKey(), uriInfo));
                             return res;
                         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
@@ -172,24 +172,23 @@ public class SlicesApiRequest extends ApiRequest {
         Set<Map<String, Object>> dimensionsResult = new LinkedHashSet<>();
         Set<Map<String, Object>> metricsResult = new LinkedHashSet<>();
 
-        columnCache.entrySet().stream()
-                .forEach(
-                        e -> {
-                            Map<String, Object> row = new LinkedHashMap<>();
-                            row.put("intervals", e.getValue());
+        columnCache.entrySet().forEach(
+                e -> {
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("intervals", e.getValue());
 
-                            Column key = e.getKey();
-                            if (key instanceof DimensionColumn) {
-                                Dimension dimension = ((DimensionColumn) key).getDimension();
-                                row.put("name", dimension.getApiName());
-                                row.put("uri", DimensionsServlet.getDimensionUrl(dimension, uriInfo));
-                                dimensionsResult.add(row);
-                            } else {
-                                row.put("name", key.getName());
-                                metricsResult.add(row);
-                            }
-                        }
-                );
+                    Column key = e.getKey();
+                    if (key instanceof DimensionColumn) {
+                        Dimension dimension = ((DimensionColumn) key).getDimension();
+                        row.put("name", dimension.getApiName());
+                        row.put("uri", DimensionsServlet.getDimensionUrl(dimension, uriInfo));
+                        dimensionsResult.add(row);
+                    } else {
+                        row.put("name", key.getName());
+                        metricsResult.add(row);
+                    }
+                }
+        );
 
         Set<SortedMap<DateTime, Map<String, SegmentInfo>>> sliceMetadata = dataSourceMetadataService.getTableSegments(
                 Collections.singleton(table.getTableName())

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
@@ -214,7 +214,7 @@ class WeightEvaluationQuerySpec extends Specification {
 
         and: "The weight-check query doesn't have a sort at either level"
         !new WeightEvaluationQuery(groupByQuery, 1).limitSpec.columns
-        !new WeightEvaluationQuery(groupByQuery, 1).innermostQuery.limitSpec.schema.columns
+        !new WeightEvaluationQuery(groupByQuery, 1).innermostQuery.limitSpec.columns
     }
 
     @Unroll

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
@@ -214,7 +214,7 @@ class WeightEvaluationQuerySpec extends Specification {
 
         and: "The weight-check query doesn't have a sort at either level"
         !new WeightEvaluationQuery(groupByQuery, 1).limitSpec.columns
-        !new WeightEvaluationQuery(groupByQuery, 1).innermostQuery.limitSpec.columns
+        !new WeightEvaluationQuery(groupByQuery, 1).innermostQuery.limitSpec.schema.columns
     }
 
     @Unroll

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolverSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/BasePhysicalTableResolverSpec.groovy
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.table.resolver
 
 import com.yahoo.bard.webservice.table.PhysicalTable
+import com.yahoo.bard.webservice.table.PhysicalTableSchema
 
 import spock.lang.Shared
 import spock.lang.Specification
@@ -24,13 +25,17 @@ class BasePhysicalTableResolverSpec extends Specification {
     QueryPlanningConstraint dataSourceConstraint
 
     def setupSpec() {
+        PhysicalTableSchema commonSchema = Mock(PhysicalTableSchema)
         one = Mock(PhysicalTable)
         two = Mock(PhysicalTable)
         three = Mock(PhysicalTable)
 
         one.getName() >> "one"
+        one.getSchema() >> commonSchema
         two.getName() >> "two"
+        two.getSchema() >> commonSchema
         three.getName() >> "three"
+        three.getSchema() >> commonSchema
 
         pickFirst = { PhysicalTable table1, PhysicalTable table2 -> table1 } as BinaryOperator<PhysicalTable>
         pickLast  = { PhysicalTable table1, PhysicalTable table2 -> table2 } as BinaryOperator<PhysicalTable>

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
@@ -36,7 +36,6 @@ import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationP
 import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier
 import com.yahoo.bard.webservice.druid.util.SketchFieldConverter
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
 import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
@@ -166,7 +166,7 @@ class SketchIntersectionReportingResources extends Specification {
                 Mock(DataSourceMetadataService)
         )
 
-        TableGroup tableGroup = new TableGroup([physicalTable] as LinkedHashSet, metrics)
+        TableGroup tableGroup = new TableGroup([physicalTable] as LinkedHashSet, metrics, physicalTable.dimensions)
         table = new LogicalTable("NETWORK", DAY, tableGroup, metricDict)
 
         JSONArray metricJsonObjArray = new JSONArray("[{\"filter\":{\"AND\":\"country|id-in[US,IN],property|id-in[114,125]\"},\"name\":\"foo\"},{\"filter\":{},\"name\":\"pageviews\"}]")

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
@@ -163,7 +163,7 @@ class ThetaSketchIntersectionReportingResources extends Specification {
                 Mock(DataSourceMetadataService)
         )
 
-        TableGroup tableGroup = new TableGroup([physicalTable] as LinkedHashSet, metrics)
+        TableGroup tableGroup = new TableGroup([physicalTable] as LinkedHashSet, metrics, physicalTable.dimensions)
 
         table = new LogicalTable("NETWORK", DAY, tableGroup, metricDict)
 


### PR DESCRIPTION
This PR removes many instances where we were using deprecated APIs and such in Fili code. These are generally in implementations, not interfaces, so there's no real impact.

There's also some cleanups (groovy cleanups and other simplifications) in here as well, but broken out as separate commits.