### PR TITLE
Make druid client follow redirects by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,9 @@ Current
 
 ### Fixed:
 
+- [Default the AsyncDruidWebServiceImpl to follow redirects](https://github.com/yahoo/fili/pull/214)
+    * It defaulted to not following redirects, and now it doesn't
+
 - [Reenable custom query types in TestDruidWebService]()
 
 - [Fixed Segment Metadata Loader Unconfigured Dimension Bug](https://github.com/yahoo/fili/pull/197)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImpl.java
@@ -115,6 +115,7 @@ public class AsyncDruidWebServiceImpl implements DruidWebService {
                 .setRequestTimeout(requestTimeout)
                 .setConnectionTtl(requestTimeout)
                 .setPooledConnectionIdleTimeout(requestTimeout)
+                .setFollowRedirect(true)
                 .build();
 
         return new DefaultAsyncHttpClient(config);


### PR DESCRIPTION
Not following redirects is a pain if hosts need to move and leave a redirect behind to point to their new location, or if there is some sort of redirection-based load balancing. The Druid clients now will follow redirects (max count defaults to 5)