### PR TITLE
Partition table config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -530,6 +530,8 @@ Changes:
 
 ### Deprecated:
 
+- [Deprecated DefaultingDictionary usage in DefaultingVolatileIntervalsService](https://github.com/yahoo/fili/pull/259)
+
 - [`RequestLog::switchTiming` has been deprecated](https://github.com/yahoo/fili/pull/141)
     - `RequestLog::switchTiming` is very context-dependent, and therefore brittle. In particular, adding any additional
       timers inside code called by a timed block may result in the original timer not stopping properly. All usages of
@@ -620,6 +622,13 @@ New Capabilities & Enhancements:
 - Better ability to use custom Druid query types
 
 ### Added:
+
+- [Added Dimension Value implementation for PartitionTableDefinition]
+    * Added `DimensionIdFilter` implementation of  `DataSourceFilter`
+    * Created `DimensionListPartitionTableDefinition` 
+
+- [Added 'hasAnyRows' to SearchProvider interface](https://github.com/yahoo/fili/pull/259)
+    * Has Any Rows allows implementations to optimize queries which only need to identify existence of matches
 
 - [Customize Logging Format in RequestLog](https://github.com/yahoo/fili/pull/81)
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/TableName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/TableName.java
@@ -43,6 +43,11 @@ public interface TableName {
                 }
                 return false;
             }
+
+            @Override
+            public String toString() {
+                return asName();
+            }
         };
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
@@ -52,7 +52,6 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames
-
     ) {
         super(name, timeGrain, metricNames, dimensionConfigs, logicalToPhysicalNames);
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
@@ -33,7 +33,9 @@ public class DimensionListPartitionTableDefinition extends PhysicalTableDefiniti
      * @param timeGrain  Zoned time grain of the table
      * @param metricNames  The Set of metric names on the table
      * @param dimensionConfigs  Set of dimensions on the table as dimension configs
-     * @param tablePartDefinitions A map from table names to a map of dimension names to sets of values for those dimensions.  The named table will match if for every dimension named at least one of the set of values is part of the query.
+     * @param tablePartDefinitions A map from table names to a map of dimension names to sets of values for those
+     * dimensions.  The named table will match if for every dimension named at least one of the set of values is part
+     * of the query.
      */
     public DimensionListPartitionTableDefinition(
             TableName name,
@@ -60,7 +62,7 @@ public class DimensionListPartitionTableDefinition extends PhysicalTableDefiniti
                                 entry.getValue(),
                                 dictionaries.getDimensionDictionary()
                         ))
-        ));
+                ));
 
         return new PartitionCompositeTable(
                 getName(),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
  */
 public class DimensionListPartitionTableDefinition extends PhysicalTableDefinition {
 
-    Map<TableName, Map<String, Set<String>>> tablePartDefinitions;
+    private final Map<TableName, Map<String, Set<String>>> tablePartDefinitions;
 
     /**
      * Constructor.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
@@ -33,7 +33,7 @@ public class DimensionListPartitionTableDefinition extends PhysicalTableDefiniti
      * @param timeGrain  Zoned time grain of the table
      * @param metricNames  The Set of metric names on the table
      * @param dimensionConfigs  Set of dimensions on the table as dimension configs
-     * @param tablePartDefinitions A map from table names to the dimension value matches for that table
+     * @param tablePartDefinitions A map from table names to a map of dimension names to sets of values for those dimensions.  The named table will match if for every dimension named at least one of the set of values is part of the query.
      */
     public DimensionListPartitionTableDefinition(
             TableName name,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
@@ -33,7 +33,7 @@ public class DimensionListPartitionTableDefinition extends PhysicalTableDefiniti
      * @param timeGrain  Zoned time grain of the table
      * @param metricNames  The Set of metric names on the table
      * @param dimensionConfigs  Set of dimensions on the table as dimension configs
-     * @param tablePartDefinitions A map from table names to a map of dimension names to sets of values for those
+     * @param tablePartDefinitions  A map from table names to a map of dimension names to sets of values for those
      * dimensions.  The named table will match if for every dimension named at least one of the set of values is part
      * of the query.
      */
@@ -79,7 +79,7 @@ public class DimensionListPartitionTableDefinition extends PhysicalTableDefiniti
      * @param dimensionNameMap  The configuration map from dimension names to sets of dimension key values.
      * @param dimensionDictionary  The dictionary of dimensions to use for binding.
      *
-     * @return A map of dimensions to dimension key values.
+     * @return a map of dimensions to dimension key values.
      */
     private Map<Dimension, Set<String>> toDimensionValuesMap(
             Map<String, Set<String>> dimensionNameMap,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
@@ -1,0 +1,93 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.table;
+
+import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
+import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
+import com.yahoo.bard.webservice.data.config.names.FieldName;
+import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.dimension.Dimension;
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
+import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
+import com.yahoo.bard.webservice.table.PartitionCompositeTable;
+import com.yahoo.bard.webservice.table.PhysicalTable;
+import com.yahoo.bard.webservice.table.resolver.DataSourceFilter;
+import com.yahoo.bard.webservice.table.resolver.DimensionIdFilter;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Holds the fields needed to define a partition physical table.
+ */
+public class DimensionListPartitionTableDefinition extends PhysicalTableDefinition {
+
+    Map<TableName, Map<String, Set<String>>> tablePartDefinitions;
+
+    /**
+     * Constructor.
+     *
+     * @param name  Table name of the physical table
+     * @param timeGrain  Zoned time grain of the table
+     * @param metricNames  The Set of metric names on the table
+     * @param dimensionConfigs  Set of dimensions on the table as dimension configs
+     * @param tablePartDefinitions A map from table names to the dimension value matches for that table
+     */
+    public DimensionListPartitionTableDefinition(
+            TableName name,
+            ZonedTimeGrain timeGrain,
+            Set<FieldName> metricNames,
+            Set<? extends DimensionConfig> dimensionConfigs,
+            Map<TableName, Map<String, Set<String>>> tablePartDefinitions
+    ) {
+        super(name, timeGrain, metricNames, dimensionConfigs);
+        this.tablePartDefinitions = tablePartDefinitions;
+    }
+
+    @Override
+    public Set<TableName> getDependentTableNames() {
+        return tablePartDefinitions.keySet();
+    }
+
+    @Override
+    public PhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
+        Map<PhysicalTable, DataSourceFilter> availabilityFilters = tablePartDefinitions.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> dictionaries.getPhysicalDictionary().get(entry.getKey().asName()),
+                        entry -> new DimensionIdFilter(toDimensionValuesMap(
+                                entry.getValue(),
+                                dictionaries.getDimensionDictionary()
+                        ))
+        ));
+
+        return new PartitionCompositeTable(
+                getName(),
+                getTimeGrain(),
+                buildColumns(dictionaries.getDimensionDictionary()),
+                getLogicalToPhysicalNames(),
+                availabilityFilters
+        );
+    }
+
+    /**
+     * Bind a map from String dimension names to dimension keys.
+     *
+     * @param dimensionNameMap  The configuration map from dimension names to sets of dimension key values.
+     * @param dimensionDictionary  The dictionary of dimensions to use for binding.
+     *
+     * @return A map of dimensions to dimension key values.
+     */
+    private Map<Dimension, Set<String>> toDimensionValuesMap(
+            Map<String, Set<String>> dimensionNameMap,
+            DimensionDictionary dimensionDictionary
+    ) {
+        return dimensionNameMap.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> dimensionDictionary.findByApiName(entry.getKey()),
+                        Map.Entry::getValue
+                        )
+                );
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionRow.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionRow.java
@@ -13,7 +13,8 @@ import javax.validation.constraints.NotNull;
  * DimensionRow is the model for a row in a Dimension lookup table.
  */
 public class DimensionRow extends LinkedHashMap<DimensionField, String> implements Comparable<DimensionRow> {
-    private String keyvalue;
+
+    private String keyValue;
 
     /**
      * Build a dimension row with a key field value and a map of field values.
@@ -23,16 +24,25 @@ public class DimensionRow extends LinkedHashMap<DimensionField, String> implemen
      */
     public DimensionRow(@NotNull DimensionField key, Map<DimensionField, String> fieldValueMap) {
         super(fieldValueMap);
-        this.keyvalue = fieldValueMap.get(key);
-        if (keyvalue == null) {
+        this.keyValue = fieldValueMap.get(key);
+        if (keyValue == null) {
             throw new IllegalArgumentException("Missing key " + key);
         }
+    }
+
+    /**
+     * Getter.
+     *
+     * @return The value of the key field for this dimension row
+     */
+    public String getKeyValue() {
+        return keyValue;
     }
 
     @Override
     public int compareTo(DimensionRow that) {
         if (this == that) { return 0; }
-        int c = this.keyvalue.compareTo(that.keyvalue);
+        int c = this.keyValue.compareTo(that.keyValue);
         if (c == 0) {
             for (DimensionField k : this.keySet()) {
                 c = String.valueOf(this.get(k)).compareTo(String.valueOf(that.get(k)));

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionRow.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/DimensionRow.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.NotNull;
  */
 public class DimensionRow extends LinkedHashMap<DimensionField, String> implements Comparable<DimensionRow> {
 
-    private String keyValue;
+    private final String keyValue;
 
     /**
      * Build a dimension row with a key field value and a map of field values.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/SearchProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/SearchProvider.java
@@ -109,6 +109,17 @@ public interface SearchProvider {
     );
 
     /**
+     * Determine if any rows match these filters.
+     *
+     * @param filters  ApiFilters to use for finding matching dimension rows
+     *
+     * @return true if at least one row is returned.
+     */
+    default boolean hasAnyRows(Set<ApiFilter> filters) {
+        return findFilteredDimensionRowsPaged(filters, PaginationParameters.ONE_RESULT).getNumResults() > 0;
+    }
+
+    /**
      * Method to add / update indexes.
      *
      * @param rowId  Unique ID for the dimension row

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/DefaultingVolatileIntervalsService.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/DefaultingVolatileIntervalsService.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.data.volatility;
 import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.table.PhysicalTable;
+import com.yahoo.bard.webservice.util.DefaultingDictionary;
 import com.yahoo.bard.webservice.util.IntervalUtils;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
@@ -18,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * An implementation of VolatileIntervalsService backed by DefaultingDictionary.
+ * An implementation of VolatileIntervalsService.
  */
 public class DefaultingVolatileIntervalsService implements VolatileIntervalsService {
 
@@ -48,6 +49,20 @@ public class DefaultingVolatileIntervalsService implements VolatileIntervalsServ
      */
     public DefaultingVolatileIntervalsService(VolatileIntervalsFunction defaultIntervalsFunction) {
         this(defaultIntervalsFunction, Collections.emptyMap());
+    }
+
+    /**
+     * Use the map of specific functions for physical tables.
+     *
+     * @param intervalsFunctions  the map of specific functions for physical tables
+     *
+     * @deprecated Simply use maps and default values
+     */
+    @Deprecated
+    public DefaultingVolatileIntervalsService(
+                DefaultingDictionary<PhysicalTable, VolatileIntervalsFunction> intervalsFunctions
+    ) {
+        this(intervalsFunctions.getDefaultValue(), intervalsFunctions);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -151,9 +151,8 @@ public abstract class BasePhysicalTable implements PhysicalTable {
             return Objects.equals(name.asName(), that.name.asName())
                     && Objects.equals(schema, that.schema)
                     && Objects.equals(availability, that.availability);
-        } else {
-            return false;
         }
+        return false;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -138,5 +139,22 @@ public abstract class BasePhysicalTable implements PhysicalTable {
     @Deprecated
     protected void setAvailability(Availability availability) {
         this.availability = availability;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof BasePhysicalTable) {
+            BasePhysicalTable that = (BasePhysicalTable) obj;
+            return Objects.equals(name.asName(), that.name.asName())
+                    && Objects.equals(schema, that.schema)
+                    && Objects.equals(availability, that.availability);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name.asName(), schema, availability);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -157,4 +157,9 @@ public abstract class BasePhysicalTable implements PhysicalTable {
     public int hashCode() {
         return Objects.hash(name.asName(), schema, availability);
     }
+
+    @Override
+    public String toString() {
+        return "Physical table: " + name.asName() + ": schema: " + schema + ": availability :" + availability;
+    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -142,7 +142,9 @@ public abstract class BasePhysicalTable implements PhysicalTable {
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
         if (obj instanceof BasePhysicalTable) {
             BasePhysicalTable that = (BasePhysicalTable) obj;
             return Objects.equals(name.asName(), that.name.asName())

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -143,8 +143,9 @@ public abstract class BasePhysicalTable implements PhysicalTable {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
+        }
         if (obj instanceof BasePhysicalTable) {
             BasePhysicalTable that = (BasePhysicalTable) obj;
             return Objects.equals(name.asName(), that.name.asName())

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -160,6 +160,11 @@ public abstract class BasePhysicalTable implements PhysicalTable {
 
     @Override
     public String toString() {
-        return "Physical table: " + name.asName() + ": schema: " + schema + ": availability :" + availability;
+        return String.format(
+                "Physical table: '%s', schema: '%s', availability: '%s'",
+                name.asName(),
+                schema,
+                availability
+        );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseSchema.java
@@ -51,6 +51,11 @@ public class BaseSchema implements Schema {
     }
 
     @Override
+    public String toString() {
+        return String.format("%s: columns: %s granularity: %s", getClass().getSimpleName(), columns, granularity);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
@@ -97,9 +97,4 @@ public class ConcretePhysicalTable extends BasePhysicalTable {
     public String getFactTableName() {
         return factTableName;
     }
-
-    @Override
-    public String toString() {
-        return super.toString() + " factTableName: " + getAvailability().getDataSourceNames();
-    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PartitionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PartitionCompositeTable.java
@@ -56,4 +56,9 @@ public class PartitionCompositeTable extends BaseCompositePhysicalTable {
         return new PartitionAvailability(dataSourceFilterMap.entrySet().stream()
                 .collect(Collectors.toMap(entry -> entry.getKey().getAvailability(), Map.Entry::getValue)));
     }
+
+    @Override
+    public String toString() {
+        return getName() + ":" + getSchema().getTimeGrain() + ":" + getAvailability();
+    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PartitionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PartitionCompositeTable.java
@@ -56,9 +56,4 @@ public class PartitionCompositeTable extends BaseCompositePhysicalTable {
         return new PartitionAvailability(dataSourceFilterMap.entrySet().stream()
                 .collect(Collectors.toMap(entry -> entry.getKey().getAvailability(), Map.Entry::getValue)));
     }
-
-    @Override
-    public String toString() {
-        return getName() + ":" + getSchema().getTimeGrain() + ":" + getAvailability();
-    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.table;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -36,7 +37,8 @@ public class PhysicalTableSchema extends BaseSchema {
         super(timeGrain, columns);
         this.timeGrain = timeGrain;
 
-        this.logicalToPhysicalColumnNames = Collections.unmodifiableMap(logicalToPhysicalColumnNames);
+        this.logicalToPhysicalColumnNames = Collections.unmodifiableMap(new LinkedHashMap<>
+                (logicalToPhysicalColumnNames));
         this.physicalToLogicalColumnNames = Collections.unmodifiableMap(
                 this.logicalToPhysicalColumnNames.entrySet().stream().collect(
                         Collectors.groupingBy(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
@@ -37,8 +37,9 @@ public class PhysicalTableSchema extends BaseSchema {
         super(timeGrain, columns);
         this.timeGrain = timeGrain;
 
-        this.logicalToPhysicalColumnNames = Collections.unmodifiableMap(new LinkedHashMap<>
-                (logicalToPhysicalColumnNames));
+        this.logicalToPhysicalColumnNames = Collections.unmodifiableMap(
+                new LinkedHashMap<>(logicalToPhysicalColumnNames)
+        );
         this.physicalToLogicalColumnNames = Collections.unmodifiableMap(
                 this.logicalToPhysicalColumnNames.entrySet().stream().collect(
                         Collectors.groupingBy(
@@ -101,10 +102,14 @@ public class PhysicalTableSchema extends BaseSchema {
     }
 
     @Override
-    public boolean equals(final Object o) {
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (o instanceof PhysicalTableSchema) {
             PhysicalTableSchema that = (PhysicalTableSchema) o;
-            return Objects.equals(timeGrain, that.timeGrain)
+            return super.equals(o)
+                    && Objects.equals(timeGrain, that.timeGrain)
                     && Objects.equals(logicalToPhysicalColumnNames, that.logicalToPhysicalColumnNames)
                     && Objects.equals(physicalToLogicalColumnNames, that.physicalToLogicalColumnNames);
         }
@@ -113,11 +118,11 @@ public class PhysicalTableSchema extends BaseSchema {
 
     @Override
     public int hashCode() {
-        return Objects.hash(timeGrain, logicalToPhysicalColumnNames, physicalToLogicalColumnNames);
+        return Objects.hash(super.hashCode(), timeGrain, logicalToPhysicalColumnNames, physicalToLogicalColumnNames);
     }
 
     @Override
     public String toString() {
-        return "time grain: " + timeGrain + ": logicalToPhysicalColumnNames: " + logicalToPhysicalColumnNames;
+        return String.format("%s logicalToPhysicalNameMap: %s", super.toString(), logicalToPhysicalColumnNames);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
@@ -113,4 +113,9 @@ public class PhysicalTableSchema extends BaseSchema {
     public int hashCode() {
         return Objects.hash(timeGrain, logicalToPhysicalColumnNames, physicalToLogicalColumnNames);
     }
+
+    @Override
+    public String toString() {
+        return "time grain: " + timeGrain + ": logicalToPhysicalColumnNames: " + logicalToPhysicalColumnNames;
+    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableSchema.java
@@ -6,6 +6,7 @@ import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -95,5 +96,21 @@ public class PhysicalTableSchema extends BaseSchema {
      */
     public ZonedTimeGrain getTimeGrain() {
         return timeGrain;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o instanceof PhysicalTableSchema) {
+            PhysicalTableSchema that = (PhysicalTableSchema) o;
+            return Objects.equals(timeGrain, that.timeGrain)
+                    && Objects.equals(logicalToPhysicalColumnNames, that.logicalToPhysicalColumnNames)
+                    && Objects.equals(physicalToLogicalColumnNames, that.physicalToLogicalColumnNames);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timeGrain, logicalToPhysicalColumnNames, physicalToLogicalColumnNames);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -9,6 +9,7 @@ import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.validation.constraints.NotNull;
@@ -79,5 +80,23 @@ public class ConcreteAvailability implements Availability {
     @Override
     public String toString() {
         return String.format("ConcreteAvailability for table: %s", name.asName());
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof ConcreteAvailability) {
+            ConcreteAvailability that = (ConcreteAvailability) obj;
+            return Objects.equals(name.asName(), that.name.asName())
+                    && Objects.equals(dataSourceNames, that.dataSourceNames)
+                    // Since metadata service is mutable, use instance equality to ensure table equality is stable
+                    && metadataService == that.metadataService;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        // Leave metadataService out of hash because it is mutable
+        return Objects.hash(name.asName(), dataSourceNames);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -79,7 +79,11 @@ public class ConcreteAvailability implements Availability {
 
     @Override
     public String toString() {
-        return String.format("ConcreteAvailability for table: %s", name.asName() + " with data source names: " + dataSourceNames);
+        return String.format(
+                "ConcreteAvailability for table: %s with data source names %s",
+                name.asName(),
+                dataSourceNames
+        );
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -87,7 +87,7 @@ public class ConcreteAvailability implements Availability {
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (obj instanceof ConcreteAvailability) {
             ConcreteAvailability that = (ConcreteAvailability) obj;
             return Objects.equals(name.asName(), that.name.asName())

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -79,7 +79,7 @@ public class ConcreteAvailability implements Availability {
 
     @Override
     public String toString() {
-        return String.format("ConcreteAvailability for table: %s", name.asName());
+        return String.format("ConcreteAvailability for table: %s", name.asName() + " with data source names: " + dataSourceNames);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -134,7 +134,6 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
         return constructSubConstraint(constraint).entrySet().stream()
                 .map(entry -> entry.getKey().getAvailableIntervals(entry.getValue()))
                 .reduce(SimplifiedIntervalList::intersect).orElse(new SimplifiedIntervalList());
-
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -192,13 +192,13 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (obj instanceof MetricUnionAvailability) {
             MetricUnionAvailability that = (MetricUnionAvailability) obj;
             return Objects.equals(metricNames, that.metricNames)
                     && Objects.equals(availabilitiesToMetricNames, that.availabilitiesToMetricNames);
         }
-        return super.equals(obj);
+        return false;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import java.util.AbstractMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -188,5 +189,20 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
                 metricNames.stream()
                         .collect(Collectors.joining(", "))
         );
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof MetricUnionAvailability) {
+            MetricUnionAvailability that = (MetricUnionAvailability) obj;
+            return Objects.equals(metricNames, that.metricNames)
+                    && Objects.equals(availabilitiesToMetricNames, that.availabilitiesToMetricNames);
+        }
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(metricNames, availabilitiesToMetricNames);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -193,6 +193,9 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj instanceof MetricUnionAvailability) {
             MetricUnionAvailability that = (MetricUnionAvailability) obj;
             return Objects.equals(metricNames, that.metricNames)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PartitionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PartitionAvailability.java
@@ -101,6 +101,9 @@ public class PartitionAvailability extends BaseCompositeAvailability implements 
 
     @Override
     public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj instanceof PartitionAvailability) {
             PartitionAvailability that = (PartitionAvailability) obj;
             return Objects.equals(availabilityFilters, that.availabilityFilters);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PartitionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PartitionAvailability.java
@@ -7,6 +7,7 @@ import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import javax.validation.constraints.NotNull;
@@ -91,5 +92,24 @@ public class PartitionAvailability extends BaseCompositeAvailability implements 
     @Override
     public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
         return mergeAvailabilities(constraint);
+    }
+
+    @Override
+    public String toString() {
+        return availabilityFilters.toString();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof PartitionAvailability) {
+            PartitionAvailability that = (PartitionAvailability) obj;
+            return Objects.equals(availabilityFilters, that.availabilityFilters);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(availabilityFilters);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DimensionIdFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DimensionIdFilter.java
@@ -91,7 +91,7 @@ public class DimensionIdFilter implements DataSourceFilter {
     }
 
     @Override
-    public boolean equals(final Object obj) {
+    public boolean equals(Object obj) {
         if (obj instanceof DimensionIdFilter) {
             return Objects.equals(dimensionKeySelectFilters, ((DimensionIdFilter) obj).dimensionKeySelectFilters);
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DimensionIdFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DimensionIdFilter.java
@@ -1,0 +1,100 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.resolver;
+
+import com.yahoo.bard.webservice.data.dimension.Dimension;
+import com.yahoo.bard.webservice.util.StreamUtils;
+import com.yahoo.bard.webservice.web.ApiFilter;
+import com.yahoo.bard.webservice.web.FilterOperation;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * An implementation of {@link DataSourceFilter} which uses dimensionApiFilters to match partition data sources.
+ * The matching algorithm requires that for each dimension specified, the query filters must match one of the
+ * corresponding values.
+ */
+public class DimensionIdFilter implements DataSourceFilter {
+
+    private final Map<Dimension, ApiFilter> dimensionKeySelectFilters;
+
+    /**
+     * Constructor.
+     *
+     *
+     * @param dimensionMappingValues  The map of dimension to sets of dimension values which map this table.
+     */
+    public DimensionIdFilter(Map<Dimension, Set<String>> dimensionMappingValues) {
+        dimensionKeySelectFilters = dimensionMappingValues.entrySet().stream()
+                .map(entry -> new AbstractMap.SimpleEntry<>(
+                        entry.getKey(),
+                        new ApiFilter(entry.getKey(), entry.getKey().getKey(), FilterOperation.in, entry.getValue())
+                ))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Check if for a given set of request filters, adding in the filters for this `DataSourceFilter` there is a
+     * corresponding row.
+     * This method should never be called with a dimension that isn't a key in {@link #dimensionKeySelectFilters}
+     *
+     * @param dimension  The dimension whose rows are being tested on.
+     * @param constraintFilters  The api filters from the constraint
+     *
+     * @return  True if for this dimension there are rows matching the query filters AND the embedded filters.
+     */
+    protected boolean anyRowsMatch(@NotNull Dimension dimension, @NotNull Set<ApiFilter> constraintFilters) {
+        if (!dimensionKeySelectFilters.containsKey(dimension)) {
+            throw new IllegalArgumentException(
+                    "Any rows match should only be called with dimensions defined on this filter."
+            );
+        }
+        Set<ApiFilter> combinedFilters = StreamUtils.append(
+                constraintFilters,
+                dimensionKeySelectFilters.get(dimension)
+        );
+        return dimension.getSearchProvider().hasAnyRows(combinedFilters);
+    }
+
+    /**
+     * Test whether constraints for a particular dimension are missing, empty or match rows.
+     *
+     * @param dimension  The dimension for filtering
+     * @param constraintMap  The map of filters from the constraint object
+     *
+     * @return true if the constraintMap doesn't constraint this dimension or if the constraint returns rows
+     */
+    private boolean emptyConstraintOrAnyRows(Dimension dimension, Map<Dimension, Set<ApiFilter>> constraintMap) {
+        return !constraintMap.containsKey(dimension) ||
+                constraintMap.get(dimension).isEmpty() ||
+                anyRowsMatch(dimension, constraintMap.get(dimension));
+    }
+
+    @Override
+    public Boolean apply(DataSourceConstraint constraint) {
+        Map<Dimension, Set<ApiFilter>> constraintMap = constraint.getApiFilters();
+
+        return dimensionKeySelectFilters.keySet()
+                .stream()
+                .allMatch(dimension -> emptyConstraintOrAnyRows(dimension, constraintMap));
+    }
+
+    @Override
+    public int hashCode() {
+        return dimensionKeySelectFilters.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof DimensionIdFilter) {
+            return Objects.equals(dimensionKeySelectFilters, ((DimensionIdFilter) obj).dimensionKeySelectFilters);
+        }
+        return false;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DimensionIdFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DimensionIdFilter.java
@@ -27,7 +27,6 @@ public class DimensionIdFilter implements DataSourceFilter {
     /**
      * Constructor.
      *
-     *
      * @param dimensionMappingValues  The map of dimension to sets of dimension values which map this table.
      */
     public DimensionIdFilter(Map<Dimension, Set<String>> dimensionMappingValues) {
@@ -47,7 +46,7 @@ public class DimensionIdFilter implements DataSourceFilter {
      * @param dimension  The dimension whose rows are being tested on.
      * @param constraintFilters  The api filters from the constraint
      *
-     * @return  True if for this dimension there are rows matching the query filters AND the embedded filters.
+     * @return true if for this dimension there are rows matching the query filters AND the embedded filters.
      */
     protected boolean anyRowsMatch(@NotNull Dimension dimension, @NotNull Set<ApiFilter> constraintFilters) {
         if (!dimensionKeySelectFilters.containsKey(dimension)) {
@@ -92,6 +91,9 @@ public class DimensionIdFilter implements DataSourceFilter {
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj instanceof DimensionIdFilter) {
             return Objects.equals(dimensionKeySelectFilters, ((DimensionIdFilter) obj).dimensionKeySelectFilters);
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/StreamUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/StreamUtils.java
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.util;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -160,5 +161,20 @@ public class StreamUtils {
                 R castedOperand = (R) operand;
                 return castedOperand;
         };
+    }
+
+    /**
+     * Copy a set, add a value to it and return the new set.
+     *
+     * @param set  The original set being copied.
+     * @param value  The value being appended to the set.
+     * @param <T>  The type of the set
+     *
+     * @return The new set containing the additional value
+     */
+    public static <T> Set<T> append(Set<T> set, T value) {
+        HashSet<T> result = new HashSet<T>(set);
+        result.add(value);
+        return result;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/StreamUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/StreamUtils.java
@@ -170,7 +170,7 @@ public class StreamUtils {
      * @param value  The value being appended to the set.
      * @param <T>  The type of the set
      *
-     * @return The new set containing the additional value
+     * @return the new set containing the additional value
      */
     public static <T> Set<T> append(Set<T> set, T value) {
         HashSet<T> result = new HashSet<T>(set);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/PaginationParameters.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/PaginationParameters.java
@@ -36,6 +36,14 @@ public class PaginationParameters {
             1
     );
 
+    /**
+     * Return only the first result.
+     */
+    public static final PaginationParameters ONE_RESULT = new PaginationParameters(
+            1,
+            1
+    );
+
     private final int perPage;
     private final int page;
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/PaginationParameters.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/PaginationParameters.java
@@ -39,10 +39,7 @@ public class PaginationParameters {
     /**
      * Return only the first result.
      */
-    public static final PaginationParameters ONE_RESULT = new PaginationParameters(
-            1,
-            1
-    );
+    public static final PaginationParameters ONE_RESULT = new PaginationParameters(1, 1);
 
     private final int perPage;
     private final int page;

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinitionSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinitionSpec.groovy
@@ -1,0 +1,99 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.config.table
+
+import static com.yahoo.bard.webservice.data.time.ZonedTimeGrainSpec.DAY_UTC
+
+import com.yahoo.bard.webservice.data.config.ResourceDictionaries
+import com.yahoo.bard.webservice.data.config.names.TableName
+import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
+import com.yahoo.bard.webservice.data.dimension.DimensionField
+import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
+import com.yahoo.bard.webservice.table.Column
+import com.yahoo.bard.webservice.table.PartitionCompositeTable
+import com.yahoo.bard.webservice.table.PhysicalTable
+import com.yahoo.bard.webservice.table.PhysicalTableSchema
+import com.yahoo.bard.webservice.table.availability.Availability
+import com.yahoo.bard.webservice.table.resolver.DimensionIdFilter
+
+import spock.lang.Specification
+
+class DimensionListPartitionTableDefinitionSpec extends Specification {
+
+    DimensionField keyField = Mock(DimensionField)
+
+    String dimensionName = "testDimension"
+
+    Dimension testDimension = Mock(Dimension) {
+        getApiName() >> dimensionName
+        getKey() >> keyField
+    }
+
+    DimensionDictionary dimensionDictionary = new DimensionDictionary()
+    ResourceDictionaries resourceDictionaries = new ResourceDictionaries()
+
+    TableName part1Name = TableName.of("part1")
+    TableName part2Name = TableName.of("part2")
+
+    TableName dataSource1 = TableName.of("part1_ds1")
+    TableName dataSource2 = TableName.of("part1_ds2")
+    TableName dataSource3 = TableName.of("part2_ds1")
+
+
+    Map<TableName, Map<String, Set<String>>> mappings =
+            [(part1Name): [(dimensionName): ["part1Value"] as Set],
+             (part2Name): [(dimensionName): ["part2Value"] as Set]]
+
+    Availability availability1 = Mock(Availability) {
+        getDataSourceNames() >> ([dataSource1, dataSource2] as Set)
+    }
+    Availability availability2 = Mock(Availability) {
+        getDataSourceNames() >> ([dataSource3] as Set)
+    }
+    PhysicalTableSchema schema = Mock(PhysicalTableSchema) {
+        getTimeGrain() >> DAY_UTC
+    }
+
+    PhysicalTable part1 = Mock(PhysicalTable) {
+        getAvailability() >> availability1
+        getSchema() >> schema
+    }
+
+    PhysicalTable part2 = Mock(PhysicalTable) {
+        getAvailability() >> availability2
+        getSchema() >> schema
+    }
+
+    def setup() {
+        resourceDictionaries.dimensionDictionary.add(testDimension)
+
+        resourceDictionaries.physical.put(part1Name.asName(), part1)
+        resourceDictionaries.physical.put(part2Name.asName(), part2)
+    }
+
+    def "Build method duplicates the effects of the constructor"() {
+        setup:
+        DimensionListPartitionTableDefinition definition = new DimensionListPartitionTableDefinition(
+                TableName.of("partition"),
+                DAY_UTC,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                mappings
+        )
+
+        DataSourceMetadataService service = Mock(DataSourceMetadataService)
+
+        PartitionCompositeTable expected = new PartitionCompositeTable(
+                TableName.of("partition"),
+                DAY_UTC,
+                (Set<Column>) Collections.emptySet(),
+                [:],
+                [(part1): new DimensionIdFilter([(testDimension): (["part1Value"] as Set)]),
+                 (part2): new DimensionIdFilter([(testDimension): (["part2Value"] as Set)])]
+        )
+
+        expect:
+        definition.build(resourceDictionaries, service) == expected
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinitionSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinitionSpec.groovy
@@ -10,7 +10,6 @@ import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.data.dimension.DimensionField
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.Column
 import com.yahoo.bard.webservice.table.PartitionCompositeTable
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableSchema
@@ -77,8 +76,8 @@ class DimensionListPartitionTableDefinitionSpec extends Specification {
         DimensionListPartitionTableDefinition definition = new DimensionListPartitionTableDefinition(
                 TableName.of("partition"),
                 DAY_UTC,
-                Collections.emptySet(),
-                Collections.emptySet(),
+                [] as Set,
+                [] as Set,
                 mappings
         )
 
@@ -87,7 +86,7 @@ class DimensionListPartitionTableDefinitionSpec extends Specification {
         PartitionCompositeTable expected = new PartitionCompositeTable(
                 TableName.of("partition"),
                 DAY_UTC,
-                (Set<Column>) Collections.emptySet(),
+                [] as Set,
                 [:],
                 [(part1): new DimensionIdFilter([(testDimension): (["part1Value"] as Set)]),
                  (part2): new DimensionIdFilter([(testDimension): (["part2Value"] as Set)])]

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/DimensionRowSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/DimensionRowSpec.groovy
@@ -17,6 +17,7 @@ class DimensionRowSpec extends Specification {
         keyField.name >> keyFieldFieldName
         nonKeyField.name >> nonKeyFieldName
     }
+
     def "healthy initialization returns correct state"() {
         setup:
         DimensionRow testRow = new DimensionRow(keyField, [(keyField): keyValue, (nonKeyField): nonKeyValue])

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/DimensionRowSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/DimensionRowSpec.groovy
@@ -1,0 +1,28 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.data.dimension
+
+import spock.lang.Specification
+
+class DimensionRowSpec extends Specification {
+
+    String keyValue = "key"
+    String nonKeyValue = "nonKey"
+    String keyFieldFieldName = "keyFieldName"
+    String nonKeyFieldName = "nonKeyFieldName"
+    DimensionField keyField = Mock(DimensionField)
+    DimensionField nonKeyField = Mock(DimensionField)
+
+    def setup() {
+        keyField.name >> keyFieldFieldName
+        nonKeyField.name >> nonKeyFieldName
+    }
+    def "healthy initialization returns correct state"() {
+        setup:
+        DimensionRow testRow = new DimensionRow(keyField, [(keyField): keyValue, (nonKeyField): nonKeyValue])
+
+        expect:
+        testRow.getKeyValue() == keyValue
+        testRow.getRowMap() == [(nonKeyFieldName): nonKeyValue, (keyFieldFieldName): keyValue]
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/volatility/DefaultingVolatileIntervalsServiceSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/volatility/DefaultingVolatileIntervalsServiceSpec.groovy
@@ -13,6 +13,7 @@ import org.joda.time.DateTime
 import org.joda.time.Interval
 
 import spock.lang.Specification
+
 /**
  * Test the default intervals service
  */
@@ -63,9 +64,7 @@ class DefaultingVolatileIntervalsServiceSpec extends Specification {
         allGrainQuery.intervals >> fullRange
         allGrainQuery.granularity >> AllGranularity.INSTANCE
 
-        intervalsFunctions = new HashMap<>()
-        intervalsFunctions.put(table2, mockFunction2)
-        intervalsFunctions.put(table3, mockFunction3)
+        intervalsFunctions = [(table2): mockFunction2, (table3): mockFunction3]
     }
 
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/volatility/DefaultingVolatileIntervalsServiceSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/volatility/DefaultingVolatileIntervalsServiceSpec.groovy
@@ -7,14 +7,12 @@ import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 import com.yahoo.bard.webservice.druid.model.query.AllGranularity
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery
 import com.yahoo.bard.webservice.table.PhysicalTable
-import com.yahoo.bard.webservice.util.DefaultingDictionary
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
 import org.joda.time.DateTime
 import org.joda.time.Interval
 
 import spock.lang.Specification
-
 /**
  * Test the default intervals service
  */
@@ -23,9 +21,15 @@ class DefaultingVolatileIntervalsServiceSpec extends Specification {
     DruidAggregationQuery query = Mock(DruidAggregationQuery)
     DruidAggregationQuery allGrainQuery = Mock(DruidAggregationQuery)
 
-    PhysicalTable table = Mock(PhysicalTable)
-    PhysicalTable table2 = Mock(PhysicalTable)
-    PhysicalTable table3 = Mock(PhysicalTable)
+    PhysicalTable table = Mock(PhysicalTable) {
+        getName() >> "name1"
+    }
+    PhysicalTable table2 = Mock(PhysicalTable) {
+        getName() >> "name2"
+    }
+    PhysicalTable table3 = Mock(PhysicalTable) {
+        getName() >> "name3"
+    }
 
     VolatileIntervalsFunction defaultFunction = Mock(VolatileIntervalsFunction)
     VolatileIntervalsFunction mockFunction2 = Mock(VolatileIntervalsFunction)
@@ -38,7 +42,7 @@ class DefaultingVolatileIntervalsServiceSpec extends Specification {
 
     SimplifiedIntervalList fullRange = new SimplifiedIntervalList([new Interval(origin, end)])
 
-    DefaultingDictionary<PhysicalTable, VolatileIntervalsFunction> intervalsFunctions
+    Map<PhysicalTable, VolatileIntervalsFunction> intervalsFunctions
 
     def setup() {
         // Create intervals which are distinct subintervals from a common base interval
@@ -59,7 +63,7 @@ class DefaultingVolatileIntervalsServiceSpec extends Specification {
         allGrainQuery.intervals >> fullRange
         allGrainQuery.granularity >> AllGranularity.INSTANCE
 
-        intervalsFunctions = new DefaultingDictionary<>(defaultFunction)
+        intervalsFunctions = new HashMap<>()
         intervalsFunctions.put(table2, mockFunction2)
         intervalsFunctions.put(table3, mockFunction3)
     }
@@ -100,7 +104,7 @@ class DefaultingVolatileIntervalsServiceSpec extends Specification {
 
     def "getVolatileIntervals for all granularity buckets correctly"() {
         given:
-        DefaultingVolatileIntervalsService service = new DefaultingVolatileIntervalsService(intervalsFunctions)
+        DefaultingVolatileIntervalsService service = new DefaultingVolatileIntervalsService(defaultFunction, intervalsFunctions)
 
         expect:
         service.getVolatileIntervals(allGrainQuery.granularity, allGrainQuery.intervals, table) == fullRange

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DimensionIdFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DimensionIdFilterSpec.groovy
@@ -60,7 +60,7 @@ class DimensionIdFilterSpec extends Specification {
         searchProvider.hasAnyRows(_) >> searchRowsExist
 
         expect: "filter matches when there are no constraints or they exist and return rows from search provider"
-        expected == filter.emptyConstraintOrAnyRows(dimension, constraintMap)
+        filter.emptyConstraintOrAnyRows(dimension, constraintMap) == expected
 
         where:
         hasApiFilter  | emptyApiFilter | searchRowsExist | expected | description
@@ -116,10 +116,10 @@ class DimensionIdFilterSpec extends Specification {
         }
 
         expect: "True as long as the dimension that doesnt return rows is not constrained"
-        dimensionIdFilter.apply(constraint) == success
+        dimensionIdFilter.apply(constraint) == expected
 
         where:
-        constrainFailure | constrainSuccess | constrainOther | success
+        constrainFailure | constrainSuccess | constrainOther | expected
         true             | true             | true           | false
         true             | true             | false          | false
         true             | false            | true           | false

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DimensionIdFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/DimensionIdFilterSpec.groovy
@@ -1,0 +1,137 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.resolver
+
+import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.data.dimension.DimensionField
+import com.yahoo.bard.webservice.data.dimension.SearchProvider
+import com.yahoo.bard.webservice.web.ApiFilter
+import com.yahoo.bard.webservice.web.FilterOperation
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DimensionIdFilterSpec extends Specification {
+
+    def "Constructor builds the expected ApiFilter map"() {
+        setup:
+        def (Dimension dimension, _, ApiFilter expectedApiFilter, DimensionIdFilter dimensionIdFilter) = buildSimpleTestData()
+
+        expect:
+        dimensionIdFilter.dimensionKeySelectFilters == [(dimension): expectedApiFilter]
+    }
+
+    def "anyRowsMatch() throws IllegalArgumentException if dimension is not defined on the DimensionIdFilter"() {
+        def (_, foo, bar, DimensionIdFilter dimensionIdFilter) = buildSimpleTestData()
+
+        when:
+        dimensionIdFilter.anyRowsMatch(Mock(Dimension), null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "anyRowsMatch() appends apiFilter from DimensionIdFilter to constraint filters and queries search provider"() {
+        given: "A simple dimension id filter"
+        def (Dimension dimension, SearchProvider searchProvider, ApiFilter dimensionIdApiFilter, DimensionIdFilter filter) = buildSimpleTestData()
+
+        DimensionField keyField = dimension.getKey()
+
+        and: "a search provider expecting concatenated api filters"
+        ApiFilter constraintApiFilter = new ApiFilter(dimension, keyField, FilterOperation.in, ["a"] as Set)
+        Set<ApiFilter> expectedSearchApiFilters = [dimensionIdApiFilter, constraintApiFilter] as HashSet
+
+        1 * searchProvider.hasAnyRows(expectedSearchApiFilters) >> true
+
+        expect: "Check that the expected values are submitted to the backing search provider"
+        filter.anyRowsMatch(dimension, [constraintApiFilter] as Set)
+    }
+
+
+    @Unroll
+    def "Does emptyConstraintOrAnyRows match return #expected with #description"() {
+        given: "A constraint map with some constraints"
+        def (Dimension dimension, SearchProvider searchProvider, Object foo, DimensionIdFilter filter) = buildSimpleTestData()
+
+        Map<Dimension, Set<ApiFilter>> constraintMap = hasApiFilter ?
+                [(dimension): (emptyApiFilter ? Collections.emptySet() : [Mock(ApiFilter)] as Set)] :
+                [:]
+
+        searchProvider.hasAnyRows(_) >> searchRowsExist
+
+        expect: "filter matches when there are no constraints or they exist and return rows from search provider"
+        expected == filter.emptyConstraintOrAnyRows(dimension, constraintMap)
+
+        where:
+        hasApiFilter  | emptyApiFilter | searchRowsExist | expected | description
+        false         | null           | null            | true     | "no constraint"
+        true          | true           | null            | true     | "empty constraint"
+        true          | false          | true            | true     | "constraint with matching rows"
+        true          | false          | false           | false    | "constrained dimension has no matching rows"
+    }
+
+    def buildSimpleTestData(Dimension dimension = null, Set<String> values = ["a", "b"] as Set) {
+        SearchProvider searchProvider = Mock(SearchProvider)
+
+        DimensionField keyField = Mock(DimensionField)
+
+        if (dimension == null) {
+            dimension = Mock(Dimension) {
+                getApiName() >> "testDimension"
+                getKey() >> keyField
+                getSearchProvider() >> searchProvider
+            }
+        }
+
+        ApiFilter expectedApiFilter = new ApiFilter(dimension, dimension.getKey(), FilterOperation.in, values)
+        DimensionIdFilter dimensionIdFilter = new DimensionIdFilter([(dimension): values])
+
+        [dimension, searchProvider, expectedApiFilter, dimensionIdFilter]
+    }
+
+    def "apply returns true as long as no dimensions constrain and return no rows"() {
+        given: "A dimensionId filter with some filters"
+        Set<String> values = ["a", "b"] as Set
+        def (Dimension successDimension, SearchProvider hasRowsProvider, Object foo1, Object bar1) = buildSimpleTestData()
+        def (Dimension failureDimension, SearchProvider hasNoRowsProvider, Object foo2, Object bar2) = buildSimpleTestData()
+        def (Dimension nonFilterDimension, SearchProvider uncconfiguredSearch, Object foo3, Object bar3) = buildSimpleTestData()
+
+        hasRowsProvider.hasAnyRows(_) >> true
+        hasNoRowsProvider.hasAnyRows(_) >> false
+        DimensionIdFilter dimensionIdFilter = new DimensionIdFilter([(successDimension): values, (failureDimension): values])
+
+        and: "A constraint with some constraints"
+        DataSourceConstraint constraint = Mock(DataSourceConstraint)
+        Map<Dimension, ApiFilter> constraintMap = [:]
+        constraint.getApiFilters() >> constraintMap
+
+        if (constrainSuccess) {
+            addFilterOnDimension(successDimension, constraintMap)
+        }
+        if (constrainFailure) {
+            addFilterOnDimension(failureDimension, constraintMap)
+        }
+        if (constrainOther) {
+            addFilterOnDimension(nonFilterDimension, constraintMap)
+        }
+
+        expect: "True as long as the dimension that doesnt return rows is not constrained"
+        dimensionIdFilter.apply(constraint) == success
+
+        where:
+        constrainFailure | constrainSuccess | constrainOther | success
+        true             | true             | true           | false
+        true             | true             | false          | false
+        true             | false            | true           | false
+        true             | false            | false          | false
+        false            | true             | true           | true
+        false            | true             | false          | true
+        false            | false            | true           | true
+        false            | false            | false          | true
+    }
+
+    def addFilterOnDimension(Dimension dimension, Map<Dimension, Set<ApiFilter>> constraints, values = ["a"] as Set) {
+        ApiFilter apiFilter = new ApiFilter(dimension, dimension.key, FilterOperation.in, values)
+        constraints.put(dimension, [apiFilter] as Set)
+    }
+}

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/application/TestBinderFactory.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/application/TestBinderFactory.java
@@ -127,23 +127,30 @@ public class TestBinderFactory extends AbstractBinderFactory {
      */
     @Override
     protected VolatileIntervalsService getVolatileIntervalsService() {
+        PhysicalTableDictionary physicalTableDictionary = getConfigurationLoader().getPhysicalTableDictionary();
         Map<PhysicalTable, VolatileIntervalsFunction> hourlyMonthlyVolatileIntervals = new LinkedHashMap<>();
-        hourlyMonthlyVolatileIntervals.put(
-                getConfigurationLoader().getPhysicalTableDictionary().get(HOURLY.asName()),
-                () -> new SimplifiedIntervalList(
-                        Collections.singleton(
-                                new Interval(new DateTime(2016, 8, 15, 0, 0), new DateTime(2016, 8, 16, 0, 0))
-                        )
-                )
-        );
-        hourlyMonthlyVolatileIntervals.put(
-                getConfigurationLoader().getPhysicalTableDictionary().get(MONTHLY.asName()),
-                () -> new SimplifiedIntervalList(
-                        Collections.singleton(
-                                new Interval(new DateTime(2016, 8, 1, 0, 0), new DateTime(2016, 9, 1, 0, 0))
-                        )
-                )
-        );
+
+        if (physicalTableDictionary.containsKey(HOURLY.asName())) {
+            hourlyMonthlyVolatileIntervals.put(
+                    getConfigurationLoader().getPhysicalTableDictionary().get(HOURLY.asName()),
+                    () -> new SimplifiedIntervalList(
+                            Collections.singleton(
+                                    new Interval(new DateTime(2016, 8, 15, 0, 0), new DateTime(2016, 8, 16, 0, 0))
+                            )
+                    )
+            );
+        }
+        if (physicalTableDictionary.containsKey(MONTHLY.asName())) {
+            hourlyMonthlyVolatileIntervals.put(
+                    getConfigurationLoader().getPhysicalTableDictionary().get(MONTHLY.asName()),
+                    () -> new SimplifiedIntervalList(
+                            Collections.singleton(
+                                    new Interval(new DateTime(2016, 8, 1, 0, 0), new DateTime(2016, 9, 1, 0, 0))
+                            )
+                    )
+            );
+        }
+
         return new DefaultingVolatileIntervalsService(
                 NoVolatileIntervalsFunction.INSTANCE,
                 hourlyMonthlyVolatileIntervals

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
@@ -355,7 +355,7 @@ public class ClassScanner {
                             return arg;
                         }
                     } catch (InstantiationException e) {
-                        LOG.debug("Instantiation exception : {}", e);
+                        LOG.trace("Instantiation exception : {}", e);
                     }
                 }
             }


### PR DESCRIPTION
Added dimension value based partition feature.

Configuration of dimension value partitions is done by supplying a map of table names to maps of dimension names to maps of dimension values.
The entry for a given table name describes a set of filters, by dimension.  If each dimension successfully applies when combined with the restrictions on a table, then the partition is considered to pertain to the query.  A partition which pertains is used for restricting availability.