### PR TITLE
Fix to use physical name instead of logical name to retrieve available interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ Current
 ### Added:
 
 - [Fix to use physical name instead of logical name to retrieve available interval](https://github.com/yahoo/fili/pull/226)
-    * Added `PhysicalDataSourceConstraint` class to capture physical names of columns for retrieving availble interval
+    * Added `PhysicalDataSourceConstraint` class to capture physical names of columns for retrieving available intervals
 
 - [BaseCompositePhysicalTable](https://github.com/yahoo/fili/pull/242)
-    * `ConcretePhysicalTable` provides common operations, such as validating coarsest ZonedTimeGrain, for composite
+    * `BaseCompositePhysicalTable` provides common operations, such as validating coarsest ZonedTimeGrain, for composite
     tables.
 
 - [Add Reciprocal `satisfies()` relationship complementing `satisfiedBy()` on Granularity](https://github.com/yahoo/fili/issues/222)
@@ -81,10 +81,10 @@ Current
 ### Changed:
 
 - [Fix to use physical name instead of logical name to retrieve available interval](https://github.com/yahoo/fili/pull/226)
-    * `getAllAvailbleIntervals` in `ConcreteAvailability` no longer filters out unconfigured columns, instead table's `getAllAvailbleIntervals` does
+    * `getAllAvailbleIntervals` in `ConcreteAvailability` no longer filters out un-configured columns, instead table's `getAllAvailbleIntervals` does
     * `getAvailbleIntervals` in `Availbality` now takes `PhysicalDataSourceConstraint` instead of `DataSourceConstraint`
     * `Availability` no longer takes a set of columns on the table, only table needs to know
-    * `getAllAvailbleIntervals` in `Availability` now returns a map of column physical name to interval list instead of column to interval list
+    * `getAllAvailbleIntervals` in `Availability` now returns a map of column physical name string to interval list instead of column to interval list
     * `TestDataSourceMetadataService` now takes map from string to list of intervals instead of column to list of intervals for constructor
 
 - [Reduced number of queries sent by `LuceneSearchProvider` by 50% in the common case](https://github.com/yahoo/fili/pull/234)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,8 @@ Current
 - [Fix to use physical name instead of logical name to retrieve available interval](https://github.com/yahoo/fili/pull/226)
     * `getAllAvailbleIntervals` in `ConcreteAvailability` no longer filters out unconfigured columns, instead table's `getAllAvailbleIntervals` does
     * `getAvailbleIntervals` in `Availbality` now takes `PhysicalDataSourceConstraint` instead of `DataSourceConstraint`
-    * `Availbility` no longer takes a set of columns on the table, only table needs to know
-    * `getAllAvailbleIntervals` in `Availbility` now returns a map of column physical name to interval list instead of column to interval list
+    * `Availability` no longer takes a set of columns on the table, only table needs to know
+    * `getAllAvailbleIntervals` in `Availability` now returns a map of column physical name to interval list instead of column to interval list
     * `TestDataSourceMetadataService` now takes map from string to list of intervals instead of column to list of intervals for constructor
 
 - [Reduced number of queries sent by `LuceneSearchProvider` by 50% in the common case](https://github.com/yahoo/fili/pull/234)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Current
 -------
 ### Added:
 
+- [Fix to use physical name instead of logical name to retrieve available interval](https://github.com/yahoo/fili/pull/226)
+    * Added `PhysicalDataSourceConstraint` class to capture physical names of columns for retrieving availble interval
+
 - [BaseCompositePhysicalTable](https://github.com/yahoo/fili/pull/242)
     * `ConcretePhysicalTable` provides common operations, such as validating coarsest ZonedTimeGrain, for composite
     tables.
@@ -76,6 +79,13 @@ Current
 - [Support timeouts for lucene search provider](https://github.com/yahoo/fili/pull/183)
 
 ### Changed:
+
+- [Fix to use physical name instead of logical name to retrieve available interval](https://github.com/yahoo/fili/pull/226)
+    * `getAllAvailbleIntervals` in `ConcreteAvailability` no longer filters out unconfigured columns, instead table's `getAllAvailbleIntervals` does
+    * `getAvailbleIntervals` in `Availbality` now takes `PhysicalDataSourceConstraint` instead of `DataSourceConstraint`
+    * `Availbility` no longer takes a set of columns on the table, only table needs to know
+    * `getAllAvailbleIntervals` in `Availbility` now returns a map of column physical name to interval list instead of column to interval list
+    * `TestDataSourceMetadataService` now takes map from string to list of intervals instead of column to list of intervals for constructor
 
 - [Reduced number of queries sent by `LuceneSearchProvider` by 50% in the common case](https://github.com/yahoo/fili/pull/234)
     * Before, we were using `IndexSearcher::count` to get the total number of documents, which spawned an entire second query

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.NotNull;
 /**
  * An implementation of BasePhysicalTable that contains multiple tables.
  */
-public class BaseCompositePhysicalTable extends BasePhysicalTable {
+public abstract class BaseCompositePhysicalTable extends BasePhysicalTable {
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseCompositePhysicalTable.class);
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -6,6 +6,7 @@ import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.table.availability.Availability;
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.IntervalUtils;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
@@ -16,6 +17,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
@@ -79,12 +82,21 @@ public abstract class BasePhysicalTable implements PhysicalTable {
 
     @Override
     public Map<Column, List<Interval>> getAllAvailableIntervals() {
-        return getAvailability().getAllAvailableIntervals();
+        Map<String, List<Interval>> availableIntervals = getAvailability().getAllAvailableIntervals();
+
+        return getSchema().getColumns().stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        column -> availableIntervals.getOrDefault(
+                                getSchema().getPhysicalColumnName(column.getName()),
+                                new SimplifiedIntervalList()
+                        )
+                ));
     }
 
     @Override
     public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraint) {
-        return getAvailability().getAvailableIntervals(constraint);
+        return getAvailability().getAvailableIntervals(new PhysicalDataSourceConstraint(constraint, getSchema()));
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -99,16 +99,14 @@ public abstract class BasePhysicalTable implements PhysicalTable {
     public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraint) {
 
         Set<String> tableColumnNames = getSchema().getColumnNames();
-        Set<String> invalidColumnNames = constraint.getAllColumnNames().stream()
-                .filter(name -> !tableColumnNames.contains(name))
-                .collect(Collectors.toSet());
 
+        // Validate that the requested columns are answerable by the current table
         if (!constraint.getAllColumnNames().stream().allMatch(tableColumnNames::contains)) {
             String message = String.format(
                     "Received invalid request requesting for columns: %s that is not available in this table: %s",
-                    invalidColumnNames.stream().collect(Collectors.joining(",")),
-                    getName()
-            );
+                    constraint.getAllColumnNames().stream()
+                            .filter(name -> !tableColumnNames.contains(name))
+                            .collect(Collectors.joining(",")), getName());
             LOG.error(message);
             throw new RuntimeException(message);
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseSchema.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Sets;
 
 import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A parent class for most schema implementations.
@@ -31,6 +32,17 @@ public class BaseSchema implements Schema {
     @Override
     public LinkedHashSet<Column> getColumns() {
         return columns;
+    }
+
+    /**
+     * Get the names of the columns returned by getColumns method.
+     *
+     * @return linked hash set of column names in this schema
+     */
+    public LinkedHashSet<String> getColumnNames() {
+        return getColumns().stream()
+                .map(Column::getName)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
@@ -41,7 +41,7 @@ public class ConcretePhysicalTable extends BasePhysicalTable {
                 timeGrain,
                 columns,
                 logicalToPhysicalColumnNames,
-                new ConcreteAvailability(name, columns, metadataService)
+                new ConcreteAvailability(name, metadataService)
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
@@ -44,7 +44,7 @@ public class PermissiveConcretePhysicalTable extends ConcretePhysicalTable {
                 timeGrain,
                 columns,
                 logicalToPhysicalColumnNames,
-                new PermissiveAvailability(name, columns, dataSourceMetadataService)
+                new PermissiveAvailability(name, dataSourceMetadataService)
         );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
@@ -6,9 +6,6 @@ import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.availability.PermissiveAvailability;
-import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
-import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
-import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
 import java.util.Map;
 import java.util.Set;
@@ -49,13 +46,5 @@ public class PermissiveConcretePhysicalTable extends ConcretePhysicalTable {
                 logicalToPhysicalColumnNames,
                 new PermissiveAvailability(name, dataSourceMetadataService)
         );
-    }
-
-    @Override
-    public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraint) {
-        return getAvailability().getAvailableIntervals(PhysicalDataSourceConstraint.buildWithSchemaUnion(
-                constraint,
-                getSchema()
-        ));
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
@@ -6,6 +6,9 @@ import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.availability.PermissiveAvailability;
+import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
+import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
 import java.util.Map;
 import java.util.Set;
@@ -46,5 +49,13 @@ public class PermissiveConcretePhysicalTable extends ConcretePhysicalTable {
                 logicalToPhysicalColumnNames,
                 new PermissiveAvailability(name, dataSourceMetadataService)
         );
+    }
+
+    @Override
+    public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraint) {
+        return getAvailability().getAvailableIntervals(PhysicalDataSourceConstraint.buildWithSchemaUnion(
+                constraint,
+                getSchema()
+        ));
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -46,7 +46,7 @@ public interface PhysicalTable extends Table {
     DateTime getTableAlignment();
 
     /**
-     * Getter for all the available intervals for the corresponding column.
+     * Getter for all the available intervals for the corresponding columns configured on the table.
      *
      * @return map of column to set of available intervals
      */

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.NotNull;
 /**
  * The schema for a physical table.
  */
-public class PhysicalTableSchema extends BaseSchema implements Schema {
+public class PhysicalTableSchema extends BaseSchema {
 
     private final ZonedTimeGrain timeGrain;
     private final Map<String, String> logicalToPhysicalColumnNames;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
@@ -3,8 +3,7 @@
 package com.yahoo.bard.webservice.table.availability;
 
 import com.yahoo.bard.webservice.data.config.names.TableName;
-import com.yahoo.bard.webservice.table.Column;
-import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
 import org.joda.time.Interval;
@@ -30,14 +29,14 @@ public interface Availability {
      *
      * @return The intervals, by column, available.
      */
-    Map<Column, List<Interval>> getAllAvailableIntervals();
+    Map<String, List<Interval>> getAllAvailableIntervals();
 
     /**
      * Fetch a set of intervals given a set of column name in DataSourceConstraint.
      *
-     * @param constraint  Data constraint containing columns and api filters
+     * @param constraint  Physical data source constraint containing column's physical name, metrics names, api filters
      *
      * @return A simplified list of intervals associated with all column in constraint, empty if column is missing
      */
-    SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraint);
+    SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint);
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -4,12 +4,9 @@ package com.yahoo.bard.webservice.table.availability;
 
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
-import com.yahoo.bard.webservice.table.Column;
-import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.IntervalUtils;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
-
-import com.google.common.collect.ImmutableSet;
 
 import org.joda.time.Interval;
 
@@ -18,8 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
@@ -29,29 +24,23 @@ import javax.validation.constraints.NotNull;
 public class ConcreteAvailability implements Availability {
 
     private final TableName name;
-    private final Set<Column> columns;
     private final DataSourceMetadataService metadataService;
 
-    private final Set<String> columnNames;
     private final Set<TableName> dataSourceNames;
 
     /**
      * Constructor.
      *
      * @param tableName  The name of the table and data source associated with this Availability
-     * @param columns  The columns associated with the table and availability
      * @param metadataService  A service containing the datasource segment data
      */
     public ConcreteAvailability(
             @NotNull TableName tableName,
-            @NotNull Set<Column> columns,
             @NotNull DataSourceMetadataService metadataService
     ) {
         this.name = tableName;
-        this.columns = ImmutableSet.copyOf(columns);
         this.metadataService = metadataService;
 
-        this.columnNames = columns.stream().map(Column::getName).collect(Collectors.toSet());
         this.dataSourceNames = Collections.singleton(name);
     }
 
@@ -61,59 +50,30 @@ public class ConcreteAvailability implements Availability {
     }
 
     @Override
-    public Map<Column, List<Interval>> getAllAvailableIntervals() {
-
-        Map<String, List<Interval>> allAvailableIntervals = getAvailableIntervalsByTable();
-        return columns.stream()
-                .collect(
-                        Collectors.toMap(
-                                Function.identity(),
-                                column -> new SimplifiedIntervalList(
-                                        allAvailableIntervals.getOrDefault(column.getName(), Collections.emptyList())
-                                )
-                        )
-                );
+    public Map<String, List<Interval>> getAllAvailableIntervals() {
+        return metadataService.getAvailableIntervalsByTable(name);
     }
 
     @Override
-    public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraint) {
+    public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
 
-        Set<String> requestColumns = constraint.getAllColumnNames().stream()
-                .filter(columnNames::contains)
-                .collect(Collectors.toSet());
+        Set<String> requestColumns = constraint.getAllColumnPhysicalNames();
 
         if (requestColumns.isEmpty()) {
             return new SimplifiedIntervalList();
         }
 
-        Map<String, List<Interval>> allAvailableIntervals = getAvailableIntervalsByTable();
+        Map<String, List<Interval>> allAvailableIntervals = getAllAvailableIntervals();
 
         // Need to ensure requestColumns is not empty in order to prevent returning null by reduce operation
         return new SimplifiedIntervalList(
                 requestColumns.stream()
-                        .map(columnName -> allAvailableIntervals.getOrDefault(columnName, Collections.emptyList()))
+                        .map(physicalName -> allAvailableIntervals.getOrDefault(physicalName, Collections.emptyList()))
                         .map(intervals -> (Collection<Interval>) intervals)
                         .reduce(null, IntervalUtils::getOverlappingSubintervals)
         );
     }
 
-    /**
-     * Retrieves the most up to date column to available interval map from data source metadata service.
-     *
-     * @return map of column name to list of avialable intervals
-     */
-    protected Map<String, List<Interval>> getAvailableIntervalsByTable() {
-        return metadataService.getAvailableIntervalsByTable(name);
-    }
-
-    /**
-     * Returns the configured columns in their String representation.
-     *
-     * @return the configured columns in their String representation
-     */
-    protected Set<String> getColumnNames() {
-        return columnNames;
-    }
 
     /**
      * Returns the name of the table and data source associated with this Availability.
@@ -126,11 +86,8 @@ public class ConcreteAvailability implements Availability {
 
     @Override
     public String toString() {
-        return String.format("ConcreteAvailability with table name = %s and Configured columns = [%s]",
-                name.asName(),
-                columns.stream()
-                        .map(Column::getName)
-                        .collect(Collectors.joining(", "))
+        return String.format("ConcreteAvailability for table: %s",
+                name.asName()
         );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -68,7 +68,10 @@ public class ConcreteAvailability implements Availability {
         // Need to ensure requestColumns is not empty in order to prevent returning null by reduce operation
         return new SimplifiedIntervalList(
                 requestColumns.stream()
-                        .map(physicalName -> allAvailableIntervals.getOrDefault(physicalName, Collections.emptyList()))
+                        .map(physicalName -> allAvailableIntervals.getOrDefault(
+                                physicalName,
+                                new SimplifiedIntervalList()
+                        ))
                         .map(intervals -> (Collection<Interval>) intervals)
                         .reduce(null, IntervalUtils::getOverlappingSubintervals)
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -80,7 +80,8 @@ public class MetricUnionAvailability implements Availability {
                 .map(MetricColumn::getName)
                 .collect(Collectors.toSet());
 
-        // map each metric to its corresponding availability object
+        // Construct a map of availability to its assigned metric
+        // by intersecting its underlying datasource metrics with table configured metrics
         availabilitiesToMetricNames = physicalTables.stream()
                 .map(PhysicalTable::getAvailability)
                 .collect(
@@ -178,8 +179,7 @@ public class MetricUnionAvailability implements Availability {
     private static boolean isMetricUnique(Map<Availability, Set<String>> availabilityToMetricNames) {
         Set<String> uniqueMetrics = new HashSet<>();
 
-        return availabilityToMetricNames.entrySet().stream()
-                .map(Map.Entry::getValue)
+        return availabilityToMetricNames.values().stream()
                 .flatMap(Set::stream)
                 .allMatch(uniqueMetrics::add);
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -148,6 +148,16 @@ public class MetricUnionAvailability implements Availability {
 
     @Override
     public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
+
+        Set<String> dataSourceMetricNames = availabilitiesToMetricNames.values().stream()
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+
+        // If the table is configured with a column that is not supported by the underlying data sources
+        if (!constraint.getMetricNames().stream().allMatch(dataSourceMetricNames::contains)) {
+            return new SimplifiedIntervalList();
+        }
+
         return new SimplifiedIntervalList(
                 constructSubConstraint(constraint).entrySet().stream()
                         .map(entry -> entry.getKey().getAvailableIntervals(entry.getValue()))

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -6,7 +6,7 @@ import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.table.Column;
 import com.yahoo.bard.webservice.table.PhysicalTable;
-import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.IntervalUtils;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 import com.yahoo.bard.webservice.util.Utils;
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.AbstractMap;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -65,51 +64,37 @@ public class MetricUnionAvailability implements Availability {
     private static final Logger LOG = LoggerFactory.getLogger(MetricUnionAvailability.class);
 
     private final Set<TableName> dataSourceNames;
-    private final Set<MetricColumn> metricColumns;
-    private final Map<Availability, Set<MetricColumn>> availabilitiesToAvailableColumns;
+    private final Set<String> metricNames;
+    private final Map<Availability, Set<String>> availabilitiesToMetricNames;
 
     /**
      * Constructor.
      *
      * @param physicalTables  A set of <tt>PhysicalTable</tt>s whose Dimension schemas are the same and
-     * the Metric Schemas are fully different(i.e. no overlap) on every table
+     * the Metric columns are unique(i.e. no overlap) on every table
      * @param columns  The set of all configured columns, including dimension columns, that metric union availability
      * will respond with
      */
     public MetricUnionAvailability(@NotNull Set<PhysicalTable> physicalTables, @NotNull Set<Column> columns) {
-        metricColumns = Utils.getSubsetByType(columns, MetricColumn.class);
+        metricNames = Utils.getSubsetByType(columns, MetricColumn.class).stream()
+                .map(MetricColumn::getName)
+                .collect(Collectors.toSet());
 
-        // get a map from availability to its available metric columns intersected with configured metric columns
-        // i.e. metricColumns
-        availabilitiesToAvailableColumns = physicalTables.stream()
+        // map each metric to its corresponding availability object
+        availabilitiesToMetricNames = physicalTables.stream()
                 .map(PhysicalTable::getAvailability)
                 .collect(
                         Collectors.toMap(
                                 Function.identity(),
                                 availability ->
                                         Sets.intersection(
-                                                Utils.getSubsetByType(
-                                                        availability.getAllAvailableIntervals().keySet(),
-                                                        MetricColumn.class
-                                                ),
-                                                metricColumns
+                                                availability.getAllAvailableIntervals().keySet(),
+                                                metricNames
                                         )
                         )
                 );
 
-        // validate metric uniqueness such that
-        // each table's underlying datasource schema don't have repeated metric column
-        Map<MetricColumn, Set<Availability>> duplicates = getDuplicateValues(availabilitiesToAvailableColumns);
-        if (!duplicates.isEmpty()) {
-            String message = String.format(
-                    "While constructing MetricUnionAvailability, Metric columns are not unique - %s",
-                    duplicates
-            );
-            LOG.error(message);
-            throw new IllegalArgumentException(message);
-        }
-
-        dataSourceNames = availabilitiesToAvailableColumns.keySet().stream()
+        dataSourceNames = availabilitiesToMetricNames.keySet().stream()
                 .map(Availability::getDataSourceNames)
                 .flatMap(Set::stream)
                 .collect(
@@ -118,6 +103,18 @@ public class MetricUnionAvailability implements Availability {
                                 Collections::unmodifiableSet
                         )
                 );
+
+        // validate metric uniqueness such that
+        // each table's underlying datasource schema don't have repeated metric column
+        if (!isMetricUnique(availabilitiesToMetricNames)) {
+                String message = String.format(
+                        "Metric columns must be unique across the metric union data sources, but duplicate was found " +
+                                "across the following data sources: %s",
+                        getDataSourceNames().stream().map(TableName::asName).collect(Collectors.joining(", "))
+                );
+                LOG.error(message);
+                throw new RuntimeException(message);
+        }
     }
 
     @Override
@@ -134,9 +131,9 @@ public class MetricUnionAvailability implements Availability {
      * @return a map of column to all of its available intervals in union
      */
     @Override
-    public Map<Column, List<Interval>> getAllAvailableIntervals() {
+    public Map<String, List<Interval>> getAllAvailableIntervals() {
         // get all availabilities take available interval maps from all availabilities and merge the maps together
-        return availabilitiesToAvailableColumns.keySet().stream()
+        return availabilitiesToMetricNames.keySet().stream()
                 .map(Availability::getAllAvailableIntervals)
                 .map(Map::entrySet)
                 .flatMap(Set::stream)
@@ -150,7 +147,7 @@ public class MetricUnionAvailability implements Availability {
     }
 
     @Override
-    public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraints) {
+    public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraints) {
         return new SimplifiedIntervalList(
                 constructSubConstraint(constraints).entrySet().stream()
                         .map(entry -> entry.getKey().getAvailableIntervals(entry.getValue()))
@@ -165,59 +162,26 @@ public class MetricUnionAvailability implements Availability {
                 dataSourceNames.stream()
                         .map(TableName::asName)
                         .collect(Collectors.joining(", ")),
-                metricColumns.stream()
-                        .map(Column::getName)
+                metricNames.stream()
                         .collect(Collectors.joining(", "))
         );
     }
 
     /**
-     * Returns duplicate values of <tt>MetricColumn</tt>s in a map of <tt>Availability</tt>
-     * to a set of <tt>MetricColumn</tt>'s contained in that <tt>Availability</tt>.
-     * <p>
-     * The return value is a map of duplicate <tt>MetricColumn</tt> to all <tt>Availabilities</tt>' that contains
-     * this <tt>MetricColumn</tt>
-     * <p>
-     * For example, when a map of {availability1: [metricCol1, metricCol2], availability2: [metricCol1]} is passed to
-     * this method, the method returns {metricCol1: [availability1, availability2]}
+     * Validates whether the metric columns are unique accross each of the underlying datasource.
      *
-     * @param availabilityToAvailableColumns  A map from <tt>Availability</tt> to set of <tt>MetricColumn</tt>
+     * @param availabilityToMetricNames  A map from <tt>Availability</tt> to set of <tt>MetricColumn</tt>
      * contained in that <tt>Availability</tt>
      *
-     * @return duplicate values of <tt>MetricColumn</tt>s
+     * @return true if metric is unique across data sources, false otherwise
      */
-    private static Map<MetricColumn, Set<Availability>> getDuplicateValues(
-            Map<Availability, Set<MetricColumn>> availabilityToAvailableColumns
-    ) {
-        Map<MetricColumn, Set<Availability>> metricColumnSetMap = new HashMap<>();
+    private static boolean isMetricUnique(Map<Availability, Set<String>> availabilityToMetricNames) {
+        Set<String> uniqueMetrics = new HashSet<>();
 
-        for (Map.Entry<Availability, Set<MetricColumn>> entry : availabilityToAvailableColumns.entrySet()) {
-            Availability availability = entry.getKey();
-            for (MetricColumn metricColumn : entry.getValue()) {
-                metricColumnSetMap.put(
-                        metricColumn,
-                        Sets.union(
-                                metricColumnSetMap.getOrDefault(metricColumn, new HashSet<>()),
-                                Sets.newHashSet(availability)
-                        )
-                );
-            }
-        }
-
-        // For example, when a map of {availability1: [metricCol1, metricCol2], availability2: [metricCol1]} is
-        // passed to this method, at this point,
-        // "metricColumnSetMap" =  {metricCol1: [availability1, availability2], {metricCol2: [availability1]}}
-        // The duplicate metric columns is "metricCol1" which can be selected by knowing that the value of "metricCol1"
-        // has a collection whose size is greater than 1; with that, we return
-        // {metricCol1: [availability1, availability2]}
-        return metricColumnSetMap.entrySet().stream()
-                .filter(entry -> entry.getValue().size() > 1)
-                .collect(
-                        Collectors.toMap(
-                                Map.Entry::getKey,
-                                Map.Entry::getValue
-                        )
-                );
+        return availabilityToMetricNames.entrySet().stream()
+                .map(Map.Entry::getValue)
+                .flatMap(Set::stream)
+                .allMatch(uniqueMetrics::add);
     }
 
     /**
@@ -233,8 +197,10 @@ public class MetricUnionAvailability implements Availability {
      *
      * @return A map from <tt>Availability</tt> to <tt>DataSourceConstraint</tt> with non-empty metric names
      */
-    private Map<Availability, DataSourceConstraint> constructSubConstraint(DataSourceConstraint constraint) {
-        return availabilitiesToAvailableColumns.entrySet().stream()
+    private Map<Availability, PhysicalDataSourceConstraint> constructSubConstraint(
+            PhysicalDataSourceConstraint constraint
+    ) {
+        return availabilitiesToMetricNames.entrySet().stream()
                 .map(entry ->
                         new AbstractMap.SimpleEntry<>(
                                 entry.getKey(),
@@ -242,11 +208,6 @@ public class MetricUnionAvailability implements Availability {
                         )
                 )
                 .filter(entry -> !entry.getValue().getMetricNames().isEmpty())
-                .collect(
-                        Collectors.toMap(
-                                Map.Entry::getKey,
-                                Map.Entry::getValue
-                        )
-                );
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -148,12 +148,6 @@ public class MetricUnionAvailability implements Availability {
 
     @Override
     public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
-
-        // If there are columns requested that are not configured on this table
-        if (constraint.getAllColumnPhysicalNames().size() != constraint.getAllColumnNames().size()) {
-            return new SimplifiedIntervalList();
-        }
-
         return new SimplifiedIntervalList(
                 constructSubConstraint(constraint).entrySet().stream()
                         .map(entry -> entry.getKey().getAvailableIntervals(entry.getValue()))

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
@@ -4,15 +4,14 @@ package com.yahoo.bard.webservice.table.availability;
 
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
-import com.yahoo.bard.webservice.table.Column;
-import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
+
 import org.joda.time.Interval;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
@@ -26,16 +25,14 @@ public class PermissiveAvailability extends ConcreteAvailability {
     /**
      * Constructor.
      *
-     * @param tableName The name of the data source
-     * @param columns A set of columns associated with the data source
-     * @param metadataService A service containing the data source segment data
+     * @param tableName  The name of the data source
+     * @param metadataService  A service containing the data source segment data
      */
     public PermissiveAvailability(
             @NotNull TableName tableName,
-            @NotNull Set<Column> columns,
             @NotNull DataSourceMetadataService metadataService
     ) {
-        super(tableName, columns, metadataService);
+        super(tableName, metadataService);
     }
 
     /**
@@ -43,19 +40,21 @@ public class PermissiveAvailability extends ConcreteAvailability {
      * <p>
      * This is different from its parent's
      * {@link
-     * com.yahoo.bard.webservice.table.availability.ConcreteAvailability#getAvailableIntervals(DataSourceConstraint)};
+     * com.yahoo.bard.webservice.table.availability.ConcreteAvailability#getAvailableIntervals
+     * (PhysicalDataSourceConstraint)};
      * Instead of returning the intersection of all available intervals, this method returns the union of them.
      *
-     * @param ignoredConstraints  Data constraint containing columns and api filters. Constrains are ignored, because
+     * @param constraint  Data constraint containing columns and api filters. Constrains are ignored, because
      * <tt>PermissiveAvailability</tt> returns as much available intervals as possible by, for example, allowing
      * missing intervals and returning unions of available intervals
      *
      * @return the union of all available intervals
      */
     @Override
-    public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint ignoredConstraints) {
-        Map<String, List<Interval>> allAvailableIntervals = getAvailableIntervalsByTable();
-        return getColumnNames().stream()
+    public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
+        Map<String, List<Interval>> allAvailableIntervals = getAllAvailableIntervals();
+
+        return constraint.getAllColumnPhysicalNames().stream()
                 .map(columnName -> allAvailableIntervals.getOrDefault(columnName, Collections.emptyList()))
                 .flatMap(List::stream)
                 .collect(SimplifiedIntervalList.getCollector());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
@@ -40,8 +40,9 @@ public class PermissiveAvailability extends ConcreteAvailability {
      * <p>
      * This is different from its parent's
      * {@link
-     * com.yahoo.bard.webservice.table.availability.ConcreteAvailability#getAvailableIntervals
-     * (PhysicalDataSourceConstraint)};
+     * com.yahoo.bard.webservice.table.availability.ConcreteAvailability#getAvailableIntervals(
+     * PhysicalDataSourceConstraint
+     * )};
      * Instead of returning the intersection of all available intervals, this method returns the union of them.
      *
      * @param constraint  Data constraint containing columns and api filters. Constrains are ignored, because

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
@@ -55,9 +55,8 @@ public class PermissiveAvailability extends ConcreteAvailability {
 
     @Override
     public String toString() {
-        return String.format("PermissiveAvailability with table name = %s and Configured columns = [%s]",
-                getName().asName(),
-                getColumnNames()
+        return String.format("PermissiveAvailability with table name = %s",
+                getName().asName()
         );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
@@ -7,12 +7,6 @@ import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
-import org.joda.time.Interval;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import javax.validation.constraints.NotNull;
 
 /**
@@ -45,20 +39,18 @@ public class PermissiveAvailability extends ConcreteAvailability {
      * )};
      * Instead of returning the intersection of all available intervals, this method returns the union of them.
      *
-     * @param constraint  Data constraint containing columns and api filters. Constrains are ignored, because
+     * @param ignoredConstraint  Data constraint containing columns and api filters. Constrains are ignored, because
      * <tt>PermissiveAvailability</tt> returns as much available intervals as possible by, for example, allowing
      * missing intervals and returning unions of available intervals
      *
      * @return the union of all available intervals
      */
     @Override
-    public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
-        Map<String, List<Interval>> allAvailableIntervals = getAllAvailableIntervals();
+    public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint ignoredConstraint) {
 
-        return constraint.getAllColumnPhysicalNames().stream()
-                .map(columnName -> allAvailableIntervals.getOrDefault(columnName, Collections.emptyList()))
-                .flatMap(List::stream)
-                .collect(SimplifiedIntervalList.getCollector());
+        return getAllAvailableIntervals().values().stream()
+                .map(SimplifiedIntervalList::new)
+                .reduce(new SimplifiedIntervalList(), SimplifiedIntervalList::simplifyIntervals);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
@@ -47,7 +47,6 @@ public class PermissiveAvailability extends ConcreteAvailability {
      */
     @Override
     public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint ignoredConstraint) {
-
         return getAllAvailableIntervals().values().stream()
                 .map(SimplifiedIntervalList::new)
                 .reduce(new SimplifiedIntervalList(), SimplifiedIntervalList::simplifyIntervals);
@@ -55,8 +54,6 @@ public class PermissiveAvailability extends ConcreteAvailability {
 
     @Override
     public String toString() {
-        return String.format("PermissiveAvailability with table name = %s",
-                getName().asName()
-        );
+        return String.format("PermissiveAvailability with table name = %s", getName().asName());
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
@@ -3,7 +3,6 @@
 package com.yahoo.bard.webservice.table.resolver;
 
 import com.yahoo.bard.webservice.data.dimension.Dimension;
-import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.web.ApiFilter;
 import com.yahoo.bard.webservice.web.DataApiRequest;
@@ -87,6 +86,22 @@ public class DataSourceConstraint {
         this.apiFilters = apiFilters;
     }
 
+    /**
+     * Copy Constructor.
+     *
+     * @param dataSourceConstraint  The data source constraint to copy from
+     */
+    protected DataSourceConstraint(DataSourceConstraint dataSourceConstraint) {
+        this.requestDimensions = dataSourceConstraint.getRequestDimensions();
+        this.filterDimensions = dataSourceConstraint.getFilterDimensions();
+        this.metricDimensions = dataSourceConstraint.getMetricDimensions();
+        this.metricNames = dataSourceConstraint.getMetricNames();
+        this.apiFilters = dataSourceConstraint.getApiFilters();
+        this.allDimensions = dataSourceConstraint.getAllDimensions();
+        this.allDimensionNames = dataSourceConstraint.getAllDimensionNames();
+        this.allColumnNames = dataSourceConstraint.getAllColumnNames();
+    }
+
     public Set<Dimension> getRequestDimensions() {
         return requestDimensions;
     }
@@ -126,19 +141,18 @@ public class DataSourceConstraint {
      * The new set of metric names will be an intersection between old metric names and
      * a user provided set of metric names
      *
-     * @param metricColumns  The set of metric columns that are to be intersected with metric names in
+     * @param metricNames  The set of metric names that are to be intersected with metric names in
      * <tt>this DataSourceConstraint</tt>
      *
      * @return the new <tt>DataSourceConstraint</tt> instance with a new subset of metric names
      */
-    public DataSourceConstraint withMetricIntersection(Set<MetricColumn> metricColumns) {
+    public DataSourceConstraint withMetricIntersection(Set<String> metricNames) {
         return new DataSourceConstraint(
                 requestDimensions,
                 filterDimensions,
                 metricDimensions,
-                metricColumns.stream()
-                        .map(MetricColumn::getName)
-                        .filter(metricNames::contains)
+                metricNames.stream()
+                        .filter(this.metricNames::contains)
                         .collect(Collectors.toSet()),
                 allDimensions,
                 allDimensionNames,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
@@ -1,0 +1,48 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.resolver;
+
+import com.yahoo.bard.webservice.table.Column;
+import com.yahoo.bard.webservice.table.PhysicalTableSchema;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Data source constraint containing physical name of the columns.
+ */
+public class PhysicalDataSourceConstraint extends DataSourceConstraint {
+
+    private final Set<String> allColumnPhysicalNames;
+
+    /**
+     * Constructor.
+     *
+     * @param dataSourceConstraint  Data source constraint containing all the column names as logical names
+     * @param physicalTableSchema  A map from logical column name to physical column names
+     */
+    public PhysicalDataSourceConstraint(
+            DataSourceConstraint dataSourceConstraint,
+            PhysicalTableSchema physicalTableSchema
+    ) {
+        super(dataSourceConstraint);
+
+        Set<String> schemaColumnNames = physicalTableSchema.getColumns().stream()
+                .map(Column::getName)
+                .collect(Collectors.toSet());
+
+        this.allColumnPhysicalNames = dataSourceConstraint.getAllColumnNames().stream()
+                .filter(schemaColumnNames::contains)
+                .map(physicalTableSchema::getPhysicalColumnName)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Getter for the all column names as physical names.
+     *
+     * @return the physical name of all the columns
+     */
+    public Set<String> getAllColumnPhysicalNames() {
+        return allColumnPhysicalNames;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
@@ -38,7 +38,8 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
     }
 
     /**
-     * Constructor, use with care, beware of inconsistent caching behavior.
+     * Constructor, use with care, beware of possible inconsistent between underlying dimension and metrics property
+     * and allColumnPhysicalName.
      *
      * @param dataSourceConstraint  Data source constraint containing all the column names as logical names
      * @param allColumnPhysicalNames  The physical names of the columns

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
@@ -29,10 +29,7 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
     ) {
         super(dataSourceConstraint);
 
-        Set<String> schemaColumnNames = physicalTableSchema.getColumnNames();
-
         this.allColumnPhysicalNames = dataSourceConstraint.getAllColumnNames().stream()
-                .filter(schemaColumnNames::contains)
                 .map(physicalTableSchema::getPhysicalColumnName)
                 .collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
@@ -27,12 +27,31 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
     ) {
         super(dataSourceConstraint);
 
+        Set<String> schemaColumnNames = physicalTableSchema.getColumnNames();
+
+        this.allColumnPhysicalNames = dataSourceConstraint.getAllColumnNames().stream()
+                .filter(schemaColumnNames::contains)
+                .map(physicalTableSchema::getPhysicalColumnName)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Private Constructor that union columns in constraint and schema, use buildWithSchemaUnion to invoke.
+     *
+     * @param physicalTableSchema  A map from logical column name to physical column names
+     * @param dataSourceConstraint  Data source constraint containing all the column names as logical names
+     */
+    private PhysicalDataSourceConstraint(
+            PhysicalTableSchema physicalTableSchema,
+            DataSourceConstraint dataSourceConstraint
+    ) {
+        super(dataSourceConstraint);
+
         Set<String> schemaColumnNames = physicalTableSchema.getColumns().stream()
                 .map(Column::getName)
                 .collect(Collectors.toSet());
 
-        this.allColumnPhysicalNames = dataSourceConstraint.getAllColumnNames().stream()
-                .filter(schemaColumnNames::contains)
+        this.allColumnPhysicalNames = schemaColumnNames.stream()
                 .map(physicalTableSchema::getPhysicalColumnName)
                 .collect(Collectors.toSet());
     }
@@ -44,5 +63,20 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
      */
     public Set<String> getAllColumnPhysicalNames() {
         return allColumnPhysicalNames;
+    }
+
+    /**
+     * Builds a physical data source constraint with the union of columns in schema.
+     *
+     * @param dataSourceConstraint  Data source constraint containing all the column names as logical names
+     * @param physicalTableSchema  A map from logical column name to physical column names
+     *
+     * @return a new physical data source constraint with all columns in schema
+     */
+    public static PhysicalDataSourceConstraint buildWithSchemaUnion(
+            DataSourceConstraint dataSourceConstraint,
+            PhysicalTableSchema physicalTableSchema
+    ) {
+        return new PhysicalDataSourceConstraint(physicalTableSchema, dataSourceConstraint);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
@@ -2,12 +2,9 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver;
 
-import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.table.PhysicalTableSchema;
-import com.yahoo.bard.webservice.web.ApiFilter;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -41,7 +38,7 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
     }
 
     /**
-     * Constructor, use with care, beware of caching behavior.
+     * Constructor, use with care, beware of inconsistent caching behavior.
      *
      * @param dataSourceConstraint  Data source constraint containing all the column names as logical names
      * @param allColumnPhysicalNames  The physical names of the columns
@@ -53,43 +50,6 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
         super(dataSourceConstraint);
         this.allColumnPhysicalNames = allColumnPhysicalNames;
 
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param requestDimensions  Dimensions contained in request
-     * @param filterDimensions  Filtered dimensions
-     * @param metricDimensions  Metric related dimensions
-     * @param metricNames  Names of metrics
-     * @param allDimensions  Set of all dimension objects
-     * @param allDimensionNames  Set of all dimension names
-     * @param allColumnNames  Set of all column names
-     * @param apiFilters  Map of dimension to its set of API filters
-     * @param allColumnPhysicalNames  Set of all column physical names
-     */
-    protected PhysicalDataSourceConstraint(
-            Set<Dimension> requestDimensions,
-            Set<Dimension> filterDimensions,
-            Set<Dimension> metricDimensions,
-            Set<String> metricNames,
-            Set<Dimension> allDimensions,
-            Set<String> allDimensionNames,
-            Set<String> allColumnNames,
-            Map<Dimension, Set<ApiFilter>> apiFilters,
-            Set<String> allColumnPhysicalNames
-    ) {
-        super(
-                requestDimensions,
-                filterDimensions,
-                metricDimensions,
-                metricNames,
-                allDimensions,
-                allDimensionNames,
-                allColumnNames,
-                apiFilters
-        );
-        this.allColumnPhysicalNames = allColumnPhysicalNames;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
@@ -2,11 +2,12 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver;
 
-import com.yahoo.bard.webservice.table.Column;
 import com.yahoo.bard.webservice.table.PhysicalTableSchema;
 
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * Data source constraint containing physical name of the columns.
@@ -22,8 +23,8 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
      * @param physicalTableSchema  A map from logical column name to physical column names
      */
     public PhysicalDataSourceConstraint(
-            DataSourceConstraint dataSourceConstraint,
-            PhysicalTableSchema physicalTableSchema
+            @NotNull DataSourceConstraint dataSourceConstraint,
+            @NotNull PhysicalTableSchema physicalTableSchema
     ) {
         super(dataSourceConstraint);
 
@@ -36,47 +37,11 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
     }
 
     /**
-     * Private Constructor that union columns in constraint and schema, use buildWithSchemaUnion to invoke.
-     *
-     * @param physicalTableSchema  A map from logical column name to physical column names
-     * @param dataSourceConstraint  Data source constraint containing all the column names as logical names
-     */
-    private PhysicalDataSourceConstraint(
-            PhysicalTableSchema physicalTableSchema,
-            DataSourceConstraint dataSourceConstraint
-    ) {
-        super(dataSourceConstraint);
-
-        Set<String> schemaColumnNames = physicalTableSchema.getColumns().stream()
-                .map(Column::getName)
-                .collect(Collectors.toSet());
-
-        this.allColumnPhysicalNames = schemaColumnNames.stream()
-                .map(physicalTableSchema::getPhysicalColumnName)
-                .collect(Collectors.toSet());
-    }
-
-    /**
      * Getter for the all column names as physical names.
      *
      * @return the physical name of all the columns
      */
     public Set<String> getAllColumnPhysicalNames() {
         return allColumnPhysicalNames;
-    }
-
-    /**
-     * Builds a physical data source constraint with the union of columns in schema.
-     *
-     * @param dataSourceConstraint  Data source constraint containing all the column names as logical names
-     * @param physicalTableSchema  A map from logical column name to physical column names
-     *
-     * @return a new physical data source constraint with all columns in schema
-     */
-    public static PhysicalDataSourceConstraint buildWithSchemaUnion(
-            DataSourceConstraint dataSourceConstraint,
-            PhysicalTableSchema physicalTableSchema
-    ) {
-        return new PhysicalDataSourceConstraint(physicalTableSchema, dataSourceConstraint);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
@@ -2,8 +2,12 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver;
 
+import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.table.PhysicalTableSchema;
+import com.yahoo.bard.webservice.web.ApiFilter;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -33,7 +37,59 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
         this.allColumnPhysicalNames = dataSourceConstraint.getAllColumnNames().stream()
                 .filter(schemaColumnNames::contains)
                 .map(physicalTableSchema::getPhysicalColumnName)
-                .collect(Collectors.toSet());
+                .collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
+    }
+
+    /**
+     * Constructor, use with care, beware of caching behavior.
+     *
+     * @param dataSourceConstraint  Data source constraint containing all the column names as logical names
+     * @param allColumnPhysicalNames  The physical names of the columns
+     */
+    private PhysicalDataSourceConstraint(
+            @NotNull DataSourceConstraint dataSourceConstraint,
+            @NotNull Set<String> allColumnPhysicalNames
+    ) {
+        super(dataSourceConstraint);
+        this.allColumnPhysicalNames = allColumnPhysicalNames;
+
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param requestDimensions  Dimensions contained in request
+     * @param filterDimensions  Filtered dimensions
+     * @param metricDimensions  Metric related dimensions
+     * @param metricNames  Names of metrics
+     * @param allDimensions  Set of all dimension objects
+     * @param allDimensionNames  Set of all dimension names
+     * @param allColumnNames  Set of all column names
+     * @param apiFilters  Map of dimension to its set of API filters
+     * @param allColumnPhysicalNames  Set of all column physical names
+     */
+    protected PhysicalDataSourceConstraint(
+            Set<Dimension> requestDimensions,
+            Set<Dimension> filterDimensions,
+            Set<Dimension> metricDimensions,
+            Set<String> metricNames,
+            Set<Dimension> allDimensions,
+            Set<String> allDimensionNames,
+            Set<String> allColumnNames,
+            Map<Dimension, Set<ApiFilter>> apiFilters,
+            Set<String> allColumnPhysicalNames
+    ) {
+        super(
+                requestDimensions,
+                filterDimensions,
+                metricDimensions,
+                metricNames,
+                allDimensions,
+                allDimensionNames,
+                allColumnNames,
+                apiFilters
+        );
+        this.allColumnPhysicalNames = allColumnPhysicalNames;
     }
 
     /**
@@ -43,5 +99,29 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
      */
     public Set<String> getAllColumnPhysicalNames() {
         return allColumnPhysicalNames;
+    }
+
+    /**
+     * Create a new <tt>PhysicalDataSourceConstraint</tt> instance with a new subset of metric names.
+     * <p>
+     * The new set of metric names will be an intersection between old metric names and
+     * a user provided set of metric names
+     *
+     * @param metricNames  The set of metric columns that are to be intersected with metric names in
+     * <tt>this DataSourceConstraint</tt>
+     *
+     * @return the new <tt>PhysicalDataSourceConstraint</tt> instance with a new subset of metric names
+     */
+    @Override
+    public PhysicalDataSourceConstraint withMetricIntersection(Set<String> metricNames) {
+        Set<String> nonIntersectingMetric = getMetricNames().stream()
+                .filter(metricName -> !metricNames.contains(metricName))
+                .collect(Collectors.toSet());
+
+        Set<String> resultColumnNames = this.allColumnPhysicalNames.stream()
+                .filter(name -> !nonIntersectingMetric.contains(name))
+                .collect(Collectors.toSet());
+
+        return new PhysicalDataSourceConstraint(super.withMetricIntersection(metricNames), resultColumnNames);
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
@@ -57,11 +57,11 @@ class PartialDataHandlerSpec extends Specification {
          * dim1 is missing four days of data internally, dim2 and dim3 are complete over the period and page_views is
          * starts inside the dim1 hole and goes to the end of the period.
          */
-        Map<Column, Set<Interval>> segmentIntervals = [
-                (new Column("userDeviceType")): buildIntervals(["2014-07-01/2014-07-09","2014-07-11/2014-07-29"]) as Set,
-                (new Column("property")): buildIntervals(["2014-07-01/2014-07-29"]) as Set,
-                (new Column("os")): buildIntervals(["2014-07-01/2014-07-29"]) as Set,
-                (new Column("page_views")): buildIntervals(["2014-07-04/2014-07-29"]) as Set
+        Map<String, Set<Interval>> segmentIntervals = [
+                'user_device_type': buildIntervals(["2014-07-01/2014-07-09","2014-07-11/2014-07-29"]) as Set,
+                'property': buildIntervals(["2014-07-01/2014-07-29"]) as Set,
+                'os': buildIntervals(["2014-07-01/2014-07-29"]) as Set,
+                'page_views': buildIntervals(["2014-07-04/2014-07-29"]) as Set
         ]
 
         table = new ConcretePhysicalTable(

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
@@ -233,21 +233,21 @@ public class QueryBuildingTestingResources {
         t4d1 = new ConcretePhysicalTable("table4d1", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
         t4d2 = new ConcretePhysicalTable("table4d2", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
 
-        Map<Column, Set<Interval>> availabilityMap1 = [:]
-        Map<Column, Set<Interval>> availabilityMap2 = [:]
+        Map<String, Set<Interval>> availabilityMap1 = [:]
+        Map<String, Set<Interval>> availabilityMap2 = [:]
 
         [d1, d2, m1, m2, m3].each {
-            availabilityMap1.put(toColumn(it), [interval1].toSet())
-            availabilityMap2.put(toColumn(it), [interval2].toSet())
+            availabilityMap1.put(toColumn(it).getName(), [interval1].toSet())
+            availabilityMap2.put(toColumn(it).getName(), [interval2].toSet())
         }
 
-        t4h1.setAvailability(new ConcreteAvailability(t4h1.getTableName(), t4h1.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap1)))
-        t4d1.setAvailability(new ConcreteAvailability(t4d1.getTableName(), t4d1.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap1)))
+        t4h1.setAvailability(new ConcreteAvailability(t4h1.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
+        t4d1.setAvailability(new ConcreteAvailability(t4d1.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
 
         t5h = new ConcretePhysicalTable("table5d", utcHour, [d8, d9, d10, d11, d12, d13, m1].collect{toColumn(it)}.toSet(), [:], metadataService)
 
-        t4h2.setAvailability(new ConcreteAvailability(t4h2.getTableName(), t4h2.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap2)))
-        t4d2.setAvailability(new ConcreteAvailability(t4d1.getTableName(), t4d1.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap2)))
+        t4h2.setAvailability(new ConcreteAvailability(t4h2.getTableName(), new TestDataSourceMetadataService(availabilityMap2)))
+        t4d2.setAvailability(new ConcreteAvailability(t4d1.getTableName(), new TestDataSourceMetadataService(availabilityMap2)))
 
         setupPartialData()
 
@@ -319,19 +319,19 @@ public class QueryBuildingTestingResources {
         partialSecond = new ConcretePhysicalTable("partialSecond", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
         wholeThird = new ConcretePhysicalTable("wholeThird", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
 
-        Map<Column, Set<Interval>> availabilityMap1 = [:]
-        Map<Column, Set<Interval>> availabilityMap2 = [:]
-        Map<Column, Set<Interval>> availabilityMap3 = [:]
+        Map<String, Set<Interval>> availabilityMap1 = [:]
+        Map<String, Set<Interval>> availabilityMap2 = [:]
+        Map<String, Set<Interval>> availabilityMap3 = [:]
 
         [d1, d2, m1, m2, m3].each {
-            availabilityMap1.put(toColumn(it), [new Interval("2015/2015")].toSet())
-            availabilityMap2.put(toColumn(it), [new Interval("2015/2016")].toSet())
-            availabilityMap3.put(toColumn(it), [new Interval("2011/2016")].toSet())
+            availabilityMap1.put(toColumn(it).getName(), [new Interval("2015/2015")].toSet())
+            availabilityMap2.put(toColumn(it).getName(), [new Interval("2015/2016")].toSet())
+            availabilityMap3.put(toColumn(it).getName(), [new Interval("2011/2016")].toSet())
         }
-        emptyFirst.setAvailability(new ConcreteAvailability(emptyFirst.getTableName(), emptyFirst.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap1)))
-        emptyLast.setAvailability(new ConcreteAvailability(emptyLast.getTableName(), emptyLast.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap1)))
-        partialSecond.setAvailability(new ConcreteAvailability(partialSecond.getTableName(), partialSecond.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap2)))
-        wholeThird.setAvailability(new ConcreteAvailability(wholeThird.getTableName(), wholeThird.getSchema().getColumns(), new TestDataSourceMetadataService(availabilityMap3)))
+        emptyFirst.setAvailability(new ConcreteAvailability(emptyFirst.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
+        emptyLast.setAvailability(new ConcreteAvailability(emptyLast.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
+        partialSecond.setAvailability(new ConcreteAvailability(partialSecond.getTableName(), new TestDataSourceMetadataService(availabilityMap2)))
+        wholeThird.setAvailability(new ConcreteAvailability(wholeThird.getTableName(), new TestDataSourceMetadataService(availabilityMap3)))
 
         tg1All = new TableGroup([emptyFirst, partialSecond, wholeThird, emptyLast] as LinkedHashSet, [].toSet(), [].toSet())
         ti1All = new TableIdentifier("base1All", AllGranularity.INSTANCE)
@@ -350,9 +350,8 @@ public class QueryBuildingTestingResources {
             table.setAvailability(
                     new ConcreteAvailability(
                             table.getTableName(),
-                            table.getSchema().getColumns(),
                             new TestDataSourceMetadataService(
-                                [new DimensionColumn(d1), new LogicalMetricColumn(m1)].collectEntries() {
+                                [new DimensionColumn(d1).getName(), new LogicalMetricColumn(m1).getName()].collectEntries() {
                                     [(it): [availability]]
                                 }
                             )

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
@@ -213,53 +213,53 @@ public class QueryBuildingTestingResources {
         TimeGrain utcHour = HOUR.buildZonedTimeGrain(UTC)
         TimeGrain utcDay = DAY.buildZonedTimeGrain(UTC)
 
-        volatileHourTable = new ConcretePhysicalTable("hour", HOUR.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)}.toSet(), [:], metadataService)
-        volatileDayTable = new ConcretePhysicalTable("day", DAY.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)}.toSet(), [:], metadataService)
+        volatileHourTable = new ConcretePhysicalTable("hour", HOUR.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
+        volatileDayTable = new ConcretePhysicalTable("day", DAY.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t1h = new ConcretePhysicalTable("table1h", utcHour, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)}.toSet(), ["ageBracket":"age_bracket"], metadataService)
-        t1d = new ConcretePhysicalTable("table1d", utcDay, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)}.toSet(), ["ageBracket":"age_bracket"], metadataService)
-        t1hShort = new ConcretePhysicalTable("table1Short", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
+        t1h = new ConcretePhysicalTable("table1h", utcHour, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        t1d = new ConcretePhysicalTable("table1d", utcDay, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        t1hShort = new ConcretePhysicalTable("table1Short", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t2h = new ConcretePhysicalTable("table2", utcHour, [d1, d2, d4, m1, m4, m5].collect{toColumn(it)}.toSet(), [:], metadataService)
-        t3d = new ConcretePhysicalTable("table3", utcDay, [d1, d2, d5, m6].collect{toColumn(it)}.toSet(), [:], metadataService)
+        t2h = new ConcretePhysicalTable("table2", utcHour, [d1, d2, d4, m1, m4, m5].collect{toColumn(it)} as Set, [:], metadataService)
+        t3d = new ConcretePhysicalTable("table3", utcDay, [d1, d2, d5, m6].collect{toColumn(it)} as Set, [:], metadataService)
 
-        tna1236d = new ConcretePhysicalTable("tableNA1236", utcDay, [d1, d2, d3, d6].collect{toColumn(it)}.toSet(),["ageBracket":"age_bracket"], metadataService)
-        tna1237d = new ConcretePhysicalTable("tableNA1237", utcDay, [d1, d2, d3, d7].collect{toColumn(it)}.toSet(), ["ageBracket":"age_bracket"], metadataService)
-        tna167d = new ConcretePhysicalTable("tableNA167", utcDay, [d1, d6, d7].collect{toColumn(it)}.toSet(), ["ageBracket":"age_bracket", "dim7":"dim_7"], metadataService)
-        tna267d = new ConcretePhysicalTable("tableNA267", utcDay, [d2, d6, d7].collect{toColumn(it)}.toSet(), ["dim7":"dim_7"], metadataService)
+        tna1236d = new ConcretePhysicalTable("tableNA1236", utcDay, [d1, d2, d3, d6].collect{toColumn(it)} as Set,["ageBracket":"age_bracket"], metadataService)
+        tna1237d = new ConcretePhysicalTable("tableNA1237", utcDay, [d1, d2, d3, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        tna167d = new ConcretePhysicalTable("tableNA167", utcDay, [d1, d6, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket", "dim7":"dim_7"], metadataService)
+        tna267d = new ConcretePhysicalTable("tableNA267", utcDay, [d2, d6, d7].collect{toColumn(it)} as Set, ["dim7":"dim_7"], metadataService)
 
-        t4h1 = new ConcretePhysicalTable("table4h1", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        t4h2 = new ConcretePhysicalTable("table4h2", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        t4d1 = new ConcretePhysicalTable("table4d1", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        t4d2 = new ConcretePhysicalTable("table4d2", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
+        t4h1 = new ConcretePhysicalTable("table4h1", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4h2 = new ConcretePhysicalTable("table4h2", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4d1 = new ConcretePhysicalTable("table4d1", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4d2 = new ConcretePhysicalTable("table4d2", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
         Map<String, Set<Interval>> availabilityMap1 = [:]
         Map<String, Set<Interval>> availabilityMap2 = [:]
 
         [d1, d2, m1, m2, m3].each {
-            availabilityMap1.put(toColumn(it).getName(), [interval1].toSet())
-            availabilityMap2.put(toColumn(it).getName(), [interval2].toSet())
+            availabilityMap1.put(toColumn(it).getName(), [interval1] as Set)
+            availabilityMap2.put(toColumn(it).getName(), [interval2] as Set)
         }
 
         t4h1.setAvailability(new ConcreteAvailability(t4h1.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
         t4d1.setAvailability(new ConcreteAvailability(t4d1.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
 
-        t5h = new ConcretePhysicalTable("table5d", utcHour, [d8, d9, d10, d11, d12, d13, m1].collect{toColumn(it)}.toSet(), [:], metadataService)
+        t5h = new ConcretePhysicalTable("table5d", utcHour, [d8, d9, d10, d11, d12, d13, m1].collect{toColumn(it)} as Set, [:], metadataService)
 
         t4h2.setAvailability(new ConcreteAvailability(t4h2.getTableName(), new TestDataSourceMetadataService(availabilityMap2)))
         t4d2.setAvailability(new ConcreteAvailability(t4d1.getTableName(), new TestDataSourceMetadataService(availabilityMap2)))
 
         setupPartialData()
 
-        tg1h = new TableGroup([t1h, t1d, t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [d1].toSet())
-        tg1d = new TableGroup([t1d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [d1].toSet())
-        tg1Short = new TableGroup([t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg2h = new TableGroup([t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg3d = new TableGroup([t3d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg4h = new TableGroup([t1h, t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg5h = new TableGroup([t2h, t1h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
-        tg6h = new TableGroup([t5h] as LinkedHashSet, [].toSet(), [].toSet())
-        tgna = new TableGroup([tna1236d, tna1237d, tna167d, tna267d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())}.toSet(), [].toSet())
+        tg1h = new TableGroup([t1h, t1d, t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [d1] as Set)
+        tg1d = new TableGroup([t1d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [d1] as Set)
+        tg1Short = new TableGroup([t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg2h = new TableGroup([t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg3d = new TableGroup([t3d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg4h = new TableGroup([t1h, t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg5h = new TableGroup([t2h, t1h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg6h = new TableGroup([t5h] as LinkedHashSet, [] as Set, [] as Set)
+        tgna = new TableGroup([tna1236d, tna1237d, tna167d, tna267d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
 
         lt12 = new LogicalTable("base12", HOUR, tg1h, metricDictionary)
         lt13 = new LogicalTable("base13", DAY, tg1d, metricDictionary)
@@ -314,26 +314,26 @@ public class QueryBuildingTestingResources {
     def setupPartialData() {
         // In the event of partiality on all data, the coarsest table will be selected and the leftmost of the
         // coarsest tables should be selected
-        emptyFirst = new ConcretePhysicalTable("emptyFirst", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        emptyLast = new ConcretePhysicalTable("emptyLast", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        partialSecond = new ConcretePhysicalTable("partialSecond", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
-        wholeThird = new ConcretePhysicalTable("wholeThird", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)}.toSet(), [:], metadataService)
+        emptyFirst = new ConcretePhysicalTable("emptyFirst", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        emptyLast = new ConcretePhysicalTable("emptyLast", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        partialSecond = new ConcretePhysicalTable("partialSecond", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        wholeThird = new ConcretePhysicalTable("wholeThird", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
         Map<String, Set<Interval>> availabilityMap1 = [:]
         Map<String, Set<Interval>> availabilityMap2 = [:]
         Map<String, Set<Interval>> availabilityMap3 = [:]
 
         [d1, d2, m1, m2, m3].each {
-            availabilityMap1.put(toColumn(it).getName(), [new Interval("2015/2015")].toSet())
-            availabilityMap2.put(toColumn(it).getName(), [new Interval("2015/2016")].toSet())
-            availabilityMap3.put(toColumn(it).getName(), [new Interval("2011/2016")].toSet())
+            availabilityMap1.put(toColumn(it).getName(), [new Interval("2015/2015")] as Set)
+            availabilityMap2.put(toColumn(it).getName(), [new Interval("2015/2016")] as Set)
+            availabilityMap3.put(toColumn(it).getName(), [new Interval("2011/2016")] as Set)
         }
         emptyFirst.setAvailability(new ConcreteAvailability(emptyFirst.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
         emptyLast.setAvailability(new ConcreteAvailability(emptyLast.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
         partialSecond.setAvailability(new ConcreteAvailability(partialSecond.getTableName(), new TestDataSourceMetadataService(availabilityMap2)))
         wholeThird.setAvailability(new ConcreteAvailability(wholeThird.getTableName(), new TestDataSourceMetadataService(availabilityMap3)))
 
-        tg1All = new TableGroup([emptyFirst, partialSecond, wholeThird, emptyLast] as LinkedHashSet, [].toSet(), [].toSet())
+        tg1All = new TableGroup([emptyFirst, partialSecond, wholeThird, emptyLast] as LinkedHashSet, [] as Set, [] as Set)
         ti1All = new TableIdentifier("base1All", AllGranularity.INSTANCE)
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/ConcretePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/ConcretePhysicalTableSpec.groovy
@@ -86,7 +86,20 @@ class ConcretePhysicalTableSpec extends Specification {
         dimensionColumn             | intervalSet1
         metricColumn1               | intervalSet2
         metricColumn2               | intervalSet3
-        new Column("MissingName")   | [] as Set
+    }
+
+    @Unroll
+    def "Physical table getAvailableIntervals throws exception when requesting a column not on the table"() {
+        given:
+        DataSourceConstraint constraints = Mock(DataSourceConstraint)
+        constraints.getAllColumnNames() >> ['un_configured']
+
+        when:
+        physicalTable.getAvailableIntervals(constraints)
+
+        then:
+        RuntimeException exception = thrown()
+        exception.message == 'Received invalid request requesting for columns: un_configured that is not available in this table: test table'
     }
 
     def "test datasource metadata service correctly initializes"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/ConcretePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/ConcretePhysicalTableSpec.groovy
@@ -88,7 +88,6 @@ class ConcretePhysicalTableSpec extends Specification {
         metricColumn2               | intervalSet3
     }
 
-    @Unroll
     def "Physical table getAvailableIntervals throws exception when requesting a column not on the table"() {
         given:
         DataSourceConstraint constraints = Mock(DataSourceConstraint)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTableSpec.groovy
@@ -53,12 +53,12 @@ class PermissiveConcretePhysicalTableSpec extends Specification {
                 TableName.of('test table'),
                 DAY.buildZonedTimeGrain(UTC),
                 [disjointIntervalColumn, leftAbuttingIntervalColumn, rightAbuttingIntervalColumn] as Set,
-                ['dimension': 'druidDim'],
+                [:],
                 new TestDataSourceMetadataService([
-                        (disjointIntervalColumn)     : [disjointInterval] as Set,
-                        (leftAbuttingIntervalColumn) : [leftAbuttingInterval] as Set,
-                        (rightAbuttingIntervalColumn): [rightAbuttingInterval] as Set,
-                        (new Column('ignored'))      : [new Interval('2010-01-01/2500-12-31')] as Set
+                        (disjointIntervalColumn.getName())     : [disjointInterval] as Set,
+                        (leftAbuttingIntervalColumn.getName()) : [leftAbuttingInterval] as Set,
+                        (rightAbuttingIntervalColumn.getName()): [rightAbuttingInterval] as Set,
+                        (new Column('ignored').getName())      : [new Interval('2010-01-01/2500-12-31')] as Set
                 ])
         )
     }
@@ -74,12 +74,12 @@ class PermissiveConcretePhysicalTableSpec extends Specification {
 
         where:
         allColumnNames                                                | expected
-        ["disjointIntervalColumn"]                                    | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["leftAbuttingIntervalColumn"]                                | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["rightAbuttingIntervalColumn"]                               | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["disjointIntervalColumn", "leftAbuttingIntervalColumn"]      | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["disjointIntervalColumn",  "rightAbuttingIntervalColumn"]    | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["leftAbuttingIntervalColumn", "rightAbuttingIntervalColumn"] | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["disjointIntervalColumn"]                                    | [disjointInterval] as Set
+        ["leftAbuttingIntervalColumn"]                                | [leftAbuttingInterval] as Set
+        ["rightAbuttingIntervalColumn"]                               | [rightAbuttingInterval] as Set
+        ["disjointIntervalColumn", "leftAbuttingIntervalColumn"]      | [disjointInterval, leftAbuttingInterval] as Set
+        ["disjointIntervalColumn",  "rightAbuttingIntervalColumn"]    | [disjointInterval, rightAbuttingInterval] as Set
+        ["leftAbuttingIntervalColumn", "rightAbuttingIntervalColumn"] | [leftAbuttingInterval, rightAbuttingInterval] as Set
 
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTableSpec.groovy
@@ -31,6 +31,7 @@ class PermissiveConcretePhysicalTableSpec extends Specification {
     @Shared Interval leftAbuttingInterval
     @Shared Interval rightAbuttingInterval
     @Shared Interval disjointInterval
+    @Shared Interval invisibleInterval
 
     def setupSpec() {
         disjointIntervalColumn = new DimensionColumn(
@@ -48,6 +49,7 @@ class PermissiveConcretePhysicalTableSpec extends Specification {
         disjointInterval = new Interval("2018-01-01/2018-02-01")
         leftAbuttingInterval = new Interval("2017-01-01/2017-02-01")
         rightAbuttingInterval = new Interval("2017-02-01/2017-03-01")
+        invisibleInterval = new Interval("2016-01-01/2016-02-01")
 
         permissiveConcretePhysicalTable = new PermissiveConcretePhysicalTable(
                 TableName.of('test table'),
@@ -58,7 +60,7 @@ class PermissiveConcretePhysicalTableSpec extends Specification {
                         (disjointIntervalColumn.getName())     : [disjointInterval] as Set,
                         (leftAbuttingIntervalColumn.getName()) : [leftAbuttingInterval] as Set,
                         (rightAbuttingIntervalColumn.getName()): [rightAbuttingInterval] as Set,
-                        (new Column('ignored').getName())      : [new Interval('2010-01-01/2500-12-31')] as Set
+                        (new Column('invisible').getName())    : [invisibleInterval] as Set
                 ])
         )
     }
@@ -74,11 +76,11 @@ class PermissiveConcretePhysicalTableSpec extends Specification {
 
         where:
         allColumnNames                                                | expected
-        ["disjointIntervalColumn"]                                    | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["leftAbuttingIntervalColumn"]                                | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["rightAbuttingIntervalColumn"]                               | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["disjointIntervalColumn", "leftAbuttingIntervalColumn"]      | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["disjointIntervalColumn",  "rightAbuttingIntervalColumn"]    | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
-        ["leftAbuttingIntervalColumn", "rightAbuttingIntervalColumn"] | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["disjointIntervalColumn"]                                    | [invisibleInterval, disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["leftAbuttingIntervalColumn"]                                | [invisibleInterval, disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["rightAbuttingIntervalColumn"]                               | [invisibleInterval, disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["disjointIntervalColumn", "leftAbuttingIntervalColumn"]      | [invisibleInterval, disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["disjointIntervalColumn",  "rightAbuttingIntervalColumn"]    | [invisibleInterval, disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["leftAbuttingIntervalColumn", "rightAbuttingIntervalColumn"] | [invisibleInterval, disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTableSpec.groovy
@@ -74,12 +74,11 @@ class PermissiveConcretePhysicalTableSpec extends Specification {
 
         where:
         allColumnNames                                                | expected
-        ["disjointIntervalColumn"]                                    | [disjointInterval] as Set
-        ["leftAbuttingIntervalColumn"]                                | [leftAbuttingInterval] as Set
-        ["rightAbuttingIntervalColumn"]                               | [rightAbuttingInterval] as Set
-        ["disjointIntervalColumn", "leftAbuttingIntervalColumn"]      | [disjointInterval, leftAbuttingInterval] as Set
-        ["disjointIntervalColumn",  "rightAbuttingIntervalColumn"]    | [disjointInterval, rightAbuttingInterval] as Set
-        ["leftAbuttingIntervalColumn", "rightAbuttingIntervalColumn"] | [leftAbuttingInterval, rightAbuttingInterval] as Set
-
+        ["disjointIntervalColumn"]                                    | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["leftAbuttingIntervalColumn"]                                | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["rightAbuttingIntervalColumn"]                               | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["disjointIntervalColumn", "leftAbuttingIntervalColumn"]      | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["disjointIntervalColumn",  "rightAbuttingIntervalColumn"]    | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
+        ["leftAbuttingIntervalColumn", "rightAbuttingIntervalColumn"] | [disjointInterval, leftAbuttingInterval, rightAbuttingInterval] as Set
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ConcreteAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ConcreteAvailabilitySpec.groovy
@@ -32,7 +32,7 @@ class ConcreteAvailabilitySpec extends Specification{
                 new TestDataSourceMetadataService([
                         (columnPhysicalName1): [interval1] as Set,
                         (columnPhysicalName2): [interval2] as Set,
-                        'hidden_column'     : [interval1] as Set
+                        'hidden_column'      : [interval1] as Set
                 ])
         )
     }
@@ -42,7 +42,7 @@ class ConcreteAvailabilitySpec extends Specification{
         concreteAvailability.getAllAvailableIntervals() == [
                 (columnPhysicalName1): [interval1],
                 (columnPhysicalName2): [interval2],
-                'hidden_column'     : [interval1],
+                'hidden_column'      : [interval1],
         ] as LinkedHashMap
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
@@ -252,38 +252,4 @@ class MetricUnionAvailabilitySpec extends Specification {
         ['2017-01-01/2017-02-01'] | ['2017-01-01/2017-01-15'] | ['2017-01-01/2017-01-15'] | "full back overlap (0/10, 0/5)"
         ['2017-01-01/2017-02-01'] | ['2017-01-15/2017-01-25'] | ['2017-01-15/2017-01-25'] | "fully contain (0/10, 3/9)"
     }
-
-    def "getAvailableInterval requesting un-configured column on the table will result in empty available interval"() {
-        given:
-        Interval interval = new Interval('2000-01-01/3000-01-01')
-        availability1.getAllAvailableIntervals() >> [
-                (metric1): [interval]
-        ]
-        availability2.getAllAvailableIntervals() >> [
-                (metric2): [interval]
-        ]
-
-        availability1.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList([interval])
-        availability2.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList([interval])
-
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1, metricColumn2] as Set)
-
-        DataSourceConstraint dataSourceConstraint = new DataSourceConstraint(
-                [] as Set,
-                [] as Set,
-                [] as Set,
-                [metric1, metric2, 'un_configured'] as Set,
-                [] as Set,
-                [] as Set,
-                [metric1, metric2, 'un_configured'] as Set,
-                [:]
-        )
-
-        PhysicalTableSchema physicalTableSchema = new PhysicalTableSchema(Mock(ZonedTimeGrain), [new Column(metric1), new Column(metric2)], [:])
-
-        PhysicalDataSourceConstraint physicalDataSourceConstraint = new PhysicalDataSourceConstraint(dataSourceConstraint, physicalTableSchema)
-
-        expect:
-        metricUnionAvailability.getAvailableIntervals(physicalDataSourceConstraint) == new SimplifiedIntervalList()
-    }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
@@ -2,12 +2,11 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.availability
 
-import com.yahoo.bard.webservice.table.Column
-
 import com.yahoo.bard.webservice.data.config.names.TableName
 import com.yahoo.bard.webservice.data.metric.MetricColumn
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
 import org.joda.time.Interval
@@ -22,8 +21,8 @@ class MetricUnionAvailabilitySpec extends Specification {
     Availability availability1
     Availability availability2
 
-    MetricColumn metricColumn1
-    MetricColumn metricColumn2
+    String metric1
+    String metric2
 
     PhysicalTable physicalTable1
     PhysicalTable physicalTable2
@@ -39,8 +38,8 @@ class MetricUnionAvailabilitySpec extends Specification {
         availability1.getDataSourceNames() >> ([TableName.of('source1')] as Set)
         availability2.getDataSourceNames() >> ([TableName.of('source2')] as Set)
 
-        metricColumn1 = new MetricColumn('metric1')
-        metricColumn2 = new MetricColumn('metric2')
+        metric1 = 'metric1'
+        metric2 = 'metric2'
 
         physicalTable1 = Mock(PhysicalTable)
         physicalTable2 = Mock(PhysicalTable)
@@ -54,32 +53,32 @@ class MetricUnionAvailabilitySpec extends Specification {
     def "Metric columns are initialized by fetching columns from availabilities, not from physical tables"() {
         given:
         availability1.getAllAvailableIntervals() >> [
-                (metricColumn1): []
+                (metric1): []
         ]
         availability2.getAllAvailableIntervals() >> [
-                (metricColumn2): []
+                (metric2): []
         ]
 
         MetricColumn tableColumn1 = new MetricColumn("shouldNotBeReturned1")
         MetricColumn tableColumn2 = new MetricColumn("shouldNotBeReturned2")
 
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1, metricColumn2] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [new MetricColumn(metric1), new MetricColumn(metric2)] as Set)
 
         when:
-        Map<Availability, Set<MetricColumn>> availabilitiesToAvailableColumns = metricUnionAvailability.availabilitiesToAvailableColumns
+        Map<Availability, Set<String>> availabilitiesToAvailableColumns = metricUnionAvailability.availabilitiesToMetricNames
 
         then:
         availabilitiesToAvailableColumns.size() == 2
 
         availabilitiesToAvailableColumns.containsKey(availability1)
-        Set<MetricColumn> availableColumns1 = availabilitiesToAvailableColumns.get(availability1)
-        availableColumns1.contains(metricColumn1)
+        Set<String> availableColumns1 = availabilitiesToAvailableColumns.get(availability1)
+        availableColumns1.contains(metric1)
         !availableColumns1.contains(tableColumn1)
         !availableColumns1.contains(tableColumn2)
 
         availabilitiesToAvailableColumns.containsKey(availability2)
-        Set<MetricColumn> availableColumns2 = availabilitiesToAvailableColumns.get(availability2)
-        availableColumns2.contains(metricColumn2)
+        Set<String> availableColumns2 = availabilitiesToAvailableColumns.get(availability2)
+        availableColumns2.contains(metric2)
         !availableColumns2.contains(tableColumn1)
         !availableColumns2.contains(tableColumn2)
     }
@@ -87,46 +86,41 @@ class MetricUnionAvailabilitySpec extends Specification {
     @Unroll
     def "checkDuplicateValue returns duplicate metric column names or empty, if no duplicates, from 2 physical tables in the case of #caseDescription"() {
         when:
-        Map<MetricColumn, Set<Availability>> actual = MetricUnionAvailability.getDuplicateValues(
+        boolean actual = MetricUnionAvailability.isMetricUnique(
                 [
-                        (availability1): metricColumnNames1.collect{it -> new MetricColumn(it)} as Set,
-                        (availability2): metricColumnNames2.collect{it -> new MetricColumn(it)} as Set
+                        (availability1): metricColumnNames1.collect{it -> it} as Set,
+                        (availability2): metricColumnNames2.collect{it -> it} as Set
                 ]
         )
 
         then:
-        actual.size() == expected.size()
-        for (Map.Entry<String, Integer> entry : expected.entrySet()) {
-            MetricColumn duplicate = new MetricColumn(entry.key)
-            assert actual.containsKey(duplicate)
-            assert actual.get(duplicate).size() == entry.value
-        }
+        actual == expected
 
         where:
-        metricColumnNames1     | metricColumnNames2                | expected                     | caseDescription
-        []                     | []                                | [:]                          | 'both physical tables having empty metric column names (no duplicates)'
-        ['metric1']            | []                                | [:]                          | 'one empty table and one non-empty table (no duplicates)'
-        ['metric1']            | ['metric1']                       | ['metric1': 2]               | 'both physical tables having the same metric column names'
-        ['metric1', 'metric2'] | ['metric1']                       | ['metric1': 2]               | 'two tables having intersections'
-        ['metric1']            | ['metric2']                       | [:]                          | 'two tables having no intersections (no duplicates)'
-        ['metric1', 'metric2'] | ['metric1', 'metric2', 'metric3'] | ['metric1': 2, 'metric2': 2] | 'two tables having no intersections (no duplicates)'
+        metricColumnNames1     | metricColumnNames2                | expected           | caseDescription
+        []                     | []                                | true               | 'both physical tables having empty metric column names (no duplicates)'
+        ['metric1']            | []                                | true               | 'one empty table and one non-empty table (no duplicates)'
+        ['metric1']            | ['metric1']                       | false              | 'both physical tables having the same metric column names'
+        ['metric1', 'metric2'] | ['metric1']                       | false              | 'two tables having intersections'
+        ['metric1']            | ['metric2']                       | true               | 'two tables having no intersections (no duplicates)'
+        ['metric1', 'metric2'] | ['metric1', 'metric2', 'metric3'] | false              | 'two tables having no intersections (no duplicates)'
     }
 
     def "constructor throws IllegalArgumentException when 2 availabilities have the same metric column"() {
         given:
         availability1.getAllAvailableIntervals() >> [
-                (metricColumn1): []
+                (metric1): []
         ]
         availability2.getAllAvailableIntervals() >> [
-                (metricColumn1): []
+                (metric1): []
         ]
 
         when:
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [new MetricColumn(metric1)] as Set)
 
         then:
-        IllegalArgumentException exception = thrown()
-        exception.message.startsWith("While constructing MetricUnionAvailability, Metric columns are not unique")
+        RuntimeException exception = thrown()
+        exception.message.startsWith("Metric columns must be unique across the metric union data sources, but duplicate was found across the following data sources: source1, source2")
     }
 
 
@@ -151,20 +145,20 @@ class MetricUnionAvailabilitySpec extends Specification {
     def "getAllAvailableIntervals returns the combined intervals of all columns of all availabilities"() {
         given:
         availability1.getAllAvailableIntervals() >> [
-                (metricColumn1): [new Interval('2018-01-01/2018-02-01')],
-                (new Column('column')): [new Interval('2018-01-01/2018-02-01')]
+                (metric1): [new Interval('2018-01-01/2018-02-01')],
+                ('column'): [new Interval('2018-01-01/2018-02-01')]
         ]
         availability2.getAllAvailableIntervals() >> [
-                (metricColumn2): [new Interval('2019-01-01/2019-02-01')]
+                (metric2): [new Interval('2019-01-01/2019-02-01')]
         ]
 
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metric1] as Set)
 
         expect:
         metricUnionAvailability.getAllAvailableIntervals() == [
-                (metricColumn1): [new Interval('2018-01-01/2018-02-01')],
-                (metricColumn2): [new Interval('2019-01-01/2019-02-01')],
-                (new Column('column')): [new Interval('2018-01-01/2018-02-01')]
+                (metric1): [new Interval('2018-01-01/2018-02-01')],
+                (metric2): [new Interval('2019-01-01/2019-02-01')],
+                'column' : [new Interval('2018-01-01/2018-02-01')]
         ]
 
     }
@@ -173,10 +167,10 @@ class MetricUnionAvailabilitySpec extends Specification {
     def "getAvailableIntervals returns the intersection of requested columns when available intervals have #reason"() {
         given:
         availability1.getAllAvailableIntervals() >> [
-                (metricColumn1): []
+                (metric1): []
         ]
         availability2.getAllAvailableIntervals() >> [
-                (metricColumn2): []
+                (metric2): []
         ]
 
         availability1.getAvailableIntervals(_ as DataSourceConstraint) >> new SimplifiedIntervalList(
@@ -186,9 +180,11 @@ class MetricUnionAvailabilitySpec extends Specification {
                 availableIntervals2.collect{it -> new Interval(it)} as Set
         )
 
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1, metricColumn2] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [new MetricColumn(metric1), new MetricColumn(metric2)] as Set)
 
-        DataSourceConstraint dataSourceConstraint = new DataSourceConstraint(
+
+
+        PhysicalDataSourceConstraint dataSourceConstraint = new PhysicalDataSourceConstraint(
                 [] as Set,
                 [] as Set,
                 [] as Set,
@@ -196,7 +192,8 @@ class MetricUnionAvailabilitySpec extends Specification {
                 [] as Set,
                 [] as Set,
                 [] as Set,
-                [:]
+                [:],
+                ['metric1', 'metric2'] as Set
         )
 
         expect:
@@ -206,7 +203,7 @@ class MetricUnionAvailabilitySpec extends Specification {
         )
 
         where:
-        availableIntervals1 | availableIntervals2 | availableIntervals | reason
+        availableIntervals1       | availableIntervals2       | availableIntervals        | reason
         []                        | []                        | []                        | "two empty intervals collections"
         ['2018-01-01/2018-02-01'] | []                        | []                        | "one interval collection being empty"
         ['2017-01-01/2017-02-01'] | ['2017-01-01/2017-02-01'] | ['2017-01-01/2017-02-01'] | "full overlap (start/end, start/end)"

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DataSourceConstraintSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DataSourceConstraintSpec.groovy
@@ -2,7 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.resolver
 
-import com.yahoo.bard.webservice.data.metric.MetricColumn
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DataSourceConstraintSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DataSourceConstraintSpec.groovy
@@ -20,7 +20,7 @@ class DataSourceConstraintSpec extends Specification {
                 [] as Set,
                 [] as Set,
                 [:]
-        ).withMetricIntersection(other.collect{it -> new MetricColumn(it)} as Set)
+        ).withMetricIntersection(other as Set)
 
         expect:
         newDataSourceConstraint.getMetricNames() == newMetricNames as Set

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraintSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraintSpec.groovy
@@ -1,0 +1,35 @@
+package com.yahoo.bard.webservice.table.resolver
+
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain
+import com.yahoo.bard.webservice.table.Column
+import com.yahoo.bard.webservice.table.PhysicalTableSchema
+
+import spock.lang.Specification
+
+/**
+ * Test PhysicalDataSourceConstraint correctly translates and filters column physical names.
+ */
+class PhysicalDataSourceConstraintSpec extends Specification {
+
+    DataSourceConstraint dataSourceConstraint
+    PhysicalTableSchema physicalTableSchema
+    PhysicalDataSourceConstraint physicalDataSourceConstraint
+
+    def setup() {
+        dataSourceConstraint = Mock(DataSourceConstraint)
+        dataSourceConstraint
+        dataSourceConstraint.getAllColumnNames() >> (['columnOne', 'columnTwo', 'columnThree'] as Set)
+        physicalTableSchema = new PhysicalTableSchema(Mock(ZonedTimeGrain), [new Column('columnOne'), new Column('columnThree')], ['columnOne': 'column_one', 'columnTwo': 'column_two'])
+        physicalDataSourceConstraint = new PhysicalDataSourceConstraint(dataSourceConstraint, physicalTableSchema)
+    }
+
+    def "physical data source constraint filters out columns not in the given schema"() {
+        expect:
+        !physicalDataSourceConstraint.getAllColumnPhysicalNames().contains('column_two')
+    }
+
+    def "physical data source constraint maps to physical name correctly even if mapping does not exist"() {
+        expect:
+        physicalDataSourceConstraint.getAllColumnPhysicalNames() == ['column_one', 'columnThree'] as Set
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraintSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraintSpec.groovy
@@ -23,30 +23,25 @@ class PhysicalDataSourceConstraintSpec extends Specification {
                 ['columnThree', 'columnFour', 'columnFive'] as Set,
                 [] as Set,
                 [] as Set,
-                ['columnOne', 'columnTwo', 'columnThree', 'columnFour', 'columnFive'] as Set,
+                ['columnOne', 'columnTwo', 'columnThree', 'columnFour'] as Set,
                 [:]
         )
 
-        physicalTableSchema = new PhysicalTableSchema(Mock(ZonedTimeGrain), [new Column('columnOne'), new Column('columnThree'), new Column('columnFour'), new Column('columnFive')], ['columnOne': 'column_one', 'columnTwo': 'column_two'])
+        physicalTableSchema = new PhysicalTableSchema(Mock(ZonedTimeGrain), [new Column('columnOne'), new Column('columnTwo'), new Column('columnThree'), new Column('columnFour')], ['columnOne': 'column_one', 'columnTwo': 'column_two'])
         physicalDataSourceConstraint = new PhysicalDataSourceConstraint(dataSourceConstraint, physicalTableSchema)
-    }
-
-    def "physical data source constraint filters out columns not in the given schema"() {
-        expect:
-        !physicalDataSourceConstraint.getAllColumnPhysicalNames().contains('column_two')
     }
 
     def "physical data source constraint maps to physical name correctly even if mapping does not exist"() {
         expect:
-        physicalDataSourceConstraint.getAllColumnPhysicalNames() == ['column_one', 'columnThree', 'columnFour', 'columnFive'] as Set
+        physicalDataSourceConstraint.getAllColumnPhysicalNames() == ['column_one', 'column_two', 'columnThree', 'columnFour'] as Set
     }
 
     def "withMetricIntersection correctly intersects metricNames and allPhysicalColumnNames with the provided metrics"() {
         given:
-        PhysicalDataSourceConstraint subConstraint = physicalDataSourceConstraint.withMetricIntersection(['columnThree', 'columnFour'] as Set)
+        PhysicalDataSourceConstraint subConstraint = physicalDataSourceConstraint.withMetricIntersection(['columnFour'] as Set)
 
         expect:
-        subConstraint.getMetricNames() == ['columnThree', 'columnFour'] as Set
-        subConstraint.withMetricIntersection(['columnThree', 'columnFour'] as Set).getAllColumnPhysicalNames() == ['column_one', 'columnThree', 'columnFour'] as Set
+        subConstraint.getMetricNames() == ['columnFour'] as Set
+        subConstraint.withMetricIntersection(['columnFour'] as Set).getAllColumnPhysicalNames() == ['column_one', 'column_two', 'columnFour'] as Set
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraintSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraintSpec.groovy
@@ -16,10 +16,18 @@ class PhysicalDataSourceConstraintSpec extends Specification {
     PhysicalDataSourceConstraint physicalDataSourceConstraint
 
     def setup() {
-        dataSourceConstraint = Mock(DataSourceConstraint)
-        dataSourceConstraint
-        dataSourceConstraint.getAllColumnNames() >> (['columnOne', 'columnTwo', 'columnThree'] as Set)
-        physicalTableSchema = new PhysicalTableSchema(Mock(ZonedTimeGrain), [new Column('columnOne'), new Column('columnThree')], ['columnOne': 'column_one', 'columnTwo': 'column_two'])
+        dataSourceConstraint =  new DataSourceConstraint(
+                [] as Set,
+                [] as Set,
+                [] as Set,
+                ['columnThree', 'columnFour', 'columnFive'] as Set,
+                [] as Set,
+                [] as Set,
+                ['columnOne', 'columnTwo', 'columnThree', 'columnFour', 'columnFive'] as Set,
+                [:]
+        )
+
+        physicalTableSchema = new PhysicalTableSchema(Mock(ZonedTimeGrain), [new Column('columnOne'), new Column('columnThree'), new Column('columnFour'), new Column('columnFive')], ['columnOne': 'column_one', 'columnTwo': 'column_two'])
         physicalDataSourceConstraint = new PhysicalDataSourceConstraint(dataSourceConstraint, physicalTableSchema)
     }
 
@@ -30,6 +38,15 @@ class PhysicalDataSourceConstraintSpec extends Specification {
 
     def "physical data source constraint maps to physical name correctly even if mapping does not exist"() {
         expect:
-        physicalDataSourceConstraint.getAllColumnPhysicalNames() == ['column_one', 'columnThree'] as Set
+        physicalDataSourceConstraint.getAllColumnPhysicalNames() == ['column_one', 'columnThree', 'columnFour', 'columnFive'] as Set
+    }
+
+    def "withMetricIntersection correctly intersects metricNames and allPhysicalColumnNames with the provided metrics"() {
+        given:
+        PhysicalDataSourceConstraint subConstraint = physicalDataSourceConstraint.withMetricIntersection(['columnThree', 'columnFour'] as Set)
+
+        expect:
+        subConstraint.getMetricNames() == ['columnThree', 'columnFour'] as Set
+        subConstraint.withMetricIntersection(['columnThree', 'columnFour'] as Set).getAllColumnPhysicalNames() == ['column_one', 'columnThree', 'columnFour'] as Set
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SlicesApiRequestSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SlicesApiRequestSpec.groovy
@@ -91,7 +91,7 @@ class SlicesApiRequestSpec extends BaseDataSourceMetadataSpec {
         Set<Map<String, Object>> dimensionsResult = new LinkedHashSet<>()
         Set<Map<String, Object>> metricsResult = new LinkedHashSet<>()
 
-        table.availability.allAvailableIntervals.each {
+        table.getAllAvailableIntervals().each {
             Map<String, Object> row = new LinkedHashMap<>()
             row["intervals"] = it.value
             row["name"] = it.key.name

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/metadata/TestDataSourceMetadataService.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/metadata/TestDataSourceMetadataService.java
@@ -3,7 +3,6 @@
 package com.yahoo.bard.webservice.metadata;
 
 import com.yahoo.bard.webservice.data.config.names.TableName;
-import com.yahoo.bard.webservice.table.Column;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
 import org.joda.time.Interval;
@@ -26,10 +25,10 @@ public class TestDataSourceMetadataService extends DataSourceMetadataService {
      *
      * @param testData interval data to be injected into this test metadata service with key as column
      */
-    public TestDataSourceMetadataService(Map<Column, Set<Interval>> testData) {
+    public TestDataSourceMetadataService(Map<String, Set<Interval>> testData) {
         super();
         this.testAvailableIntervals = testData.entrySet().stream()
-                .collect(Collectors.toMap(entry -> entry.getKey().getName(), Map.Entry::getValue));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**


### PR DESCRIPTION
* Added `PhysicalDataSourceConstraint` class to capture physical names of columns for retrieving availble interval
* `getAllAvailbleIntervals` in `ConcreteAvailability` no longer filters out unconfigured columns, instead table's `getAllAvailbleIntervals` does
* `getAvailbleIntervals` in `Availbality` now takes `PhysicalDataSourceConstraint` instead of `DataSourceConstraint`
* `Availbility` no longer takes a set of columns on the table, only table needs to know
* `getAllAvailbleIntervals` in `Availbility` now returns a map of column physical name to interval list instead of column to interval list
* `TestDataSourceMetadataService` now takes map from string to list of intervals instead of column to list of intervals for constructor