### PR TITLE
Improve Lucene search speed with internal cache

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/HashDataCache.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/HashDataCache.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.AbstractMap;
@@ -76,7 +77,7 @@ public class HashDataCache<T extends Serializable> implements DataCache<T> {
     public String hash(String key) {
         try {
             MessageDigest md = MessageDigest.getInstance(algorithm);
-            byte[] keyBytes = key.getBytes("UTF-8");
+            byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
             md.update(keyBytes, 0, keyBytes.length);
             byte[] binaryhash = md.digest();
             return Base64.encode(binaryhash);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/MemTupleDataCache.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/MemTupleDataCache.java
@@ -9,6 +9,7 @@ import net.spy.memcached.MemcachedClient;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
@@ -73,7 +74,7 @@ public class MemTupleDataCache<V extends Serializable>
     protected String hash(String key) {
         try {
             MessageDigest gen = HASH_GENERATOR.get();
-            byte[] keyBytes = key.getBytes("UTF-8");
+            byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
             gen.update(keyBytes, 0, keyBytes.length);
             byte[] binaryhash = gen.digest();
 


### PR DESCRIPTION
We found some Lucene searches could be much too slow to be repeated often.  The cache speeds our searches significantly.

The cache will always be cleared on writes.