### PR TITLE
Clean up config loading and add more logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,16 @@ Current
 - [Make `TemplateDruidQuery::getMetricField` get the first field instead of any field](https://github.com/yahoo/fili/pull/210)
     * Previously, order was by luck, now it's by the contract of `findFirst`
 
+- [Clean up config loading and add more logs and checks]()
+    * Use correct logger in `ConfigurationGraph` (was `ConfigResourceLoader`)
+    * Add error / logging messages for
+      - Module dependency indicator
+    * Tweak loading resources debug log to read better
+    * Tweak module found log to read better
+    * Convert from `Resource::getFilename` to `Resource::getDescription` when reporting errors in the configuration
+      graph. `getDescription` is more informative, usually holding the whole file path, rather than just the terminal
+      segment / file _name_
+
 - [Restore non-default query support in TestDruidWebservice](https://github.com/yahoo/fili/pull/202)
 
 - [Base TableDataSource serialization on ConcretePhysicalTable fact name](https://github.com/yahoo/fili/pull/202)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/TypeAwareDimensionLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/TypeAwareDimensionLoader.java
@@ -14,15 +14,11 @@ import com.yahoo.bard.webservice.data.dimension.impl.RegisteredLookupDimension;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Load dimensions based on the type of the dimension.
  */
 public class TypeAwareDimensionLoader implements DimensionLoader {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TypeAwareDimensionLoader.class);
     private final Iterable<DimensionConfig> configSource;
     private final HealthCheckRegistry healthCheckRegistry;
 

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigMessageFormat.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigMessageFormat.java
@@ -58,7 +58,10 @@ public enum ConfigMessageFormat implements MessageFormatter {
     ),
     // These are not an error message, only used for logging
     MODULE_FOUND_MESSAGE(
-        "Module named '%s' in resource '%s"
+            "Module '%s' found in resource '%s'"
+    ),
+    MODULE_DEPENDS_ON_MESSAGE(
+            "Module '%s' depends on modules '%s'"
     ),
 
     RESOURCE_LOAD_MESSAGE(

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigResourceLoader.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigResourceLoader.java
@@ -75,7 +75,7 @@ public class ConfigResourceLoader {
      */
     public Stream<Resource> loadResourcesWithName(String name) throws IOException {
         String resourceName = RESOURCE_LOADER_PREFIX + name;
-        LOG.debug("Attempting to load resources named {}", resourceName);
+        LOG.debug("Loading resources named '{}'", resourceName);
         return Arrays.stream(resolver.getResources(resourceName))
                 .peek(it -> LOG.debug(RESOURCE_LOAD_MESSAGE.logFormat(name, it)));
     }

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigurationGraph.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigurationGraph.java
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.config;
 
 import static com.yahoo.bard.webservice.config.ConfigMessageFormat.CIRCULAR_DEPENDENCY;
 import static com.yahoo.bard.webservice.config.ConfigMessageFormat.MISSING_DEPENDENCY;
+import static com.yahoo.bard.webservice.config.ConfigMessageFormat.MODULE_DEPENDS_ON_MESSAGE;
 import static com.yahoo.bard.webservice.config.ConfigMessageFormat.MODULE_FOUND_MESSAGE;
 import static com.yahoo.bard.webservice.config.ConfigMessageFormat.MODULE_NAME_DUPLICATION;
 import static com.yahoo.bard.webservice.config.ConfigMessageFormat.MODULE_NAME_MISSING;
@@ -28,7 +29,7 @@ import java.util.stream.Stream;
  */
 public class ConfigurationGraph {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ConfigResourceLoader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationGraph.class);
 
     /**
      * The special property which uniquely identifies the name of the module.
@@ -102,6 +103,7 @@ public class ConfigurationGraph {
 
         // later dependencies have higher precedence.  Store moduleDependencies in precedence order descending
         Collections.reverse(dependencies);
+        LOG.debug(MODULE_DEPENDS_ON_MESSAGE.logFormat(moduleName, dependencies));
 
         moduleDependencies.put(moduleName, dependencies);
     }

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/LayeredFileSystemConfig.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/LayeredFileSystemConfig.java
@@ -76,9 +76,9 @@ public class LayeredFileSystemConfig implements SystemConfig {
         try {
             // Loader pulls resources in from class path locations.
             ConfigResourceLoader loader = new ConfigResourceLoader();
-            List<Configuration> userConfig = loader.loadConfigurations(USER_CONFIG_FILE_NAME);
 
             // User configuration provides overrides for configuration on a specific environment or specialized role
+            List<Configuration> userConfig = loader.loadConfigurations(USER_CONFIG_FILE_NAME);
             if (userConfig.size() > 1) {
                 List<Resource> resources = loader.loadResourcesWithName(USER_CONFIG_FILE_NAME)
                         .collect(Collectors.toList());
@@ -91,7 +91,6 @@ public class LayeredFileSystemConfig implements SystemConfig {
 
             // Application configuration defines configuration at an application level for a bard instance
             List<Configuration> applicationConfig = loader.loadConfigurations(APPLICATION_CONFIG_FILE_NAME);
-
             if (applicationConfig.size() > 1) {
                 List<Resource> resources = loader.loadResourcesWithName(APPLICATION_CONFIG_FILE_NAME)
                         .collect(Collectors.toList());

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ModuleLoader.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ModuleLoader.java
@@ -81,7 +81,7 @@ public class ModuleLoader {
         try {
             Map<Configuration, String> configurationFileNameMap = configResourceLoader
                     .loadResourcesWithName(MODULE_CONFIG_FILE_NAME)
-                    .collect(Collectors.toMap(configResourceLoader::loadConfigFromResource, Resource::getFilename)
+                    .collect(Collectors.toMap(configResourceLoader::loadConfigFromResource, Resource::getDescription)
             );
             return new ConfigurationGraph(configurationFileNameMap, ModuleLoader::validateModuleName);
 

--- a/fili-system-config/src/test/groovy/com/yahoo/bard/webservice/config/ModuleLoaderSpec.groovy
+++ b/fili-system-config/src/test/groovy/com/yahoo/bard/webservice/config/ModuleLoaderSpec.groovy
@@ -81,7 +81,17 @@ class ModuleLoaderSpec extends Specification{
         RESOURCE_G.getFilename() >> RESOURCE_NAME_G
         RESOURCE_H.getFilename() >> RESOURCE_NAME_H
         RESOURCE_J.getFilename() >> RESOURCE_NAME_J
+        RESOURCE_A.getDescription() >> RESOURCE_NAME_A
+        RESOURCE_B.getDescription() >> RESOURCE_NAME_B
+        RESOURCE_C.getDescription() >> RESOURCE_NAME_C
+        RESOURCE_D.getDescription() >> RESOURCE_NAME_D
+        RESOURCE_E.getDescription() >> RESOURCE_NAME_E
+        RESOURCE_F.getDescription() >> RESOURCE_NAME_F
+        RESOURCE_G.getDescription() >> RESOURCE_NAME_G
+        RESOURCE_H.getDescription() >> RESOURCE_NAME_H
+        RESOURCE_J.getDescription() >> RESOURCE_NAME_J
         RESOURCE_MISSING_CHILD.getFilename() >> RESOURCE_NAME_MISSING_CHILD
+        RESOURCE_MISSING_CHILD.getDescription() >> RESOURCE_NAME_MISSING_CHILD
 
         resourceLoader = Mock(ConfigResourceLoader)
         resourceLoader.loadResourcesWithName(_) >> resourceConfigurationMap.keySet().stream()


### PR DESCRIPTION
- Use correct logger in ConfigurationGraph (was ConfigResourceLoader)
- Add error / logging messages for module dependency indicator
- Tweak loading resources debug log to read better
- Tweak module found log to read better
- Convert from Resource::getFilename to Resource::getDescription when
  reporting errors in the configuration graph. getDescription is more
  informative, usually holding the whole file path, rather than just the
  terminal segment / file _name_