### PR TITLE
Deprecate unused Column constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ Current
     - This method is a part of the infrastructure to support the recently
     deprecated `RequestLog::switchTiming`.
 
+- [LogicalMetricColumn doesn't need a 2-arg constructor](https://github.com/yahoo/fili/pull/204)
+    * It's only used in one place, and there's no real need for it because the other constructor does the same thing
+
+- [DimensionColumn's 2-arg constructor is only used by a deprecated class](https://github.com/yahoo/fili/pull/204)
+    * When that deprecated class (`LogicalDimensionColumn`) goes away, this constructor will go away as well
 
 ### Fixed:
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionColumn.java
@@ -30,7 +30,10 @@ public class DimensionColumn extends Column {
      *
      * @param dimension  The column's corresponding dimension
      * @param columnName  Column name backing dimension
+     *
+     * @deprecated LogicalDimensionColumn is the only caller of this, and since it's deprecated, so is this constructor
      */
+    @Deprecated
     protected DimensionColumn(@NotNull Dimension dimension, @NotNull String columnName) {
         super(columnName);
         this.dimension = dimension;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/LogicalMetricColumn.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/LogicalMetricColumn.java
@@ -14,7 +14,11 @@ public class LogicalMetricColumn extends MetricColumn {
      *
      * @param name  The column name
      * @param metric  The logical metric
+     *
+     * @deprecated because LogicalMetricColumn is really only a thing for LogicalTable, so there's no reason for there
+     * to be an alias on the LogicalMetric inside the LogicalTableSchema.
      */
+    @Deprecated
     public LogicalMetricColumn(String name, LogicalMetric metric) {
         super(name);
         this.metric = metric;
@@ -26,7 +30,8 @@ public class LogicalMetricColumn extends MetricColumn {
      * @param metric  The logical metric
      */
     public LogicalMetricColumn(LogicalMetric metric) {
-        this(metric.getName(), metric);
+        super(metric.getName());
+        this.metric = metric;
     }
 
     /**


### PR DESCRIPTION
Some of the column constructors are or almost are unused. This deprecates those so we can clean them up soon.