### PR TITLE
Adds a timer around DataApiRequestMappers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Current
 
 - [Add Reciprocal `satisfies()` relationship complementing `satisfiedBy()` on Granularity](https://github.com/yahoo/fili/issues/222)
 
+- [Add a timer around DataApiRequestMappers](https://github.com/yahoo/fili/pull/250)
+
 - [Method for finding coarsest ZonedTimeGrain](https://github.com/yahoo/fili/pull/230)
     * Added utility method for returning coarsest `ZonedTimeGrain` from a collection of `ZonedTimeGrain`s. This is
     useful to construct composite tables that requires the coarsest `ZonedTimeGrain` among a set of tables.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
@@ -369,7 +369,9 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
             }
 
             if (requestMapper != null) {
-                apiRequest = (DataApiRequest) requestMapper.apply(apiRequest, containerRequestContext);
+                try (TimedPhase timer = RequestLog.startTiming("DataApiRequestMappers")) {
+                    apiRequest = (DataApiRequest) requestMapper.apply(apiRequest, containerRequestContext);
+                }
             }
 
             // Build the query template


### PR DESCRIPTION
-- DataApiRequestMappers are allowed to perform arbitrary
transformations on the `DataApiRequest`. As a result, these mappers may
be very expensive. So, we should add a timer that allows customers to
easily see if they are spending all their time in their own mappers.