### PR TITLE
Un-luck TemplateDruidQuery::getMetricField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ Current
 
 ### Changed:
 
+- [Make `TemplateDruidQuery::getMetricField` get the first field instead of any field](https://github.com/yahoo/fili/pull/210)
+    * Previously, order was by luck, now it's by the contract of `findFirst`
+
 - [Restore non-default query support in TestDruidWebservice](https://github.com/yahoo/fili/pull/202)
 
 - [Base TableDataSource serialization on ConcretePhysicalTable fact name](https://github.com/yahoo/fili/pull/202)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/TemplateDruidQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/TemplateDruidQuery.java
@@ -412,7 +412,7 @@ public class TemplateDruidQuery implements DruidAggregationQuery<TemplateDruidQu
     public MetricField getMetricField(String name) {
         return Stream.concat(postAggregations.stream(), aggregations.stream())
                 .filter(field -> field.getName().equals(name))
-                .findAny()
+                .findFirst()
                 .orElseThrow(IllegalArgumentException::new);
     }
 


### PR DESCRIPTION
`findAny` will use the 1st one it sees in a parallel world, which _may_ not be in the order the streams gave the results. `findFirst` ensures order is followed, meaning that we'll get a PostAgg if there is one, otherwise we might not have.