### PR TITLE
Implement BaseCompositePhysicalTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Current
 -------
 ### Added:
 
+- [BaseCompositePhysicalTable](https://github.com/yahoo/fili/pull/242)
+    * `ConcretePhysicalTable` provides common operations, such as validating coarsest ZonedTimeGrain, for composite
+    tables.
+
 - [Add Reciprocal `satisfies()` relationship complementing `satisfiedBy()` on Granularity](https://github.com/yahoo/fili/issues/222)
 
 - [MetricUnionAvailability and MetricUnionCompositeTable](https://github.com/yahoo/fili/pull/193)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
@@ -19,6 +19,7 @@ import javax.validation.constraints.NotNull;
  * An implementation of BasePhysicalTable that contains multiple tables.
  */
 public class BaseCompositePhysicalTable extends BasePhysicalTable {
+
     private static final Logger LOG = LoggerFactory.getLogger(MetricUnionCompositeTable.class);
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
@@ -1,0 +1,89 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table;
+
+import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
+import com.yahoo.bard.webservice.table.availability.Availability;
+import com.yahoo.bard.webservice.util.IntervalUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * An implementation of BasePhysicalTable that contains multiple tables.
+ */
+public class BaseCompositePhysicalTable extends BasePhysicalTable {
+    private static final Logger LOG = LoggerFactory.getLogger(MetricUnionCompositeTable.class);
+
+    /**
+     * Constructor.
+     *
+     * @param name  Name that represents set of fact table names that are put together under this table
+     * @param columns  The columns for this table
+     * @param physicalTables  A set of PhysicalTables that are put together under this table. The
+     * tables will be used to compute common/coarsest time grain among them. The PhysicalTables needs to have mutually
+     * satisfying time grains in order to calculate the common/coarsest time grain.
+     * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
+     * @param availability  The Availability of this table
+     */
+    public BaseCompositePhysicalTable(
+            @NotNull TableName name,
+            @NotNull Set<Column> columns,
+            @NotNull Set<PhysicalTable> physicalTables,
+            @NotNull Map<String, String> logicalToPhysicalColumnNames,
+            @NotNull Availability availability
+    ) {
+        super(
+                name,
+                IntervalUtils.getCoarsestTimeGrain(physicalTables).orElseThrow(() -> {
+                    String message = String.format(
+                            "At least 1 physical table needs to be provided in order to calculate " +
+                                    "coarsest time grain for %s",
+                            name.asName()
+                    );
+                    LOG.error(message);
+                    return new IllegalArgumentException(message);
+                }),
+                columns,
+                logicalToPhysicalColumnNames,
+                availability
+        );
+        verifyGrainSatisfiesAllTables(getSchema().getTimeGrain(), physicalTables, name);
+    }
+
+    /**
+     * Verifies that the coarsest ZonedTimeGrain satisfies all tables.
+     *
+     * @param coarsestTimeGrain  The coarsest ZonedTimeGrain to be verified
+     * @param physicalTables  A set of PhysicalTables whose ZonedTimeGrains are checked to make sure
+     * they all satisfies with the given coarsest ZonedTimeGrain
+     * @param name  Name of the current MetricUnionCompositeTable that represents set of fact table names
+     * joined together
+     *
+     * @throws IllegalArgumentException when there is no mutually satisfying grain among the table's time grains
+     */
+    private static void verifyGrainSatisfiesAllTables(
+            ZonedTimeGrain coarsestTimeGrain,
+            Set<PhysicalTable> physicalTables,
+            TableName name
+    ) throws IllegalArgumentException {
+        if (!physicalTables.stream()
+                .map(PhysicalTable::getSchema)
+                .map(PhysicalTableSchema::getTimeGrain)
+                .allMatch(grain -> grain.satisfiedBy(coarsestTimeGrain))) {
+            String message = String.format("There is no mutually satisfying grain among: %s for current table " +
+                            "%s",
+                    physicalTables,
+                    name.asName()
+            );
+            LOG.error(message);
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.table;
 
 import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.table.availability.MetricUnionAvailability;
 
 import java.util.Map;
@@ -56,21 +57,22 @@ public class MetricUnionCompositeTable extends BaseCompositePhysicalTable {
      * Constructor.
      *
      * @param name  Name that represents set of fact table names joined together
+     * @param timeGrain  The time grain of the table. The time grain has to satisfy all grains of the tables
      * @param columns  The columns for this table
-     * @param physicalTables  A set of <tt>PhysicalTable</tt>s whose same metric schema is to be joined together. The
-     * tables will be used to construct MetricUnionAvailability, as well as to compute common/coarsest time grain among
-     * them. The <tt>PhysicalTable</tt>s needs to have mutually satisfying time grains in order to calculate the
-     * common/coarsest time grain.
+     * @param physicalTables  A set of PhysicalTables that are put together under this table. The
+     * tables shall have zoned time grains that all satisfy the provided timeGrain
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
      */
     public MetricUnionCompositeTable(
             @NotNull TableName name,
+            @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,
             @NotNull Set<PhysicalTable> physicalTables,
             @NotNull Map<String, String> logicalToPhysicalColumnNames
     ) {
         super(
                 name,
+                timeGrain,
                 columns,
                 physicalTables,
                 logicalToPhysicalColumnNames,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
@@ -5,9 +5,6 @@ package com.yahoo.bard.webservice.table;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.table.availability.MetricUnionAvailability;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -54,7 +51,6 @@ import javax.validation.constraints.NotNull;
  *
  */
 public class MetricUnionCompositeTable extends BaseCompositePhysicalTable {
-    private static final Logger LOG = LoggerFactory.getLogger(MetricUnionCompositeTable.class);
 
     /**
      * Constructor.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/IntervalUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/IntervalUtils.java
@@ -4,10 +4,7 @@ package com.yahoo.bard.webservice.util;
 
 import com.yahoo.bard.webservice.config.SystemConfig;
 import com.yahoo.bard.webservice.config.SystemConfigProvider;
-import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
-import com.yahoo.bard.webservice.table.PhysicalTable;
-import com.yahoo.bard.webservice.table.PhysicalTableSchema;
 import com.yahoo.bard.webservice.table.resolver.GranularityComparator;
 
 import org.joda.time.DateTime;
@@ -214,20 +211,5 @@ public class IntervalUtils {
         return intervalSets.stream().flatMap(Collection::stream)
                 .map(Interval::getStart)
                 .reduce(Utils::getMinValue);
-    }
-
-    /**
-     * Returns the coarsest ZonedTimeGrain among a set of PhysicalTables.
-     *
-     * @param physicalTables  A set of PhysicalTables among which the coarsest ZonedTimeGrain is to be found.
-     *
-     * @return the coarsest ZonedTimeGrain among a set of PhysicalTables
-     */
-    public static Optional<ZonedTimeGrain> getCoarsestTimeGrain(Collection<PhysicalTable> physicalTables) {
-        return physicalTables.stream()
-                .sorted(COMPARATOR)
-                .findFirst()
-                .map(PhysicalTable::getSchema)
-                .map(PhysicalTableSchema::getTimeGrain);
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/BaseCompositePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/BaseCompositePhysicalTableSpec.groovy
@@ -4,10 +4,11 @@ package com.yahoo.bard.webservice.table
 
 import com.yahoo.bard.webservice.data.config.names.TableName
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain
+import com.yahoo.bard.webservice.table.availability.Availability
 
 import spock.lang.Specification
 
-class MetricUnionCompositeTableSpec extends Specification {
+class BaseCompositePhysicalTableSpec extends Specification {
     TableName tableName
 
     def setup() {
@@ -16,11 +17,12 @@ class MetricUnionCompositeTableSpec extends Specification {
 
     def "Constructor throws illegal argument exception on empty physical tables"() {
         when:
-        MetricUnionCompositeTable metricUnionCompositeTable = new MetricUnionCompositeTable(
+        BaseCompositePhysicalTable baseCompositePhysicalTable = new BaseCompositePhysicalTable(
                 tableName,
                 [] as Set,
                 [] as Set,
-                [:]
+                [:],
+                Mock(Availability)
         )
 
         then:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/BaseCompositePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/BaseCompositePhysicalTableSpec.groovy
@@ -9,26 +9,6 @@ import com.yahoo.bard.webservice.table.availability.Availability
 import spock.lang.Specification
 
 class BaseCompositePhysicalTableSpec extends Specification {
-    TableName tableName
-
-    def setup() {
-        tableName =  TableName.of("table1")
-    }
-
-    def "Constructor throws illegal argument exception on empty physical tables"() {
-        when:
-        BaseCompositePhysicalTable baseCompositePhysicalTable = new BaseCompositePhysicalTable(
-                tableName,
-                [] as Set,
-                [] as Set,
-                [:],
-                Mock(Availability)
-        )
-
-        then:
-        IllegalArgumentException illegalArgumentException = thrown()
-        illegalArgumentException.message == 'At least 1 physical table needs to be provided in order to calculate coarsest time grain for table1'
-    }
 
     def "verifyGrainSatisfiesAllTables throws illegal argument exception on non-mutually satisfying grain among physical tables"() {
         given:
@@ -52,7 +32,7 @@ class BaseCompositePhysicalTableSpec extends Specification {
         physicalTable2.getSchema() >> schema2
 
         when:
-        MetricUnionCompositeTable.verifyGrainSatisfiesAllTables(coarsestTimeGrain, [physicalTable1, physicalTable2] as Set, tableName)
+        MetricUnionCompositeTable.verifyGrainSatisfiesAllTables(coarsestTimeGrain, [physicalTable1, physicalTable2] as Set, TableName.of("table1"))
 
         then:
         IllegalArgumentException illegalArgumentException = thrown()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/IntervalUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/IntervalUtilsSpec.groovy
@@ -332,51 +332,6 @@ class IntervalUtilsSpec extends Specification {
         DAY   | ["2012-02-03/2017-04-04"] | ["2012-02-03/2012-05-04", "2017-02-03/2017-04-04"]
     }
 
-    @Unroll
-    def "getCoarsestTimeGrain returns coarsest grain in the case of #description"() {
-        given:
-        PhysicalTableSchema schema1 = Mock(PhysicalTableSchema)
-        PhysicalTableSchema schema2 = Mock(PhysicalTableSchema)
-        PhysicalTableSchema schema3 = Mock(PhysicalTableSchema)
-
-        schema1.getTimeGrain() >> new ZonedTimeGrain(timeGrain1, DateTimeZone.forID(timeZone1))
-        schema2.getTimeGrain() >> new ZonedTimeGrain(timeGrain2, DateTimeZone.forID(timeZone2))
-        schema3.getTimeGrain() >> new ZonedTimeGrain(timeGrain3, DateTimeZone.forID(timeZone3))
-
-        PhysicalTable physicalTable1 = Mock(PhysicalTable)
-        PhysicalTable physicalTable2 = Mock(PhysicalTable)
-        PhysicalTable physicalTable3 = Mock(PhysicalTable)
-
-        physicalTable1.getSchema() >> schema1
-        physicalTable2.getSchema() >> schema2
-        physicalTable3.getSchema() >> schema3
-
-        expect:
-        IntervalUtils.getCoarsestTimeGrain(
-                [
-                        physicalTable1,
-                        physicalTable2,
-                        physicalTable3
-                ]
-        ).get() == new ZonedTimeGrain(expectedTimeGrain, DateTimeZone.forID(expectedTimeZone))
-
-        where:
-        timeGrain1 | timeGrain2 | timeGrain3 | timeZone1         | timeZone2             | timeZone3         | expectedTimeGrain | expectedTimeZone  | description
-        DAY        | DAY        | DAY        | 'America/Chicago' | 'America/Los_Angeles' | 'America/Phoenix' | DAY               | 'America/Chicago' | 'same grain but different time zones'
-        MINUTE     | HOUR       | DAY        | 'America/Phoenix' | 'America/Phoenix'     | 'America/Phoenix' | DAY               | 'America/Phoenix' | 'same time zone but different grans'
-        MINUTE     | HOUR       | DAY        | 'America/Chicago' | 'America/Los_Angeles' | 'America/Phoenix' | DAY               | 'America/Phoenix' | 'different grains, with DAY as the coarsest grain, and different time zones'
-        HOUR       | DAY        | WEEK       | 'America/Chicago' | 'America/Los_Angeles' | 'America/Phoenix' | WEEK              | 'America/Phoenix' | 'different grains, with WEEK as the coarsest grain, and different time zones'
-        DAY        | WEEK       | MONTH      | 'America/Chicago' | 'America/Los_Angeles' | 'America/Phoenix' | MONTH             | 'America/Phoenix' | 'different grains, with MONTH as the coarsest grain, and different time zones'
-        WEEK       | MONTH      | QUARTER    | 'America/Chicago' | 'America/Los_Angeles' | 'America/Phoenix' | QUARTER           | 'America/Phoenix' | 'different grains, with QUARTER as the coarsest grain, and different time zones'
-        MONTH      | QUARTER    | YEAR       | 'America/Chicago' | 'America/Los_Angeles' | 'America/Phoenix' | YEAR              | 'America/Phoenix' | 'different grains, with YEAR as the coarsest grain, and different time zones'
-
-    }
-
-    def "getCoarsestTimeGrain returns empty on empty input physical table collections"() {
-        expect:
-        IntervalUtils.getCoarsestTimeGrain([]) == Optional.empty()
-    }
-
     /**
      * Returns the instant at which this year began.
      *


### PR DESCRIPTION
![screen shot 2017-04-14 at 10 38 14 am](https://cloud.githubusercontent.com/assets/16126939/25047781/7d0e6f0c-20fe-11e7-97b3-834023f10a21.png)

PR https://github.com/yahoo/fili/pull/195 reveals a need to implement a common class between `PartitionCompositeTable` and `MetricUnionCompositeTable`.
