### PR TITLE
Constrained availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Current
 -------
 ### Added:
 
+- [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
+    * Add ConstrainedTable which closes over a physical table and an availability, caching all availability merges.
+    * Add PartialDataHandler method to use `ConstrainedTable`
+    * Add SimplifiedIntervalLit.empty() to produce empty SILs
+
 - [Prepare For Partial Data V2](https://github.com/yahoo/fili/pull/264)
     * Add new query context for druid's uncovered interval feature
     * Add a configurable property named "druid_uncovered_interval_limit"
@@ -105,10 +110,18 @@ Current
 
 ### Changed:
 
+- [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
+    * Switched `PartialDataRequestHandler` to use the table from the query rather than the `PhysicalTableDictionary`
+    * `DruidQueryBuilder` uses constrained tables to dynamically pick between Union and Table DataSource implementations.
+    * `PartialDataHandler` has multiple different entrypoints now depending on pre or post constraint conditions.
+    * `getAvailability` moved to a `ConfigTable` interface and all configured Tables to that interface
+    * DataSource implementations bind to `ConstrainedTable` and only ConstrainedTable is used after table selection
+    * `PhysicalTable.getAllAvailableIntervals` explicitly rather than implicitly uses `SimplifiedIntervalList`
+    * Bound and default versions of getAvailableIntervals and getAllAvailableIntervals added to PhysicalTable interface    
+    
 - [Druid filters are now lazy.](https://github.com/yahoo/fili/pull/269)
     - The Druid filter is built when requested, NOT at DatApiRequest construction. This will
         make it easier to write performant `DataApiRequest` mappers.
-
 
 - [Reduce log level of failure to store a result in the asynchronous job store](https://github.com/yahoo/fili/pull/266)
     * Customers who aren't using the asynchronous infrastructure shouldn't be seeing spurious warnings about a failure
@@ -273,6 +286,9 @@ Current
     * Converted to 404 when error was cause by not finding a path element
 
 ### Deprecated:
+
+- [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
+    * Deprecated static empty instance of SimplifiedIntervalList.NO_INTERVALS
 
 - [Support for Lucene 5 indexes](https://github.com/yahoo/fili/pull/265)
     * Added lucene-backward-codecs.jar as a dependency to restore support for indexes built on earlier instances.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Current
     * Add PartialDataHandler method to use `ConstrainedTable`
     * Add SimplifiedIntervalLit.empty() to produce empty SILs
 
+- [Moved UnionDataSource to support only single tables](https://github.com/yahoo/fili/pull/262/files)
+    * `DataSource` now supports getDataSource() operation
+
 - [Prepare For Partial Data V2](https://github.com/yahoo/fili/pull/264)
     * Add new query context for druid's uncovered interval feature
     * Add a configurable property named "druid_uncovered_interval_limit"
@@ -120,6 +123,11 @@ Current
     * Bound and default versions of getAvailableIntervals and getAllAvailableIntervals added to PhysicalTable interface
     * Package-private optimize tests in `DruidQueryBuilder` moved to protected
     * Immutable `NoVolatileIntervalsFunction` class made final
+    
+- [Moved UnionDataSource to support only single tables](https://github.com/yahoo/fili/pull/262/files)
+    * `UnionDataSource` now accepts only single tables instead of sets of tables.
+    * `DataSource` now supports getDataSource() operation
+    * `IntervalUtils.collectBucketedIntervalsNotInIntervalList` moved to `PartialDataHandler`
     
     
 - [Druid filters are now lazy.](https://github.com/yahoo/fili/pull/269)
@@ -290,6 +298,9 @@ Current
 
 ### Deprecated:
 
+- [Moved UnionDataSource to support only single tables](https://github.com/yahoo/fili/pull/262/files)
+    * `DataSource` deprecates getDataSources()
+
 - [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
     * Deprecated static empty instance of SimplifiedIntervalList.NO_INTERVALS
 
@@ -353,6 +364,9 @@ Current
 - [Refactor Physical Table Definition and Update Table Loader](https://github.com/yahoo/fili/pull/207)
     * Removed deprecated `PhysicalTableDefinition` constructor that takes an `ZonlessTimeGrain`, use `ZonedTimeGrain` instead
     * Removed `buildPhysicalTable` in `BaseTableLoader`, building table logic is pushed into `PhysicalTableDefinition`
+
+- [Moved UnionDataSource to support only single tables](https://github.com/yahoo/fili/pull/262/files)
+    * `DataSource` no longer accepts Set<Table> constructor
 
 - [CompositePhsyicalTable Core Components Refactor](https://github.com/yahoo/fili/pull/179)
     * Removed deprecated method `findMissingRequestTimeGrainIntervals` from `PartialDataHandler`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Current
     * Add PartialDataHandler method to use `ConstrainedTable`
     * Add SimplifiedIntervalLit.empty() to produce empty SILs
 
+- [Testing: ClassScannerSpec now supports 'discoverable' depenencies ](https://github.com/yahoo/fili/pull/262/files)
+    * Creating 'supplyDependencies' method on a class's spec allows definitions of dependencies for dynamic equality testing
+
 - [Moved UnionDataSource to support only single tables](https://github.com/yahoo/fili/pull/262/files)
     * `DataSource` now supports getDataSource() operation
 
@@ -298,11 +301,12 @@ Current
 
 ### Deprecated:
 
-- [Moved UnionDataSource to support only single tables](https://github.com/yahoo/fili/pull/262/files)
-    * `DataSource` deprecates getDataSources()
-
 - [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
     * Deprecated static empty instance of SimplifiedIntervalList.NO_INTERVALS
+    * PartialDataRequestHandler constructor using `PhysicalTableDictionary`
+
+- [Moved UnionDataSource to support only single tables](https://github.com/yahoo/fili/pull/262/files)
+    * `DataSource` deprecates getDataSources()
 
 - [Support for Lucene 5 indexes](https://github.com/yahoo/fili/pull/265)
     * Added lucene-backward-codecs.jar as a dependency to restore support for indexes built on earlier instances.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Current
 - [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
     * Add ConstrainedTable which closes over a physical table and an availability, caching all availability merges.
     * Add PartialDataHandler method to use `ConstrainedTable`
-    * Add SimplifiedIntervalLit.empty() to produce empty SILs
 
 - [Testing: ClassScannerSpec now supports 'discoverable' depenencies ](https://github.com/yahoo/fili/pull/262/files)
     * Creating 'supplyDependencies' method on a class's spec allows definitions of dependencies for dynamic equality testing
@@ -307,6 +306,9 @@ Current
 
 - [Moved UnionDataSource to support only single tables](https://github.com/yahoo/fili/pull/262/files)
     * `DataSource` deprecates getDataSources()
+
+- [SimplifiedIntervalList::NO_INTERVALS](https://github.com/yahoo/fili/pull/262/files)
+    * This is unsafe since it is modifiable
 
 - [Support for Lucene 5 indexes](https://github.com/yahoo/fili/pull/265)
     * Added lucene-backward-codecs.jar as a dependency to restore support for indexes built on earlier instances.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,12 +112,15 @@ Current
 
 - [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
     * Switched `PartialDataRequestHandler` to use the table from the query rather than the `PhysicalTableDictionary`
-    * `DruidQueryBuilder` uses constrained tables to dynamically pick between Union and Table DataSource implementations.
-    * `PartialDataHandler` has multiple different entrypoints now depending on pre or post constraint conditions.
+    * `DruidQueryBuilder` uses constrained tables to dynamically pick between Union and Table DataSource implementations
+    * `PartialDataHandler` has multiple different entrypoints now depending on pre or post constraint conditions
     * `getAvailability` moved to a `ConfigTable` interface and all configured Tables to that interface
     * DataSource implementations bind to `ConstrainedTable` and only ConstrainedTable is used after table selection
     * `PhysicalTable.getAllAvailableIntervals` explicitly rather than implicitly uses `SimplifiedIntervalList`
-    * Bound and default versions of getAvailableIntervals and getAllAvailableIntervals added to PhysicalTable interface    
+    * Bound and default versions of getAvailableIntervals and getAllAvailableIntervals added to PhysicalTable interface
+    * Package-private optimize tests in `DruidQueryBuilder` moved to protected
+    * Immutable `NoVolatileIntervalsFunction` class made final
+    
     
 - [Druid filters are now lazy.](https://github.com/yahoo/fili/pull/269)
     - The Druid filter is built when requested, NOT at DatApiRequest construction. This will

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/DruidDimensionsLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/DruidDimensionsLoader.java
@@ -17,8 +17,9 @@ import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.DruidSearchQuery;
 import com.yahoo.bard.webservice.druid.model.query.RegexSearchQuerySpec;
 import com.yahoo.bard.webservice.druid.model.query.SearchQuerySpec;
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
+import com.yahoo.bard.webservice.table.availability.ConcreteAvailability;
+import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
 import com.yahoo.bard.webservice.web.handlers.RequestContext;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -133,8 +134,8 @@ public class DruidDimensionsLoader extends Loader<Boolean> {
                 .collect(Collectors.toList());
 
         this.dataSources = physicalTableDictionary.values().stream()
-                .filter(physicalTable -> physicalTable instanceof ConcretePhysicalTable)
-                .map(physicalTable -> (ConcretePhysicalTable) physicalTable)
+                .filter(physicalTable -> physicalTable.getAvailability() instanceof ConcreteAvailability)
+                .map(table -> table.withConstraint(DataSourceConstraint.emptyConstraint(table)))
                 .map(TableDataSource::new)
                 .collect(Collectors.toList());
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/DruidDimensionsLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/DruidDimensionsLoader.java
@@ -135,7 +135,7 @@ public class DruidDimensionsLoader extends Loader<Boolean> {
 
         this.dataSources = physicalTableDictionary.values().stream()
                 .filter(physicalTable -> physicalTable.getAvailability() instanceof ConcreteAvailability)
-                .map(table -> table.withConstraint(DataSourceConstraint.emptyConstraint(table)))
+                .map(table -> table.withConstraint(DataSourceConstraint.unconstrained(table)))
                 .map(TableDataSource::new)
                 .collect(Collectors.toList());
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
@@ -311,9 +311,9 @@ public class DruidQueryBuilder {
         );
 
         // Override the grain with what's set in the template if it has one set
-        if (template.getTimeGrain() != null) {
-            granularity = template.getTimeGrain().buildZonedTimeGrain(timeZone);
-        }
+        Granularity mergeGrain = (template.getTimeGrain() != null) ?
+                template.getTimeGrain().buildZonedTimeGrain(timeZone) :
+                granularity;
 
         LOG.trace("Building a single pass druid topN query");
 
@@ -321,7 +321,7 @@ public class DruidQueryBuilder {
         return new TopNQuery(
                 buildTableDataSource(table),
                 // The check that the set of dimensions has exactly one element is currently done above
-                granularity,
+                mergeGrain,
                 groupByDimension.iterator().next(),
                 filter,
                 template.getAggregations(),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
@@ -32,8 +32,6 @@ import com.yahoo.bard.webservice.table.resolver.PhysicalTableResolver;
 import com.yahoo.bard.webservice.table.resolver.QueryPlanningConstraint;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 
-import com.google.common.collect.Sets;
-
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.slf4j.Logger;
@@ -119,10 +117,7 @@ public class DruidQueryBuilder {
 
         // Resolve the table from the the group, the combined dimensions in request, and template time grain
         QueryPlanningConstraint constraint = new QueryPlanningConstraint(request, template);
-        ConstrainedTable table = resolver.resolve(
-                group.getPhysicalTables(),
-                constraint
-        ).withConstraint(constraint);
+        ConstrainedTable table = resolver.resolve(group.getPhysicalTables(), constraint).withConstraint(constraint);
 
         return druidTopNMetric != null ?
             buildTopNQuery(
@@ -205,8 +200,8 @@ public class DruidQueryBuilder {
         Filter mergedFilter = filter;
 
         // Override the grain with what's set in the template if it has one set
-        Granularity mergedGranularity = template.getTimeGrain() != null ?
-                template.getTimeGrain().buildZonedTimeGrain(timeZone)
+        Granularity mergedGranularity = template.getTimeGrain() != null
+                ? template.getTimeGrain().buildZonedTimeGrain(timeZone)
                 : granularity;
 
         DataSource dataSource;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
@@ -253,7 +253,7 @@ public class DruidQueryBuilder {
         if (table.getDataSourceNames().size() == 1) {
             return new TableDataSource(table, table.getDataSourceNames().stream().findFirst().get());
         } else {
-            return new UnionDataSource(Sets.newHashSet(table));
+            return new UnionDataSource(table);
         }
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
@@ -251,7 +251,7 @@ public class DruidQueryBuilder {
      */
     private DataSource buildTableDataSource(ConstrainedTable table) {
         if (table.getDataSourceNames().size() == 1) {
-            return new TableDataSource(table, table.getDataSourceNames().stream().findFirst().get());
+            return new TableDataSource(table);
         } else {
             return new UnionDataSource(table);
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/PartialDataHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/PartialDataHandler.java
@@ -44,7 +44,7 @@ public class PartialDataHandler {
     ) {
         SimplifiedIntervalList availableIntervals = physicalTables.stream()
                 .map(table -> table.withConstraint(constraint))
-                .map(table -> table.getAvailableIntervals())
+                .map(PhysicalTable::getAvailableIntervals)
                 .reduce(SimplifiedIntervalList::intersect)
                 .orElse(new SimplifiedIntervalList());
 
@@ -68,7 +68,7 @@ public class PartialDataHandler {
     ) {
 
         SimplifiedIntervalList availableIntervals = physicalTables.stream()
-                .map(table -> table.getAvailableIntervals())
+                .map(PhysicalTable::getAvailableIntervals)
                 .reduce(SimplifiedIntervalList::intersect)
                 .orElse(new SimplifiedIntervalList());
         return findMissingTimeGrainIntervals(availableIntervals, requestedIntervals, granularity);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/PartialDataHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/PartialDataHandler.java
@@ -34,7 +34,7 @@ public class PartialDataHandler {
      * <p>
      * Any requested subinterval bucket that is partially unavailable is collected and returned in a simplified form.
      *
-     * @param availableIntervals  the intervals available in the tables
+     * @param availableIntervals  The intervals available in the tables
      * @param requestedIntervals  The intervals that may not be fully satisfied
      * @param granularity  The granularity at which to find missing intervals
      *
@@ -51,9 +51,11 @@ public class PartialDataHandler {
                 granularity
         );
 
+        // The missing intervals is the request intervals if any of the requested intervals are missing for ALL grain
         if (granularity instanceof AllGranularity && !missingIntervals.isEmpty()) {
             missingIntervals = requestedIntervals;
         }
+
         LOG.debug("Missing intervals: {} for grain {}", missingIntervals, granularity);
         return missingIntervals;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
@@ -11,6 +11,7 @@ import com.yahoo.bard.webservice.data.dimension.DimensionColumn;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.LogicalTable;
 import com.yahoo.bard.webservice.table.LogicalTableDictionary;
 import com.yahoo.bard.webservice.table.PhysicalTable;
@@ -183,7 +184,7 @@ public abstract class BaseTableLoader implements TableLoader {
      *
      * @return the current physical table built from table definitions
      */
-    protected PhysicalTable buildPhysicalTableWithDependency(
+    protected ConfigPhysicalTable buildPhysicalTableWithDependency(
             String currentTableName,
             Map<String, PhysicalTableDefinition> availableTableDefinitions,
             ResourceDictionaries dictionaries

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
@@ -9,7 +9,7 @@ import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.ConcretePhysicalTable;
-import com.yahoo.bard.webservice.table.PhysicalTable;
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 
 import java.util.Collections;
 import java.util.Map;
@@ -62,7 +62,7 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
     }
 
     @Override
-    public PhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
+    public ConfigPhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
         return new ConcretePhysicalTable(
                         getName(),
                         getTimeGrain(),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinition.java
@@ -10,8 +10,8 @@ import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.PartitionCompositeTable;
-import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.resolver.DataSourceFilter;
 import com.yahoo.bard.webservice.table.resolver.DimensionIdFilter;
 
@@ -54,8 +54,8 @@ public class DimensionListPartitionTableDefinition extends PhysicalTableDefiniti
     }
 
     @Override
-    public PhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
-        Map<PhysicalTable, DataSourceFilter> availabilityFilters = tablePartDefinitions.entrySet().stream()
+    public ConfigPhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
+        Map<ConfigPhysicalTable, DataSourceFilter> availabilityFilters = tablePartDefinitions.entrySet().stream()
                 .collect(Collectors.toMap(
                         entry -> dictionaries.getPhysicalDictionary().get(entry.getKey().asName()),
                         entry -> new DimensionIdFilter(toDimensionValuesMap(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
@@ -8,8 +8,8 @@ import com.yahoo.bard.webservice.data.config.names.FieldName;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.MetricUnionCompositeTable;
-import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
 
 import org.slf4j.Logger;
@@ -78,7 +78,7 @@ public class MetricUnionCompositeTableDefinition extends PhysicalTableDefinition
     }
 
     @Override
-    public PhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
+    public ConfigPhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
         return new MetricUnionCompositeTable(
                 getName(),
                 getTimeGrain(),
@@ -95,7 +95,7 @@ public class MetricUnionCompositeTableDefinition extends PhysicalTableDefinition
      *
      * @return set of PhysicalTables from the ResourceDictionaries
      */
-    private Set<PhysicalTable> getPhysicalTables(ResourceDictionaries resourceDictionaries) {
+    private Set<ConfigPhysicalTable> getPhysicalTables(ResourceDictionaries resourceDictionaries) {
         PhysicalTableDictionary physicalTableDictionary = resourceDictionaries.getPhysicalDictionary();
         return dependentTableNames.stream()
                 .map(TableName::asName)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PermissiveConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PermissiveConcretePhysicalTableDefinition.java
@@ -8,8 +8,8 @@ import com.yahoo.bard.webservice.data.config.names.FieldName;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.PermissiveConcretePhysicalTable;
-import com.yahoo.bard.webservice.table.PhysicalTable;
 
 import java.util.Map;
 import java.util.Set;
@@ -58,7 +58,7 @@ public class PermissiveConcretePhysicalTableDefinition extends ConcretePhysicalT
 
 
     @Override
-    public PhysicalTable build(
+    public ConfigPhysicalTable build(
             ResourceDictionaries dictionaries,
             DataSourceMetadataService metadataService
     ) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
@@ -12,7 +12,7 @@ import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.Column;
-import com.yahoo.bard.webservice.table.PhysicalTable;
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -98,7 +98,7 @@ public abstract class PhysicalTableDefinition {
      *
      * @return the type of physical table which was built.
      */
-    public abstract PhysicalTable build(
+    public abstract ConfigPhysicalTable build(
             ResourceDictionaries dictionaries,
             DataSourceMetadataService metadataService
     );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunction.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunction.java
@@ -26,6 +26,6 @@ public final class NoVolatileIntervalsFunction implements VolatileIntervalsFunct
 
     @Override
     public SimplifiedIntervalList getVolatileIntervals() {
-        return SimplifiedIntervalList.empty();
+        return new SimplifiedIntervalList();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunction.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunction.java
@@ -11,7 +11,7 @@ import javax.inject.Singleton;
  * This is the noop implementation of volatility. It should be access via the static instance.
  */
 @Singleton
-public class NoVolatileIntervalsFunction implements VolatileIntervalsFunction {
+public final class NoVolatileIntervalsFunction implements VolatileIntervalsFunction {
 
     /**
      * Create a singleton instance of NoVolatileIntervalsFunction.
@@ -22,7 +22,6 @@ public class NoVolatileIntervalsFunction implements VolatileIntervalsFunction {
      * Make NoVolatileIntervalsFunction a singleton by making the constructor private.
      */
     private NoVolatileIntervalsFunction() {
-        ;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunction.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunction.java
@@ -27,6 +27,6 @@ public class NoVolatileIntervalsFunction implements VolatileIntervalsFunction {
 
     @Override
     public SimplifiedIntervalList getVolatileIntervals() {
-        return SimplifiedIntervalList.NO_INTERVALS;
+        return SimplifiedIntervalList.empty();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -5,7 +5,6 @@ package com.yahoo.bard.webservice.druid.model.datasource;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 import com.yahoo.bard.webservice.table.ConstrainedTable;
-import com.yahoo.bard.webservice.table.PhysicalTable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -49,7 +48,7 @@ public abstract class DataSource {
     @JsonIgnore
     @Deprecated
     public Set<ConstrainedTable> getPhysicalTables() {
-        return Collections.singleton(physicalTable);
+        return Collections.singleton(getPhysicalTable());
     }
 
     /**
@@ -69,10 +68,7 @@ public abstract class DataSource {
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Set<String> getNames() {
-        return Collections.unmodifiableSet((LinkedHashSet) getPhysicalTables()
-                .stream()
-                .map(PhysicalTable::getDataSourceNames)
-                .flatMap(Set::stream)
+        return Collections.unmodifiableSet((LinkedHashSet<String>) getPhysicalTable().getDataSourceNames().stream()
                 .map(TableName::asName)
                 .collect(Collectors.toCollection(LinkedHashSet::new))
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -18,18 +19,19 @@ import java.util.stream.Collectors;
  * DataSource base class.
  */
 public abstract class DataSource {
+
     private final DataSourceType type;
-    private final Set<ConstrainedTable> physicalTables;
+    private final ConstrainedTable physicalTable;
 
     /**
      * Constructor.
      *
      * @param type  Type of the data source
-     * @param physicalTables  PhysicalTables pointed to by the DataSource
+     * @param physicalTable  PhysicalTables pointed to by the DataSource
      */
-    public DataSource(DataSourceType type, Set<ConstrainedTable> physicalTables) {
+    public DataSource(DataSourceType type, ConstrainedTable physicalTable) {
         this.type = type;
-        this.physicalTables = Collections.unmodifiableSet(physicalTables);
+        this.physicalTable = physicalTable;
     }
 
     public DataSourceType getType() {
@@ -42,8 +44,19 @@ public abstract class DataSource {
      * @return the set of physical tables for the data source
      */
     @JsonIgnore
+    @Deprecated
     public Set<ConstrainedTable> getPhysicalTables() {
-        return physicalTables;
+        return Collections.singleton(physicalTable);
+    }
+
+    /**
+     * Get the data source physical table.
+     *
+     * @return the set of physical tables for the data source
+     */
+    @JsonIgnore
+    public ConstrainedTable getPhysicalTable() {
+        return physicalTable;
     }
 
     /**
@@ -53,12 +66,12 @@ public abstract class DataSource {
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Set<String> getNames() {
-        return Collections.unmodifiableSet(getPhysicalTables()
+        return Collections.unmodifiableSet((LinkedHashSet) getPhysicalTables()
                 .stream()
                 .map(PhysicalTable::getDataSourceNames)
                 .flatMap(Set::stream)
                 .map(TableName::asName)
-                .collect(Collectors.toSet())
+                .collect(Collectors.toCollection(LinkedHashSet::new))
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.druid.model.datasource;
 
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
+import com.yahoo.bard.webservice.table.ConstrainedTable;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -11,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.Collections;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  */
 public abstract class DataSource {
     private final DataSourceType type;
-    private final Set<PhysicalTable> physicalTables;
+    private final Set<ConstrainedTable> physicalTables;
 
     /**
      * Constructor.
@@ -27,7 +27,7 @@ public abstract class DataSource {
      * @param type  Type of the data source
      * @param physicalTables  PhysicalTables pointed to by the DataSource
      */
-    public DataSource(DataSourceType type, Set<PhysicalTable> physicalTables) {
+    public DataSource(DataSourceType type, Set<ConstrainedTable> physicalTables) {
         this.type = type;
         this.physicalTables = Collections.unmodifiableSet(physicalTables);
     }
@@ -42,7 +42,7 @@ public abstract class DataSource {
      * @return the set of physical tables for the data source
      */
     @JsonIgnore
-    public Set<PhysicalTable> getPhysicalTables() {
+    public Set<ConstrainedTable> getPhysicalTables() {
         return physicalTables;
     }
 
@@ -55,9 +55,8 @@ public abstract class DataSource {
     public Set<String> getNames() {
         return Collections.unmodifiableSet(getPhysicalTables()
                 .stream()
-                .map(PhysicalTable::getAvailability)
-                .map(it -> it.getDataSourceNames().stream())
-                .flatMap(Function.identity())
+                .map(PhysicalTable::getDataSourceNames)
+                .flatMap(Set::stream)
                 .map(TableName::asName)
                 .collect(Collectors.toSet())
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -82,5 +82,7 @@ public abstract class DataSource {
      * @return the query that this data source is generated from
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public abstract DruidQuery<?> getQuery();
+    public DruidQuery<?> getQuery() {
+        return null;
+    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -42,6 +42,9 @@ public abstract class DataSource {
      * Get the data source physical table(s) as a collection.
      *
      * @return the set of physical tables for the data source
+     *
+     * @deprecated DataSources can only have a single table, and any unioning semantics is done at the PhysicalTable
+     * level
      */
     @JsonIgnore
     @Deprecated

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/QueryDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/QueryDataSource.java
@@ -21,7 +21,7 @@ public class QueryDataSource extends DataSource {
      * @param query  Query that defines the DataSource.
      */
     public QueryDataSource(DruidFactQuery<?> query) {
-        super(DefaultDataSourceType.QUERY, query.getDataSource().getPhysicalTables());
+        super(DefaultDataSourceType.QUERY, query.getDataSource().getPhysicalTable());
 
         this.query = query;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
@@ -42,7 +42,9 @@ public class TableDataSource extends DataSource {
                         .stream()
                         .findFirst()
                         .orElseThrow(() -> new IllegalArgumentException(
-                                "Non singleton DataSource table passed to TableDataSource constructor."))
+                                "Non singleton DataSource table passed to TableDataSource constructor."
+                                )
+                        )
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
@@ -8,7 +8,6 @@ import com.yahoo.bard.webservice.table.ConstrainedTable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -25,7 +24,7 @@ public class TableDataSource extends DataSource {
      * @param tableName  The name of the table's single datasource
      */
     public TableDataSource(ConstrainedTable physicalTable, TableName tableName) {
-        super(DefaultDataSourceType.TABLE, Collections.singleton(physicalTable));
+        super(DefaultDataSourceType.TABLE, physicalTable);
 
         this.name = tableName.asName();
     }
@@ -36,16 +35,7 @@ public class TableDataSource extends DataSource {
      * @param physicalTable  The physical table of the data source
      */
     public TableDataSource(ConstrainedTable physicalTable) {
-        this(
-                physicalTable,
-                physicalTable.getDataSourceNames()
-                        .stream()
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalArgumentException(
-                                "Non singleton DataSource table passed to TableDataSource constructor."
-                                )
-                        )
-        );
+        this(physicalTable, physicalTable.getTableName());
     }
 
     public String getName() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
@@ -2,8 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.datasource;
 
-import com.yahoo.bard.webservice.data.config.names.TableName;
-import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 import com.yahoo.bard.webservice.table.ConstrainedTable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -15,42 +13,22 @@ import java.util.Set;
  */
 public class TableDataSource extends DataSource {
 
-    private final String name;
-
-    /**
-     * Constructor.
-     *
-     * @param physicalTable  The physical table of the data source
-     * @param tableName  The name of the table's single datasource
-     */
-    public TableDataSource(ConstrainedTable physicalTable, TableName tableName) {
-        super(DefaultDataSourceType.TABLE, physicalTable);
-
-        this.name = tableName.asName();
-    }
-
     /**
      * Constructor.
      *
      * @param physicalTable  The physical table of the data source
      */
     public TableDataSource(ConstrainedTable physicalTable) {
-        this(physicalTable, physicalTable.getTableName());
+        super(DefaultDataSourceType.TABLE, physicalTable);
     }
 
     public String getName() {
-        return name;
+        return getPhysicalTable().getTableName().asName();
     }
 
     @Override
     @JsonIgnore
     public Set<String> getNames() {
         return super.getNames();
-    }
-
-    @Override
-    @JsonIgnore
-    public DruidQuery<?> getQuery() {
-        return null;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
@@ -2,8 +2,9 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.datasource;
 
+import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable;
+import com.yahoo.bard.webservice.table.ConstrainedTable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -21,11 +22,28 @@ public class TableDataSource extends DataSource {
      * Constructor.
      *
      * @param physicalTable  The physical table of the data source
+     * @param tableName  The name of the table's single datasource
      */
-    public TableDataSource(ConcretePhysicalTable physicalTable) {
+    public TableDataSource(ConstrainedTable physicalTable, TableName tableName) {
         super(DefaultDataSourceType.TABLE, Collections.singleton(physicalTable));
 
-        this.name = physicalTable.getFactTableName();
+        this.name = tableName.asName();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param physicalTable  The physical table of the data source
+     */
+    public TableDataSource(ConstrainedTable physicalTable) {
+        this(
+                physicalTable,
+                physicalTable.getDataSourceNames()
+                        .stream()
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                "Non singleton DataSource table passed to TableDataSource constructor."))
+        );
     }
 
     public String getName() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSource.java
@@ -4,7 +4,7 @@ package com.yahoo.bard.webservice.druid.model.datasource;
 
 import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
-import com.yahoo.bard.webservice.table.PhysicalTable;
+import com.yahoo.bard.webservice.table.ConstrainedTable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,7 +27,7 @@ public class UnionDataSource extends DataSource {
      *
      * @param physicalTables  The physical tables of the data source
      */
-    public UnionDataSource(Set<PhysicalTable> physicalTables) {
+    public UnionDataSource(Set<ConstrainedTable> physicalTables) {
         super(DefaultDataSourceType.UNION, physicalTables);
         // Check whether or not our union'd tables' dimensions match
         physicalTables.forEach(table ->

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSource.java
@@ -2,9 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.datasource;
 
-import static com.yahoo.bard.webservice.web.ErrorMessageFormat.INVALID_DATASOURCE_UNION;
-
-import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 import com.yahoo.bard.webservice.table.ConstrainedTable;
 
@@ -15,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Represents a Druid Union data source.
@@ -27,33 +23,10 @@ public class UnionDataSource extends DataSource {
     /**
      * Constructor.
      *
-     * @param physicalTables  The physical tables of the data source
+     * @param physicalTable  The physical table of the data source
      */
-    public UnionDataSource(Set<ConstrainedTable> physicalTables) {
-        super(DefaultDataSourceType.UNION, physicalTables);
-        // Check whether or not our union'd tables' dimensions match
-        physicalTables.forEach(table ->
-                // For each table, cycle through its dimensions and extract its physical name (i.e. expected)
-                table.getDimensions().forEach(dimension -> {
-                    String apiName = dimension.getApiName();
-                    String expectedName = table.getPhysicalColumnName(apiName);
-                    // For every other table, cycle through their dimensions and compare their names to expected
-                    physicalTables.forEach(altTable -> {
-                        Set<String> otherNames = altTable.getDimensions().stream()
-                                .map(Dimension::getApiName)
-                                .collect(Collectors.toSet());
-                        String actualName = altTable.getPhysicalColumnName(apiName);
-                        // If this other table contains the apiName, ensure that the physical name mapping is identical
-                        if (otherNames.contains(apiName)
-                                && !expectedName.equals(actualName)) {
-                            LOG.error(INVALID_DATASOURCE_UNION.logFormat(apiName, expectedName, actualName));
-                            throw new IllegalStateException(
-                                    INVALID_DATASOURCE_UNION.format(apiName, expectedName, actualName)
-                            );
-                        }
-                    });
-                })
-        );
+    public UnionDataSource(ConstrainedTable physicalTable) {
+        super(DefaultDataSourceType.UNION, physicalTable);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSource.java
@@ -2,14 +2,9 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.datasource;
 
-import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 import com.yahoo.bard.webservice.table.ConstrainedTable;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 
@@ -17,8 +12,6 @@ import java.util.Set;
  * Represents a Druid Union data source.
  */
 public class UnionDataSource extends DataSource {
-
-    private static final Logger LOG = LoggerFactory.getLogger(UnionDataSource.class);
 
     /**
      * Constructor.
@@ -33,11 +26,5 @@ public class UnionDataSource extends DataSource {
     @JsonProperty(value = "dataSources")
     public Set<String> getNames() {
         return super.getNames();
-    }
-
-    @Override
-    @JsonIgnore
-    public DruidQuery<?> getQuery() {
-        return null;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSource.java
@@ -2,6 +2,8 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.datasource;
 
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.INVALID_DATASOURCE_UNION;
+
 import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 import com.yahoo.bard.webservice.table.ConstrainedTable;
@@ -44,11 +46,10 @@ public class UnionDataSource extends DataSource {
                         // If this other table contains the apiName, ensure that the physical name mapping is identical
                         if (otherNames.contains(apiName)
                                 && !expectedName.equals(actualName)) {
-                            LOG.error("Union data source had conflicting name mappings for logical dimension " +
-                                    "'{}' with mappings of '{}' and '{}'", apiName, expectedName, actualName);
-                            throw new RuntimeException("Union Data Source had conflicting name mappings for logical "
-                                    + "dimension '" + apiName + "' with mappings of '" + expectedName + "' and "
-                                    + "'" + actualName + "'");
+                            LOG.error(INVALID_DATASOURCE_UNION.logFormat(apiName, expectedName, actualName));
+                            throw new IllegalStateException(
+                                    INVALID_DATASOURCE_UNION.format(apiName, expectedName, actualName)
+                            );
                         }
                     });
                 })

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuery.java
@@ -211,7 +211,7 @@ public class WeightEvaluationQuery extends GroupByQuery {
             case TOP_N:
                 TopNQuery topNQuery = (TopNQuery) innerQuery;
                 GroupByQuery transformed = new GroupByQuery(
-                        new UnionDataSource(topNQuery.getDataSource().getPhysicalTables()),
+                        new UnionDataSource(topNQuery.getDataSource().getPhysicalTable()),
                         topNQuery.getGranularity(),
                         topNQuery.getDimensions(),
                         topNQuery.getFilter(),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/serializers/SerializerUtil.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/serializers/SerializerUtil.java
@@ -29,11 +29,7 @@ public class SerializerUtil {
         // Search for physical name
         return mapNearestDruidQuery(
                 gen,
-                druidQuery -> druidQuery.getDataSource()
-                        .getPhysicalTables()
-                        .iterator()
-                        .next()
-                        .getPhysicalColumnName(apiName)
+                druidQuery -> druidQuery.getDataSource().getPhysicalTable().getPhysicalColumnName(apiName)
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
@@ -38,7 +38,7 @@ public abstract class BaseCompositePhysicalTable extends BasePhysicalTable {
             @NotNull TableName name,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,
-            @NotNull Set<PhysicalTable> physicalTables,
+            @NotNull Set<ConfigPhysicalTable> physicalTables,
             @NotNull Map<String, String> logicalToPhysicalColumnNames,
             @NotNull Availability availability
     ) {
@@ -63,7 +63,7 @@ public abstract class BaseCompositePhysicalTable extends BasePhysicalTable {
      */
     private void verifyGrainSatisfiesAllSourceTables(
             ZonedTimeGrain timeGrain,
-            Set<PhysicalTable> physicalTables
+            Set<? extends PhysicalTable> physicalTables
     ) throws IllegalArgumentException {
         Predicate<PhysicalTable> tableDoesNotSatisfyFilter = (physicalTable) -> ! physicalTable.getSchema()
                 .getTimeGrain()

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
@@ -38,7 +38,7 @@ public abstract class BaseCompositePhysicalTable extends BasePhysicalTable {
             @NotNull TableName name,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,
-            @NotNull Set<ConfigPhysicalTable> physicalTables,
+            @NotNull Set<? extends PhysicalTable> physicalTables,
             @NotNull Map<String, String> logicalToPhysicalColumnNames,
             @NotNull Availability availability
     ) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -81,7 +81,7 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
 
     @Override
     public Map<Column, SimplifiedIntervalList> getAllAvailableIntervals() {
-        return PhysicalTable.mapToSchemaAvailability(
+        return mapToSchemaAvailability(
                 getAvailability().getAllAvailableIntervals(),
                 getSchema()
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -142,13 +142,6 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
      *
      * @throws IllegalArgumentException If there are columns referenced by the constraint unavailable in the table
      */
-    /**
-     * Ensure that the schema of the constraint is consistent with what the table supports.
-     *
-     * @param constraint  The constraint being tested
-     *
-     * @throws IllegalArgumentException If there are columns referenced by the constraint unavailable in the table
-     */
     private void validateConstraintSchema(DataSourceConstraint constraint) throws IllegalArgumentException {
         Set<String> tableColumnNames = getSchema().getColumnNames();
         // Validate that the requested columns are answerable by the current table

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -81,8 +81,9 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
 
     @Override
     public Map<Column, SimplifiedIntervalList> getAllAvailableIntervals() {
-        return PhysicalTable.getAllAvailableIntervals(
-                getAvailability().getAllAvailableIntervals(), getSchema()
+        return PhysicalTable.mapToSchemaAvailability(
+                getAvailability().getAllAvailableIntervals(),
+                getSchema()
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -95,7 +95,7 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
 
     @Override
     public String getPhysicalColumnName(String logicalName) {
-        if (!schema.containsLogicalName(logicalName)) {
+        if (!getSchema().containsLogicalName(logicalName)) {
             LOG.warn(
                     "No mapping found for logical name '{}' to physical name on table '{}'. Will use logical name as " +
                             "physical name. This is unexpected and should not happen for properly configured " +
@@ -104,7 +104,7 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
                     getName()
             );
         }
-        return schema.getPhysicalColumnName(logicalName);
+        return getSchema().getPhysicalColumnName(logicalName);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -126,6 +126,7 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
      *
      * @return a constrained table whose availability and serialization are narrowed by this constraint
      */
+    @Override
     public ConstrainedTable withConstraint(DataSourceConstraint constraint) {
         validateConstraintSchema(constraint);
         return new ConstrainedTable(this, new PhysicalDataSourceConstraint(constraint, getSchema()));

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -27,7 +27,7 @@ import javax.validation.constraints.NotNull;
 /**
  * Base implementation of physical table that are shared across various types of physical tables.
  */
-public abstract class BasePhysicalTable implements PhysicalTable {
+public abstract class BasePhysicalTable implements ConfigPhysicalTable {
     private static final Logger LOG = LoggerFactory.getLogger(BasePhysicalTable.class);
 
     private final TableName name;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseSchema.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseSchema.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table;
 
+import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
 
 import com.google.common.collect.Sets;
@@ -41,6 +42,17 @@ public class BaseSchema implements Schema {
      */
     public LinkedHashSet<String> getColumnNames() {
         return getColumns().stream()
+                .map(Column::getName)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /**
+     * Get the names of the columns returned by getColumns method which are metric columns.
+     *
+     * @return linked hash set of column names in this schema
+     */
+    public LinkedHashSet<String> getMetricColumnNames() {
+        return getColumns(MetricColumn.class).stream()
                 .map(Column::getName)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConfigPhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConfigPhysicalTable.java
@@ -1,0 +1,19 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table;
+
+import com.yahoo.bard.webservice.table.availability.Availability;
+
+/**
+ * Availability is used only exposed configuration lifecycle of physical tables.
+ * This subinterface limits the exposure of availability information.
+ */
+public interface ConfigPhysicalTable extends PhysicalTable  {
+
+    /**
+     * Get the value of the actual availability for this physical table.
+     *
+     * @return The current actual physical availability or a runtime exception if there isn't one yet.
+     */
+    Availability getAvailability();
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConfigPhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConfigPhysicalTable.java
@@ -5,8 +5,7 @@ package com.yahoo.bard.webservice.table;
 import com.yahoo.bard.webservice.table.availability.Availability;
 
 /**
- * Availability is used only exposed configuration lifecycle of physical tables.
- * This subinterface limits the exposure of availability information.
+ * This interface limits direct access to availability to tables intended for use during the configuration lifecycle.
  */
 public interface ConfigPhysicalTable extends PhysicalTable  {
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
@@ -48,7 +48,7 @@ public class ConstrainedTable implements PhysicalTable {
         );
 
         allAvailableIntervals = Collections.unmodifiableMap(
-                PhysicalTable.mapToSchemaAvailability(
+                mapToSchemaAvailability(
                         sourceAvailability.getAllAvailableIntervals(),
                         getSchema()
                 )

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
@@ -1,0 +1,119 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table;
+
+import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.table.availability.Availability;
+import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
+import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
+
+import org.joda.time.DateTime;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Constrained table caches the results of applying a {@link DataSourceConstraint} to a Physical table's availability.
+ * Since a constraint is already applied, methods that accept a constraint should be considered deprecated.
+ */
+public class ConstrainedTable implements PhysicalTable {
+
+    private final DataSourceConstraint constraint;
+    private final PhysicalTable sourceTable;
+    private final Set<TableName> dataSourceNames;
+    private final SimplifiedIntervalList availableIntervals;
+    private final Map<Column, SimplifiedIntervalList> allAvailableIntervals;
+
+    /**
+     * Constructor.
+     *
+     * @param table  The table being constrained
+     * @param constraint  The constraint being applied
+     */
+    public ConstrainedTable(ConfigPhysicalTable table, DataSourceConstraint constraint) {
+        this.constraint = constraint;
+        sourceTable = table;
+
+        Availability sourceAvailability = table.getAvailability();
+
+        PhysicalDataSourceConstraint physicalDataSourceConstraint = new PhysicalDataSourceConstraint(
+                constraint,
+                table.getSchema()
+        );
+
+        availableIntervals = sourceAvailability.getAvailableIntervals(physicalDataSourceConstraint);
+
+        allAvailableIntervals = PhysicalTable.getAllAvailableIntervals(
+                sourceAvailability.getAllAvailableIntervals(), getSchema()
+        );
+        dataSourceNames = sourceAvailability.getDataSourceNames(physicalDataSourceConstraint);
+    }
+
+    @Override
+    public SimplifiedIntervalList getAvailableIntervals() {
+        return availableIntervals;
+    }
+
+    @Override
+    public Map<Column, SimplifiedIntervalList> getAllAvailableIntervals() {
+        return allAvailableIntervals;
+    }
+
+    @Override
+    public Set<TableName> getDataSourceNames() {
+        return dataSourceNames;
+    }
+
+    @Override
+    public String getName() {
+        return sourceTable.getName();
+    }
+
+    @Override
+    public String getPhysicalColumnName(final String logicalName) {
+        return sourceTable.getPhysicalColumnName(logicalName);
+    }
+
+    @Override
+    public PhysicalTableSchema getSchema() {
+        return sourceTable.getSchema();
+    }
+
+    @Override
+    public TableName getTableName() {
+        return sourceTable.getTableName();
+    }
+
+    @Override
+    public DateTime getTableAlignment() {
+        return sourceTable.getTableAlignment();
+    }
+
+    @Deprecated
+    @Override
+    public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraint) {
+        // WARN HERE
+        if (constraint == this.constraint) {
+            return getAvailableIntervals();
+        }
+        return sourceTable.getAvailableIntervals(constraint);
+    }
+
+    @Deprecated
+    @Override
+    public Set<TableName> getDataSourceNames(DataSourceConstraint constraint) {
+        // WARN HERE
+        if (constraint == this.constraint) {
+            return dataSourceNames;
+        }
+        return sourceTable.getDataSourceNames(constraint);
+    }
+
+    @Deprecated
+    @Override
+    public ConstrainedTable withConstraint(final DataSourceConstraint constraint) {
+        // WARN HERE
+        return sourceTable.withConstraint(constraint);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
@@ -29,18 +29,18 @@ public class ConstrainedTable implements PhysicalTable {
     /**
      * Constructor.
      *
-     * @param table  The table being constrained
+     * @param sourceTable  The table being constrained
      * @param constraint  The constraint being applied
      */
-    public ConstrainedTable(ConfigPhysicalTable table, DataSourceConstraint constraint) {
+    public ConstrainedTable(ConfigPhysicalTable sourceTable, DataSourceConstraint constraint) {
         this.constraint = constraint;
-        sourceTable = table;
+        this.sourceTable = sourceTable;
 
-        Availability sourceAvailability = table.getAvailability();
+        Availability sourceAvailability = sourceTable.getAvailability();
 
         PhysicalDataSourceConstraint physicalDataSourceConstraint = new PhysicalDataSourceConstraint(
                 constraint,
-                table.getSchema()
+                sourceTable.getSchema()
         );
 
         availableIntervals = new SimplifiedIntervalList(
@@ -56,7 +56,14 @@ public class ConstrainedTable implements PhysicalTable {
         dataSourceNames = Collections.unmodifiableSet(
                 sourceAvailability.getDataSourceNames(physicalDataSourceConstraint)
         );
+    }
 
+    private DataSourceConstraint getConstraint() {
+        return constraint;
+    }
+
+    private PhysicalTable getSourceTable() {
+        return sourceTable;
     }
 
     @Override
@@ -76,27 +83,27 @@ public class ConstrainedTable implements PhysicalTable {
 
     @Override
     public String getName() {
-        return sourceTable.getName();
+        return getSourceTable().getName();
     }
 
     @Override
     public String getPhysicalColumnName(String logicalName) {
-        return sourceTable.getPhysicalColumnName(logicalName);
+        return getSourceTable().getPhysicalColumnName(logicalName);
     }
 
     @Override
     public PhysicalTableSchema getSchema() {
-        return sourceTable.getSchema();
+        return getSourceTable().getSchema();
     }
 
     @Override
     public TableName getTableName() {
-        return sourceTable.getTableName();
+        return getSourceTable().getTableName();
     }
 
     @Override
     public DateTime getTableAlignment() {
-        return sourceTable.getTableAlignment();
+        return getSourceTable().getTableAlignment();
     }
 
     /**
@@ -108,10 +115,10 @@ public class ConstrainedTable implements PhysicalTable {
      */
     @Override
     public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraint) {
-        if (constraint.equals(constraint)) {
+        if (getConstraint().equals(constraint)) {
             return getAvailableIntervals();
         }
-        return sourceTable.getAvailableIntervals(constraint);
+        return getSourceTable().getAvailableIntervals(constraint);
     }
 
     /**
@@ -123,10 +130,10 @@ public class ConstrainedTable implements PhysicalTable {
      */
     @Override
     public Set<TableName> getDataSourceNames(DataSourceConstraint constraint) {
-        if (constraint.equals(constraint)) {
-            return dataSourceNames;
+        if (getConstraint().equals(constraint)) {
+            return getDataSourceNames();
         }
-        return sourceTable.getDataSourceNames(constraint);
+        return getSourceTable().getDataSourceNames(constraint);
     }
 
     /**
@@ -138,6 +145,6 @@ public class ConstrainedTable implements PhysicalTable {
      */
     @Override
     public ConstrainedTable withConstraint(DataSourceConstraint constraint) {
-        return sourceTable.withConstraint(constraint);
+        return getSourceTable().withConstraint(constraint);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
@@ -106,7 +106,6 @@ public class ConstrainedTable implements PhysicalTable {
      *
      * @return The intervals that the table can report on
      */
-
     @Override
     public SimplifiedIntervalList getAvailableIntervals(DataSourceConstraint constraint) {
         if (constraint.equals(constraint)) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
@@ -59,7 +59,7 @@ public class MetricUnionCompositeTable extends BaseCompositePhysicalTable {
             @NotNull TableName name,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,
-            @NotNull Set<PhysicalTable> physicalTables,
+            @NotNull Set<ConfigPhysicalTable> physicalTables,
             @NotNull Map<String, String> logicalToPhysicalColumnNames
     ) {
         super(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PartitionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PartitionCompositeTable.java
@@ -33,7 +33,7 @@ public class PartitionCompositeTable extends BaseCompositePhysicalTable {
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,
             @NotNull Map<String, String> logicalToPhysicalColumnNames,
-            @NotNull Map<PhysicalTable, DataSourceFilter> availabilityFilters
+            @NotNull Map<ConfigPhysicalTable, DataSourceFilter> availabilityFilters
     ) {
         super(
                 name,
@@ -52,7 +52,7 @@ public class PartitionCompositeTable extends BaseCompositePhysicalTable {
      *
      * @return  The availability describing the partition
      */
-    private static Availability buildAvailability(Map<PhysicalTable, DataSourceFilter> dataSourceFilterMap) {
+    private static Availability buildAvailability(Map<ConfigPhysicalTable, DataSourceFilter> dataSourceFilterMap) {
         return new PartitionAvailability(dataSourceFilterMap.entrySet().stream()
                 .collect(Collectors.toMap(entry -> entry.getKey().getAvailability(), Map.Entry::getValue)));
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
@@ -16,11 +16,11 @@ import javax.validation.constraints.NotNull;
  * An implementation of concrete physical table with permissive availability.
  * <p>
  * This is different from its parent <tt>ConcretePhysicalTable</tt>. <tt>PermissiveConcretePhysicalTable</tt>
- * is backed <tt>PermissiveAvailability</tt>. As a result, {@link PhysicalTable#getAvailability()} will return
+ * is backed <tt>PermissiveAvailability</tt>. As a result, {@link ConfigPhysicalTable#getAvailability()} will return
  * the <tt>PermissiveAvailability</tt>. Returning a different <tt>Availability</tt> affects how available intervals
  * of a table are calculated and returned.
- * For example see {@link com.yahoo.bard.webservice.table.BasePhysicalTable#getAvailableIntervals(DataSourceConstraint)}
- * {@link BasePhysicalTable#getAllAvailableIntervals()}, and {@link BasePhysicalTable#getTableAlignment()}.
+ * For example see {@link PhysicalTable#getAvailableIntervals()}
+ * {@link PhysicalTable#getAllAvailableIntervals()}, and {@link PhysicalTable#getTableAlignment()}.
  */
 public class PermissiveConcretePhysicalTable extends ConcretePhysicalTable {
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -126,4 +126,35 @@ public interface PhysicalTable extends Table {
     default ZonedTimeGrain getTimeGrain() {
         return getSchema().getTimeGrain();
     }
+
+    /**
+     * Create a constrained copy of this table.
+     *
+     * @param constraint  The dataSourceConstraint which narrows the view of the underlying availability
+     *
+     * @return a constrained table whose availability and serialization are narrowed by this constraint
+     */
+    ConstrainedTable withConstraint(DataSourceConstraint constraint);
+
+    /**
+     * Filter a map of raw intervals to those included in a physical schema.
+     *
+     * @param rawIntervals  The map of name to {@link SimplifiedIntervalList}s as the source availability
+     * @param schema  The schema describing the columns of this table
+     *
+     * @return map of column to set of available intervals
+     */
+    static Map<Column, SimplifiedIntervalList> getAllAvailableIntervals(
+            Map<String, SimplifiedIntervalList> rawIntervals,
+            PhysicalTableSchema schema
+    ) {
+        return schema.getColumns().stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        column -> rawIntervals.getOrDefault(
+                                schema.getPhysicalColumnName(column.getName()),
+                                new SimplifiedIntervalList()
+                        )
+                ));
+    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -140,7 +140,7 @@ public interface PhysicalTable extends Table {
      * Map availabilities in schema-less columns to a {@link Column} keyed availability map for a given table.
      *
      * @param rawIntervals  The map of physical name to {@link SimplifiedIntervalList}s as the source availability
-     * @param schema  The schema describing the columns of this table, which includes the logical -> physical mappings
+     * @param schema  The schema describing the columns of this table, which includes the logical -&gt; physical mappings
      *
      * @return map of column to set of available intervals
      */

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -35,7 +35,7 @@ public interface PhysicalTable extends Table {
         return getAllAvailableIntervals().values()
                 .stream()
                 .reduce(SimplifiedIntervalList::union)
-                .orElse(SimplifiedIntervalList.empty());
+                .orElse(new SimplifiedIntervalList());
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -140,7 +140,8 @@ public interface PhysicalTable extends Table {
      * Map availabilities in schema-less columns to a {@link Column} keyed availability map for a given table.
      *
      * @param rawIntervals  The map of physical name to {@link SimplifiedIntervalList}s as the source availability
-     * @param schema  The schema describing the columns of this table, which includes the logical -&gt; physical mappings
+     * @param schema  The schema describing the columns of this table, which includes the logical -&gt; physical
+     * mappings
      *
      * @return map of column to set of available intervals
      */

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -26,11 +26,12 @@ public interface PhysicalTable extends Table {
     Map<Column, SimplifiedIntervalList> getAllAvailableIntervals();
 
     /**
-     * Return a view of the available intervals for this table given a data source constraint.
+     * Return a view of the available intervals.
      *
-     * @return The intervals that the table can report on, given the constraint
+     * @return The widest set of intervals that the table can report on
      */
     default SimplifiedIntervalList getAvailableIntervals() {
+        // By default union all available columns
         return getAllAvailableIntervals().values()
                 .stream()
                 .reduce(SimplifiedIntervalList::union)
@@ -137,14 +138,14 @@ public interface PhysicalTable extends Table {
     ConstrainedTable withConstraint(DataSourceConstraint constraint);
 
     /**
-     * Filter a map of raw intervals to those included in a physical schema.
+     * Map availabilities in schema-less columns to a {@link Column} keyed availability map for a given table.
      *
      * @param rawIntervals  The map of name to {@link SimplifiedIntervalList}s as the source availability
      * @param schema  The schema describing the columns of this table
      *
      * @return map of column to set of available intervals
      */
-    static Map<Column, SimplifiedIntervalList> getAllAvailableIntervals(
+    static Map<Column, SimplifiedIntervalList> mapToSchemaAvailability(
             Map<String, SimplifiedIntervalList> rawIntervals,
             PhysicalTableSchema schema
     ) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -144,7 +144,7 @@ public interface PhysicalTable extends Table {
      *
      * @return map of column to set of available intervals
      */
-    static Map<Column, SimplifiedIntervalList> mapToSchemaAvailability(
+    default Map<Column, SimplifiedIntervalList> mapToSchemaAvailability(
             Map<String, SimplifiedIntervalList> rawIntervals,
             PhysicalTableSchema schema
     ) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableDictionary.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTableDictionary.java
@@ -10,6 +10,6 @@ import javax.inject.Singleton;
  * Map of a druid table name to PhysicalTable.
  */
 @Singleton
-public class PhysicalTableDictionary extends LinkedHashMap<String, PhysicalTable> {
+public class PhysicalTableDictionary extends LinkedHashMap<String, ConfigPhysicalTable> {
     // Empty Class
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
@@ -22,6 +22,17 @@ public interface Availability {
     Set<TableName> getDataSourceNames();
 
     /**
+     * The names of the data sources backing this availability as filtered by the constraint.
+     *
+     * @param constraint  The constraint to filter data source names.
+     *
+     * @return A set of names for data sources backing this table
+     */
+    default Set<TableName> getDataSourceNames(PhysicalDataSourceConstraint constraint) {
+        return getDataSourceNames();
+    }
+
+    /**
      * The availability of all columns.
      *
      * @return The intervals, by column, available.
@@ -29,11 +40,25 @@ public interface Availability {
     Map<String, SimplifiedIntervalList> getAllAvailableIntervals();
 
     /**
-     * Fetch a set of intervals given a set of column name in DataSourceConstraint.
+     * Fetch a {@link SimplifiedIntervalList} representing the coalesced available intervals on this availability.
      *
-     * @param constraint  Physical data source constraint containing column's physical name, metrics names, api filters
-     *
-     * @return A simplified list of intervals associated with all column in constraint, empty if column is missing
+     * @return A <tt>SimplifiedIntervalList</tt> of intervals available
      */
-    SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint);
+    default SimplifiedIntervalList getAvailableIntervals() {
+        return getAllAvailableIntervals().values().stream()
+                .reduce(SimplifiedIntervalList::intersect).orElse(new SimplifiedIntervalList());
+    }
+
+    /**
+     *
+     * Fetch a {@link SimplifiedIntervalList} representing the coalesced available intervals on this availability as
+     * filtered by the {@link PhysicalDataSourceConstraint}.
+     *
+     * @param constraint  <tt>PhysicalDataSourceConstraint</tt> containing {@link Schema} and {@link ApiFilter}s
+     *
+     * @return A <tt>SimplifiedIntervalList</tt> of intervals available
+     */
+    default SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
+        return getAvailableIntervals();
+    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
@@ -46,7 +46,7 @@ public interface Availability {
      */
     default SimplifiedIntervalList getAvailableIntervals() {
         return getAllAvailableIntervals().values().stream()
-                .reduce(SimplifiedIntervalList::intersect)
+                .reduce(SimplifiedIntervalList::union)
                 .orElse(new SimplifiedIntervalList());
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
@@ -54,7 +54,8 @@ public interface Availability {
      * Fetch a {@link SimplifiedIntervalList} representing the coalesced available intervals on this availability as
      * filtered by the {@link PhysicalDataSourceConstraint}.
      *
-     * @param constraint  <tt>PhysicalDataSourceConstraint</tt> containing {@link Schema} and {@link ApiFilter}s
+     * @param constraint  <tt>PhysicalDataSourceConstraint</tt> containing
+     * {@link com.yahoo.bard.webservice.table.Schema} and {@link com.yahoo.bard.webservice.web.ApiFilter}s
      *
      * @return A <tt>SimplifiedIntervalList</tt> of intervals available
      */

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
@@ -17,7 +17,7 @@ public interface Availability {
     /**
      * The names of the data sources backing this availability.
      *
-     * @return A set of names for datasources backing this table
+     * @return A set of names for datasources backing this availability
      */
     Set<TableName> getDataSourceNames();
 
@@ -26,7 +26,7 @@ public interface Availability {
      *
      * @param constraint  The constraint to filter data source names.
      *
-     * @return A set of names for data sources backing this table
+     * @return A set of names for data sources backing this availability
      */
     default Set<TableName> getDataSourceNames(PhysicalDataSourceConstraint constraint) {
         return getDataSourceNames();
@@ -35,7 +35,7 @@ public interface Availability {
     /**
      * The availability of all columns.
      *
-     * @return The intervals, by column, available.
+     * @return The intervals, by column name, available.
      */
     Map<String, SimplifiedIntervalList> getAllAvailableIntervals();
 
@@ -46,7 +46,8 @@ public interface Availability {
      */
     default SimplifiedIntervalList getAvailableIntervals() {
         return getAllAvailableIntervals().values().stream()
-                .reduce(SimplifiedIntervalList::intersect).orElse(new SimplifiedIntervalList());
+                .reduce(SimplifiedIntervalList::intersect)
+                .orElse(new SimplifiedIntervalList());
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -51,16 +51,6 @@ public class ConcreteAvailability implements Availability {
     }
 
     @Override
-    public SimplifiedIntervalList getAvailableIntervals() {
-        return null;
-    }
-
-    @Override
-    public Set<TableName> getDataSourceNames(PhysicalDataSourceConstraint constraint) {
-        return dataSourceNames;
-    }
-
-    @Override
     public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
 
         Set<String> requestColumns = constraint.getAllColumnPhysicalNames();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -51,6 +51,16 @@ public class ConcreteAvailability implements Availability {
     }
 
     @Override
+    public SimplifiedIntervalList getAvailableIntervals() {
+        return null;
+    }
+
+    @Override
+    public Set<TableName> getDataSourceNames(PhysicalDataSourceConstraint constraint) {
+        return dataSourceNames;
+    }
+
+    @Override
     public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
 
         Set<String> requestColumns = constraint.getAllColumnPhysicalNames();
@@ -66,7 +76,6 @@ public class ConcreteAvailability implements Availability {
                         new SimplifiedIntervalList()
                 )).reduce(SimplifiedIntervalList::intersect).orElse(new SimplifiedIntervalList());
     }
-
 
     /**
      * Returns the name of the table and data source associated with this Availability.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.table.availability;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.table.Column;
-import com.yahoo.bard.webservice.table.PhysicalTable;
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 import com.yahoo.bard.webservice.util.Utils;
@@ -85,8 +85,8 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
      * @param columns  The set of all configured columns, including dimension columns, that metric union availability
      * will respond with
      */
-    public MetricUnionAvailability(@NotNull Set<PhysicalTable> physicalTables, @NotNull Set<Column> columns) {
-        super(physicalTables.stream().map(PhysicalTable::getAvailability));
+    public MetricUnionAvailability(@NotNull Set<ConfigPhysicalTable> physicalTables, @NotNull Set<Column> columns) {
+        super(physicalTables.stream().map(ConfigPhysicalTable::getAvailability));
 
         metricNames = Utils.getSubsetByType(columns, MetricColumn.class).stream()
                 .map(MetricColumn::getName)
@@ -95,7 +95,7 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
         // Construct a map of availability to its assigned metric
         // by intersecting its underlying datasource metrics with table configured metrics
         availabilitiesToMetricNames = physicalTables.stream()
-                .map(PhysicalTable::getAvailability)
+                .map(ConfigPhysicalTable::getAvailability)
                 .collect(
                         Collectors.toMap(
                                 Function.identity(),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
@@ -167,7 +167,7 @@ public class DataSourceConstraint {
     }
 
     /**
-     * Build a constraint which should filter away no part of a given table.
+     * Build a constraint which should not filter away any part of a given table.
      *
      * @param table  The table whose dimensions and metrics are to be queried
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
@@ -167,7 +167,7 @@ public class DataSourceConstraint {
      *
      * @param table  The table whose dimensions and metrics are to be queried
      *
-     * @return  A constraint which should provide no restrictions
+     * @return a constraint which should provide no restrictions
      */
     public static DataSourceConstraint emptyConstraint(PhysicalTable table) {
         return new DataSourceConstraint(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.table.resolver;
 
 import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
+import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.web.ApiFilter;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 
@@ -158,6 +159,28 @@ public class DataSourceConstraint {
                 allDimensionNames,
                 allColumnNames,
                 apiFilters
+        );
+    }
+
+    /**
+     * Build a constraint which should filter away no part of a given table.
+     *
+     * @param table  The table whose dimensions and metrics are to be queried
+     *
+     * @return  A constraint which should provide no restrictions
+     */
+    public static DataSourceConstraint emptyConstraint(PhysicalTable table) {
+        return new DataSourceConstraint(
+                table.getDimensions(),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                table.getSchema().getMetricColumnNames(),
+                table.getDimensions(),
+                table.getDimensions().stream()
+                        .map(Dimension::getApiName)
+                        .collect(Collectors.toSet()),
+                table.getSchema().getColumnNames(),
+                Collections.emptyMap()
         );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
@@ -10,6 +10,7 @@ import com.yahoo.bard.webservice.web.DataApiRequest;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -20,11 +21,14 @@ import java.util.stream.Stream;
  */
 public class DataSourceConstraint {
 
+    // Direct fields
     private final Set<Dimension> requestDimensions;
     private final Set<Dimension> filterDimensions;
     private final Set<Dimension> metricDimensions;
     private final Set<String> metricNames;
     private final Map<Dimension, Set<ApiFilter>> apiFilters;
+
+    // Calculated fields
     private final Set<Dimension> allDimensions;
     private final Set<String> allDimensionNames;
     private final Set<String> allColumnNames;
@@ -182,5 +186,27 @@ public class DataSourceConstraint {
                 table.getSchema().getColumnNames(),
                 Collections.emptyMap()
         );
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof DataSourceConstraint) {
+            DataSourceConstraint that = (DataSourceConstraint) obj;
+            return Objects.equals(this.requestDimensions, that.requestDimensions)
+                    && Objects.equals(this.filterDimensions, that.filterDimensions)
+                    && Objects.equals(this.metricDimensions, that.metricDimensions)
+                    && Objects.equals(this.metricNames, that.metricNames)
+                    && Objects.equals(this.apiFilters, that.apiFilters);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(requestDimensions, filterDimensions, metricDimensions, metricNames, apiFilters);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/DataSourceConstraint.java
@@ -173,7 +173,7 @@ public class DataSourceConstraint {
      *
      * @return a constraint which should provide no restrictions
      */
-    public static DataSourceConstraint emptyConstraint(PhysicalTable table) {
+    public static DataSourceConstraint unconstrained(PhysicalTable table) {
         return new DataSourceConstraint(
                 table.getDimensions(),
                 Collections.emptySet(),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PartialTimeComparator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PartialTimeComparator.java
@@ -7,7 +7,6 @@ import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.util.IntervalUtils;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
-import java.util.Collections;
 import java.util.Comparator;
 
 /**
@@ -42,16 +41,14 @@ public class PartialTimeComparator implements Comparator<PhysicalTable> {
         // choose table with most data available for given columns
         long missingDurationLeft = IntervalUtils.getTotalDuration(
                 partialDataHandler.findMissingTimeGrainIntervals(
-                        requestConstraint,
-                        Collections.singleton(left),
+                        left.getAvailableIntervals(requestConstraint),
                         new SimplifiedIntervalList(requestConstraint.getIntervals()),
                         requestConstraint.getRequestGranularity()
                 )
         );
         long missingDurationRight = IntervalUtils.getTotalDuration(
                 partialDataHandler.findMissingTimeGrainIntervals(
-                        requestConstraint,
-                        Collections.singleton(right),
+                        right.getAvailableIntervals(requestConstraint),
                         new SimplifiedIntervalList(requestConstraint.getIntervals()),
                         requestConstraint.getRequestGranularity()
                 )

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraint.java
@@ -11,8 +11,11 @@ import com.yahoo.bard.webservice.web.DataApiRequest;
 import org.joda.time.Interval;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * Constraints used to match and resolve the best table for a given query.
@@ -32,7 +35,10 @@ public class QueryPlanningConstraint extends DataSourceConstraint {
      * @param dataApiRequest Api request containing the constraints information.
      * @param templateDruidQuery Query containing metric constraint information.
      */
-    public QueryPlanningConstraint(DataApiRequest dataApiRequest, TemplateDruidQuery templateDruidQuery) {
+    public QueryPlanningConstraint(
+            @NotNull DataApiRequest dataApiRequest,
+            @NotNull TemplateDruidQuery templateDruidQuery
+    ) {
         super(dataApiRequest, templateDruidQuery);
 
         this.logicalTable = dataApiRequest.getTable();
@@ -66,5 +72,36 @@ public class QueryPlanningConstraint extends DataSourceConstraint {
 
     public Granularity getRequestGranularity() {
         return requestGranularity;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof QueryPlanningConstraint) {
+            QueryPlanningConstraint that = (QueryPlanningConstraint) obj;
+            return super.equals(that)
+                    && Objects.equals(this.logicalTable, that.logicalTable)
+                    && Objects.equals(this.intervals, that.intervals)
+                    && Objects.equals(this.logicalMetrics, that.logicalMetrics)
+                    && Objects.equals(this.minimumGranularity, that.minimumGranularity)
+                    && Objects.equals(this.requestGranularity, that.requestGranularity)
+                    && Objects.equals(this.logicalMetricNames, that.logicalMetricNames);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                super.hashCode(),
+                logicalTable,
+                intervals,
+                logicalMetrics,
+                minimumGranularity,
+                requestGranularity,
+                logicalMetricNames
+        );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/VolatileTimeComparator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/VolatileTimeComparator.java
@@ -9,7 +9,6 @@ import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.util.IntervalUtils;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
-import java.util.Collections;
 import java.util.Comparator;
 
 /**
@@ -84,8 +83,7 @@ public class VolatileTimeComparator implements Comparator<PhysicalTable> {
         Granularity apiRequestGranularity = requestConstraint.getRequestGranularity();
         // First, find the volatile intervals that are also partial at the request grain.
         SimplifiedIntervalList volatilePartialRequestIntervals = partialDataHandler.findMissingTimeGrainIntervals(
-                requestConstraint,
-                Collections.singleton(table),
+                table.getAvailableIntervals(requestConstraint),
                 volatileIntervalsService.getVolatileIntervals(apiRequestGranularity, requestIntervals, table),
                 apiRequestGranularity
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/IntervalUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/IntervalUtils.java
@@ -132,33 +132,6 @@ public class IntervalUtils {
     }
 
     /**
-     * Collect all subintervals from a bucketed collection that are not subintervals of a supply.
-     * <p>
-     * The bucketed list of intervals are split by grain before being tested as subintervals of the supply list.
-     *
-     * @param supplyIntervals  The intervals which bucketed intervals are being tested against
-     * @param bucketedIntervals  The grain bucketed intervals to collect if not in the supply
-     * @param granularity  The grain at which to split the bucketingIntervals
-     *
-     * @return a simplified list of intervals reflecting the intervals in the fromSet which do not appear in the
-     * remove set
-     */
-    public static SimplifiedIntervalList collectBucketedIntervalsNotInIntervalList(
-            SimplifiedIntervalList supplyIntervals,
-            SimplifiedIntervalList bucketedIntervals,
-            Granularity granularity
-    ) {
-        // Stream the from intervals, split by grain
-        Iterable<Interval> bucketIterable = granularity.intervalsIterable(bucketedIntervals);
-
-        // Not in returns true if any part of the stream interval is not 'covered' by the remove intervals.
-        Predicate<Interval> notIn = new SimplifiedIntervalList.IsSubinterval(supplyIntervals).negate();
-        return StreamSupport.stream(bucketIterable.spliterator(), false)
-                .filter(notIn)
-                .collect(SimplifiedIntervalList.getCollector());
-    }
-
-    /**
      * Collect all subintervals of an interval list of a grain bucketed size which are subintervals of another supply
      * list of intervals.
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
@@ -107,7 +107,7 @@ public class SimplifiedIntervalList extends LinkedList<Interval> {
     /**
      * Static method to provide an empty list.
      *
-     * @return  A new, empty list.
+     * @return a new, empty list.
      */
     public static SimplifiedIntervalList empty() {
         return new SimplifiedIntervalList();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
@@ -30,6 +30,7 @@ import javax.validation.constraints.NotNull;
  */
 public class SimplifiedIntervalList extends LinkedList<Interval> {
 
+    @Deprecated
     public static final SimplifiedIntervalList NO_INTERVALS = new SimplifiedIntervalList();
 
     /**
@@ -103,6 +104,14 @@ public class SimplifiedIntervalList extends LinkedList<Interval> {
                 .collect(getCollector());
     }
 
+    /**
+     * Static method to provide an empty list.
+     *
+     * @return  A new, empty list.
+     */
+    public static SimplifiedIntervalList empty() {
+        return new SimplifiedIntervalList();
+    }
 
     /**
      * Given a sorted linked list of intervals, add the following interval to the end, merging the incoming interval
@@ -324,7 +333,7 @@ public class SimplifiedIntervalList extends LinkedList<Interval> {
         List<Interval> collected = new ArrayList<>();
 
         if (thisCurrent == null) {
-            return SimplifiedIntervalList.NO_INTERVALS;
+            return SimplifiedIntervalList.empty();
         }
 
         while (thisCurrent != null && thatCurrent != null) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
@@ -34,16 +34,16 @@ public class SimplifiedIntervalList extends LinkedList<Interval> {
     public static final SimplifiedIntervalList NO_INTERVALS = new SimplifiedIntervalList();
 
     /**
+     * Function to iterate an iterator if it has a next element, otherwise return null.
+     */
+    protected Function<Iterator<Interval>, Interval> getNextIfAvailable = (it) -> it.hasNext() ? it.next() : null;
+
+    /**
      * Constructor.
      */
     public SimplifiedIntervalList() {
         super();
     }
-
-    /**
-     * Function to iterate an iterator if it has a next element, otherwise return null.
-     */
-    protected Function<Iterator<Interval>, Interval> getNextIfAvailable = (it) -> it.hasNext() ? it.next() : null;
 
     /**
      * Simplify then build a list.
@@ -328,13 +328,13 @@ public class SimplifiedIntervalList extends LinkedList<Interval> {
         Iterator<Interval> theseIntervals = this.iterator();
         Iterator<Interval> thoseIntervals = that.iterator();
         Interval thisCurrent = getNextIfAvailable.apply(theseIntervals);
-        Interval thatCurrent = getNextIfAvailable.apply(thoseIntervals);
-
-        List<Interval> collected = new ArrayList<>();
 
         if (thisCurrent == null) {
             return SimplifiedIntervalList.empty();
         }
+
+        Interval thatCurrent = getNextIfAvailable.apply(thoseIntervals);
+        List<Interval> collected = new ArrayList<>();
 
         while (thisCurrent != null && thatCurrent != null) {
             if (thisCurrent.isBefore(thatCurrent)) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
@@ -326,12 +326,13 @@ public class SimplifiedIntervalList extends LinkedList<Interval> {
      */
     public SimplifiedIntervalList subtract(SimplifiedIntervalList that) {
         Iterator<Interval> theseIntervals = this.iterator();
-        Iterator<Interval> thoseIntervals = that.iterator();
         Interval thisCurrent = getNextIfAvailable.apply(theseIntervals);
 
         if (thisCurrent == null) {
             return SimplifiedIntervalList.empty();
         }
+
+        Iterator<Interval> thoseIntervals = that.iterator();
 
         Interval thatCurrent = getNextIfAvailable.apply(thoseIntervals);
         List<Interval> collected = new ArrayList<>();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
@@ -30,6 +30,11 @@ import javax.validation.constraints.NotNull;
  */
 public class SimplifiedIntervalList extends LinkedList<Interval> {
 
+    /**
+     * A prebuilt empty SimplifiedIntervalList.
+     *
+     * @deprecated This shared instance is vulnerable to being changed globally with side effects, use empty constructor
+     */
     @Deprecated
     public static final SimplifiedIntervalList NO_INTERVALS = new SimplifiedIntervalList();
 
@@ -102,15 +107,6 @@ public class SimplifiedIntervalList extends LinkedList<Interval> {
         return allIntervals
                 .sorted(IntervalStartComparator.INSTANCE::compare)
                 .collect(getCollector());
-    }
-
-    /**
-     * Static method to provide an empty list.
-     *
-     * @return a new, empty list.
-     */
-    public static SimplifiedIntervalList empty() {
-        return new SimplifiedIntervalList();
     }
 
     /**
@@ -329,7 +325,7 @@ public class SimplifiedIntervalList extends LinkedList<Interval> {
         Interval thisCurrent = getNextIfAvailable.apply(theseIntervals);
 
         if (thisCurrent == null) {
-            return SimplifiedIntervalList.empty();
+            return new SimplifiedIntervalList();
         }
 
         Iterator<Interval> thoseIntervals = that.iterator();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -216,6 +216,11 @@ public enum ErrorMessageFormat implements MessageFormatter {
     RESULT_MAPPING_FAILURE(
             "Error occurred while processing response data: %s"
     ),
+    INVALID_DATASOURCE_UNION(
+            "Union data source had conflicting name mappings for logical dimension '%s' with mappings of '%s' and '%s'",
+            "Union Data Source had conflicting name mappings for logical dimension '%s' with mappings of '%s' and '%s'"
+    ),
+
 
     DATA_AVAILABILITY_MISMATCH(
             "Data availability expectation does not match with actual query result obtained from druid for the " +

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -217,7 +217,6 @@ public enum ErrorMessageFormat implements MessageFormatter {
             "Error occurred while processing response data: %s"
     ),
     INVALID_DATASOURCE_UNION(
-            "Union data source had conflicting name mappings for logical dimension '%s' with mappings of '%s' and '%s'",
             "Union Data Source had conflicting name mappings for logical dimension '%s' with mappings of '%s' and '%s'"
     ),
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
@@ -12,18 +12,17 @@ import com.yahoo.bard.webservice.metadata.SegmentInfo;
 import com.yahoo.bard.webservice.table.Column;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
+import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 import com.yahoo.bard.webservice.web.endpoints.DimensionsServlet;
 import com.yahoo.bard.webservice.web.endpoints.SlicesServlet;
 
 import org.joda.time.DateTime;
-import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -168,7 +167,7 @@ public class SlicesApiRequest extends ApiRequest {
             throw new BadApiRequestException(msg);
         }
 
-        Map<Column, List<Interval>> columnCache = table.getAllAvailableIntervals();
+        Map<Column, SimplifiedIntervalList> columnCache = table.getAllAvailableIntervals();
         Set<Map<String, Object>> dimensionsResult = new LinkedHashSet<>();
         Set<Map<String, Object>> metricsResult = new LinkedHashSet<>();
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
@@ -8,6 +8,7 @@ import com.yahoo.bard.webservice.config.BardFeatureFlag;
 import com.yahoo.bard.webservice.data.PartialDataHandler;
 import com.yahoo.bard.webservice.data.metric.mappers.PartialDataResultSetMapper;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
+import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.responseprocessors.MappingResponseProcessor;
@@ -31,6 +32,24 @@ public class PartialDataRequestHandler implements DataRequestHandler {
 
     protected final @NotNull DataRequestHandler next;
     protected final @NotNull PartialDataHandler partialDataHandler;
+
+    /**
+     * Wrap the response processor in a partial data check.
+     *
+     * @param next The next request handler to invoke
+     * @param physicalTableDictionary   the repository of slice data
+     * @param partialDataHandler the service to calculate partial data from table availabilities
+     *
+     * @deprecated use constructor {@link #PartialDataRequestHandler(DataRequestHandler, PartialDataHandler)}
+     */
+    @Deprecated
+    public PartialDataRequestHandler(
+            DataRequestHandler next,
+            PhysicalTableDictionary physicalTableDictionary,
+            PartialDataHandler partialDataHandler
+    ) {
+        this(next, partialDataHandler);
+    }
 
     /**
      * Wrap the response processor in a partial data check.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
@@ -62,7 +62,7 @@ public class PartialDataRequestHandler implements DataRequestHandler {
         MappingResponseProcessor mappingResponse = (MappingResponseProcessor) response;
 
         // Gather the tables from the query
-        Set<ConstrainedTable> physicalTables = druidQuery.getInnermostQuery().getDataSource().getPhysicalTables();;
+        Set<ConstrainedTable> physicalTables = druidQuery.getInnermostQuery().getDataSource().getPhysicalTables();
 
         // Gather the missing intervals
         SimplifiedIntervalList missingIntervals = partialDataHandler.findMissingTimeGrainIntervals(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
@@ -60,7 +60,7 @@ public class PartialDataRequestHandler implements DataRequestHandler {
 
         // Gather the missing intervals
         SimplifiedIntervalList missingIntervals = partialDataHandler.findMissingTimeGrainIntervals(
-                druidQuery.getInnermostQuery().getDataSource().getPhysicalTables().stream(),
+                druidQuery.getInnermostQuery().getDataSource().getPhysicalTable().getAvailableIntervals(),
                 new SimplifiedIntervalList(request.getIntervals()),
                 request.getGranularity()
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
@@ -36,14 +36,13 @@ public class PartialDataRequestHandler implements DataRequestHandler {
      * Wrap the response processor in a partial data check.
      *
      * @param next The next request handler to invoke
-     * @param partialDataHandler the PartialDataHandler to use
+     * @param partialDataHandler the service to calculate partial data from table availabilities
      */
     public PartialDataRequestHandler(
             DataRequestHandler next,
             PartialDataHandler partialDataHandler
     ) {
         this.next = next;
-        //this.physicalTableDictionary = physicalTableDictionary;
         this.partialDataHandler = partialDataHandler;
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
@@ -8,7 +8,6 @@ import com.yahoo.bard.webservice.config.BardFeatureFlag;
 import com.yahoo.bard.webservice.data.PartialDataHandler;
 import com.yahoo.bard.webservice.data.metric.mappers.PartialDataResultSetMapper;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
-import com.yahoo.bard.webservice.table.ConstrainedTable;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.responseprocessors.MappingResponseProcessor;
@@ -17,7 +16,6 @@ import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor;
 
 import java.io.Serializable;
 import java.util.Map;
-import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
@@ -61,12 +59,9 @@ public class PartialDataRequestHandler implements DataRequestHandler {
         }
         MappingResponseProcessor mappingResponse = (MappingResponseProcessor) response;
 
-        // Gather the tables from the query
-        Set<ConstrainedTable> physicalTables = druidQuery.getInnermostQuery().getDataSource().getPhysicalTables();
-
         // Gather the missing intervals
         SimplifiedIntervalList missingIntervals = partialDataHandler.findMissingTimeGrainIntervals(
-                physicalTables,
+                druidQuery.getInnermostQuery().getDataSource().getPhysicalTables().stream(),
                 new SimplifiedIntervalList(request.getIntervals()),
                 request.getGranularity()
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/workflow/DruidWorkflow.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/workflow/DruidWorkflow.java
@@ -139,7 +139,7 @@ public class DruidWorkflow implements RequestWorkflowProvider {
 
         handler = new TopNMapperRequestHandler(handler);
 
-        handler = new PartialDataRequestHandler(handler, physicalTableDictionary, partialDataHandler);
+        handler = new PartialDataRequestHandler(handler, partialDataHandler);
 
         handler = new VolatileDataRequestHandler(
                 handler,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
@@ -29,8 +29,8 @@ import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.druid.model.query.TimeSeriesQuery
 import com.yahoo.bard.webservice.druid.model.query.TopNQuery
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
-import com.yahoo.bard.webservice.table.PhysicalTable
+import com.yahoo.bard.webservice.table.ConstrainedTable
+import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.table.resolver.DefaultPhysicalTableResolver
 import com.yahoo.bard.webservice.web.ApiFilter
 import com.yahoo.bard.webservice.web.ApiHaving
@@ -131,7 +131,7 @@ class DruidQueryBuilderSpec extends Specification {
     def "Test recursive buildQueryMethods"() {
         setup:
         Set apiSet = (["abie1234", "abde1129"].collect() { apiFilters.get(it) }) as Set
-        PhysicalTable tab = new ConcretePhysicalTable(
+        ConstrainedTable tab = TableTestUtils.buildTable(
                 "tab1",
                 DAY.buildZonedTimeGrain(UTC),
                 [] as Set,
@@ -232,7 +232,7 @@ class DruidQueryBuilderSpec extends Specification {
 
         when:
         Set apiSet = (["abie1234", "abde1129"].collect() { apiFilters.get(it) }) as Set
-        PhysicalTable tab = new ConcretePhysicalTable(
+        ConstrainedTable tab = TableTestUtils.buildTable(
                 "tab1",
                 DAY.buildZonedTimeGrain(UTC),
                 [] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
@@ -3,13 +3,18 @@
 package com.yahoo.bard.webservice.data
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
+import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.MONTH
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.WEEK
+import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.YEAR
+import static com.yahoo.bard.webservice.util.IntervalUtilsSpec.buildIntervalList
+import static com.yahoo.bard.webservice.util.IntervalUtilsSpec.complementExpectedSets
 import static org.joda.time.DateTimeZone.UTC
 
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
 import com.yahoo.bard.webservice.druid.model.query.AllGranularity
+import com.yahoo.bard.webservice.druid.model.query.Granularity
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
 import com.yahoo.bard.webservice.table.Column
@@ -21,7 +26,7 @@ import org.joda.time.DateTimeZone
 import org.joda.time.Interval
 
 import spock.lang.Specification
-
+import spock.lang.Unroll
 /**
  * Tests for the Partial Data Handler
  */
@@ -93,8 +98,7 @@ class PartialDataHandlerSpec extends Specification {
 
         expect:
         expectedIntervals == partialDataHandler.findMissingTimeGrainIntervals(
-                dataSourceConstraint,
-                [table] as Set,
+                table.getAvailableIntervals(dataSourceConstraint),
                 new SimplifiedIntervalList(dataSourceConstraint.getIntervals()),
                 dataSourceConstraint.getRequestGranularity()
         )
@@ -108,8 +112,7 @@ class PartialDataHandlerSpec extends Specification {
 
         expect:
         requestedIntervals == partialDataHandler.findMissingTimeGrainIntervals(
-                dataSourceConstraint,
-                [table] as Set,
+                table.getAvailableIntervals(dataSourceConstraint),
                 new SimplifiedIntervalList(dataSourceConstraint.getIntervals()),
                 dataSourceConstraint.getRequestGranularity()
         )
@@ -117,5 +120,70 @@ class PartialDataHandlerSpec extends Specification {
 
     SimplifiedIntervalList buildIntervals(List<String> intervals) {
         intervals.collect({ (new Interval(it)) }) as SimplifiedIntervalList
+    }
+
+
+    @Unroll
+    def "Complement of #supply yields #expected with fixed request and grain"() {
+        setup:
+        SimplifiedIntervalList supplyIntervals = buildIntervalList(supply)
+        SimplifiedIntervalList requestedIntervals = buildIntervalList(['2014/2015'])
+        Granularity granularity = MONTH
+        SimplifiedIntervalList expectedIntervals = buildIntervalList(expected)
+
+        expect:
+        PartialDataHandler.collectBucketedIntervalsNotInIntervalList(
+                supplyIntervals,
+                requestedIntervals,
+                granularity
+        ) == expectedIntervals
+
+        where:
+        supply               | expected
+        ["2013-04/2014-04"]  | ["2014-04/2015"]
+        ["2014-04/2014-05"]  | ["2014/2014-04", "2014-05/2015"]
+        ["2012-09/2016-05"]  | []
+        ["2012/2013"]        | ["2014/2015"]
+        ["2020/2023"]        | ["2014/2015"]
+    }
+
+
+    @Unroll
+    def "Collect of #requestedIntervals by #grain yields #expected when fixed supply is removed"() {
+        setup:
+        SimplifiedIntervalList supply = buildIntervalList(['2012-05-04/2017-02-03'])
+        SimplifiedIntervalList expectedIntervals = buildIntervalList(expected)
+        SimplifiedIntervalList requestedIntervals = buildIntervalList(requested)
+        Granularity granularity = grain
+
+        expect:
+        PartialDataHandler.collectBucketedIntervalsNotInIntervalList(
+                supply,
+                requestedIntervals,
+                granularity
+        ) == expectedIntervals
+
+        where:
+        grain | requested                 | expected
+        YEAR  | ["2012/2017"]             | ["2012/2013"]
+        MONTH | ["2012-02/2017"]          | ["2012-02/2012-06"]
+        DAY   | ["2012-02-02/2016-05"]    | ["2012-02-02/2012-05-04"]
+        DAY   | ["2012-06/2016-05"]       | []
+        YEAR  | ["2013/2018"]             | ["2017/2018"]
+        MONTH | ["2013/2017-04"]          | ["2017-02/2017-04"]
+        DAY   | ["2012-02-03/2017-04-04"] | ["2012-02-03/2012-05-04", "2017-02-03/2017-04-04"]
+    }
+
+    def "Test that complement cuts out the correct hole(s)"() {
+        given:
+        SimplifiedIntervalList from = buildIntervalList(fromAsStrings)
+        SimplifiedIntervalList remove = buildIntervalList(removeAsStrings)
+        SimplifiedIntervalList expected = buildIntervalList(expectedAsStrings)
+
+        expect:
+        PartialDataHandler.collectBucketedIntervalsNotInIntervalList(remove, from, granularity) == expected
+
+        where:
+        [granularity, comment, fromAsStrings, removeAsStrings, expectedAsStrings] << complementExpectedSets()
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
@@ -17,6 +17,7 @@ import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.resolver.QueryPlanningConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
+import org.joda.time.DateTimeZone
 import org.joda.time.Interval
 
 import spock.lang.Specification
@@ -35,6 +36,17 @@ class PartialDataHandlerSpec extends Specification {
     GroupByQuery groupByQuery = Mock(GroupByQuery.class)
     DimensionDictionary dimensionDictionary
     QueryPlanningConstraint dataSourceConstraint
+
+    static DateTimeZone dateTimeZone;
+
+    def setupSpec() {
+        dateTimeZone = DateTimeZone.getDefault()
+        DateTimeZone.setDefault(UTC)
+    }
+
+    def cleanupSpec() {
+        DateTimeZone.setDefault(dateTimeZone)
+    }
 
     def setup() {
         columnNames = ["userDeviceType", "property", "os",  "page_views"] as Set
@@ -104,6 +116,6 @@ class PartialDataHandlerSpec extends Specification {
     }
 
     SimplifiedIntervalList buildIntervals(List<String> intervals) {
-        intervals.collect({ new Interval(it) }) as SimplifiedIntervalList
+        intervals.collect({ (new Interval(it)) }) as SimplifiedIntervalList
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
@@ -10,6 +10,7 @@ import static com.yahoo.bard.webservice.util.IntervalUtilsSpec.buildIntervalList
 import static com.yahoo.bard.webservice.util.IntervalUtilsSpec.complementExpectedSets
 import static org.joda.time.DateTimeZone.UTC
 
+import com.yahoo.bard.webservice.data.config.names.TableName
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
@@ -27,6 +28,7 @@ import org.joda.time.Interval
 
 import spock.lang.Specification
 import spock.lang.Unroll
+
 /**
  * Tests for the Partial Data Handler
  */
@@ -42,7 +44,7 @@ class PartialDataHandlerSpec extends Specification {
     DimensionDictionary dimensionDictionary
     QueryPlanningConstraint dataSourceConstraint
 
-    static DateTimeZone dateTimeZone;
+    static DateTimeZone dateTimeZone
 
     def setupSpec() {
         dateTimeZone = DateTimeZone.getDefault()
@@ -82,7 +84,7 @@ class PartialDataHandlerSpec extends Specification {
         ]
 
         table = new ConcretePhysicalTable(
-                "basefact_network",
+                TableName.of("basefact_network"),
                 DAY.buildZonedTimeGrain(UTC),
                 [new Column("userDeviceType"), new Column("property"), new Column("os"), new Column("page_views")] as Set,
                 ["userDeviceType": "user_device_type"],
@@ -174,7 +176,8 @@ class PartialDataHandlerSpec extends Specification {
         DAY   | ["2012-02-03/2017-04-04"] | ["2012-02-03/2012-05-04", "2017-02-03/2017-04-04"]
     }
 
-    def "Test that complement cuts out the correct hole(s)"() {
+    @Unroll
+    def "Complement cuts out the correct hole(s) when #comment"() {
         given:
         SimplifiedIntervalList from = buildIntervalList(fromAsStrings)
         SimplifiedIntervalList remove = buildIntervalList(removeAsStrings)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
@@ -18,6 +18,7 @@ import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableSchema
 import com.yahoo.bard.webservice.table.TableGroup
@@ -25,8 +26,6 @@ import com.yahoo.bard.webservice.table.TableGroup
 import org.joda.time.DateTimeZone
 
 import spock.lang.Specification
-
-import java.util.stream.Collectors
 
 /**
  * Testing basic table loader functionality.
@@ -67,7 +66,7 @@ class BaseTableLoaderSpec extends Specification {
         }
 
         @Override
-        PhysicalTable build(
+        ConfigPhysicalTable build(
                 ResourceDictionaries dictionaries,
                 DataSourceMetadataService metadataService
         ) {
@@ -101,7 +100,7 @@ class BaseTableLoaderSpec extends Specification {
     PhysicalTableDefinition circularDependentDefinition5
     PhysicalTableDefinition circularDependentDefinition6
 
-    PhysicalTable physicalTable
+    ConfigPhysicalTable physicalTable
     PhysicalTableSchema physicalTableSchema
 
     def setup() {
@@ -121,7 +120,7 @@ class BaseTableLoaderSpec extends Specification {
         physicalTableSchema = Mock(PhysicalTableSchema)
         physicalTableSchema.getColumns(DimensionColumn.class) >> []
 
-        physicalTable = Mock(PhysicalTable)
+        physicalTable = Mock(ConfigPhysicalTable)
         physicalTable.getTableName() >> TableName.of('definition2')
         physicalTable.getSchema() >> physicalTableSchema
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinitionSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/DimensionListPartitionTableDefinitionSpec.groovy
@@ -10,6 +10,7 @@ import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.data.dimension.DimensionField
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable
 import com.yahoo.bard.webservice.table.PartitionCompositeTable
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableSchema
@@ -54,12 +55,12 @@ class DimensionListPartitionTableDefinitionSpec extends Specification {
         getTimeGrain() >> DAY_UTC
     }
 
-    PhysicalTable part1 = Mock(PhysicalTable) {
+    PhysicalTable part1 = Mock(ConfigPhysicalTable) {
         getAvailability() >> availability1
         getSchema() >> schema
     }
 
-    PhysicalTable part2 = Mock(PhysicalTable) {
+    PhysicalTable part2 = Mock(ConfigPhysicalTable) {
         getAvailability() >> availability2
         getSchema() >> schema
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunctionSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunctionSpec.groovy
@@ -13,6 +13,6 @@ class NoVolatileIntervalsFunctionSpec extends Specification {
 
     def "getVolatileIntervals returns empty intervals"() {
         expect:
-        SimplifiedIntervalList.NO_INTERVALS == NoVolatileIntervalsFunction.INSTANCE.getVolatileIntervals()
+        SimplifiedIntervalList.empty() == NoVolatileIntervalsFunction.INSTANCE.getVolatileIntervals()
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunctionSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/volatility/NoVolatileIntervalsFunctionSpec.groovy
@@ -13,6 +13,6 @@ class NoVolatileIntervalsFunctionSpec extends Specification {
 
     def "getVolatileIntervals returns empty intervals"() {
         expect:
-        SimplifiedIntervalList.empty() == NoVolatileIntervalsFunction.INSTANCE.getVolatileIntervals()
+        new SimplifiedIntervalList() == NoVolatileIntervalsFunction.INSTANCE.getVolatileIntervals()
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/CardinalityAggregationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/CardinalityAggregationSpec.groovy
@@ -80,7 +80,7 @@ class CardinalityAggregationSpec extends Specification {
         //       Consequently, query's also need this to be serialized.
         DruidAggregationQuery query = Mock(DruidAggregationQuery)
         DataSource ds = Mock(DataSource)
-        ds.getPhysicalTables() >> [constrainedTable]
+        ds.getPhysicalTable() >> constrainedTable
         query.dataSource >> ds
         query.aggregations >> [a1]
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/CardinalityAggregationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/CardinalityAggregationSpec.groovy
@@ -36,7 +36,8 @@ class CardinalityAggregationSpec extends Specification {
     }
 
     def setup() {
-        constrainedTable = TableTestUtils.buildTable("table",
+        constrainedTable = TableTestUtils.buildTable(
+                "table",
                 DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                 [] as Set,
                 ["d1ApiName": "d1DruidName", "d2ApiName": "d2DruidName"],

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSourceSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSourceSpec.groovy
@@ -3,7 +3,7 @@
 package com.yahoo.bard.webservice.druid.model.datasource
 
 import com.yahoo.bard.webservice.data.dimension.Dimension
-import com.yahoo.bard.webservice.table.PhysicalTable
+import com.yahoo.bard.webservice.table.ConstrainedTable
 
 import spock.lang.Specification
 
@@ -11,8 +11,8 @@ class UnionDataSourceSpec extends Specification {
     Dimension dimension1
     Dimension dimension2
 
-    PhysicalTable table1
-    PhysicalTable table2
+    ConstrainedTable table1
+    ConstrainedTable table2
 
     def setup() {
         dimension1 = Mock(Dimension)
@@ -21,8 +21,8 @@ class UnionDataSourceSpec extends Specification {
         dimension1.getApiName() >> "example"
         dimension2.getApiName() >> "otherExample"
 
-        table1 = Mock(PhysicalTable)
-        table2 = Mock(PhysicalTable)
+        table1 = Mock(ConstrainedTable)
+        table2 = Mock(ConstrainedTable)
     }
 
     def "check duplicate physical mappings for same name fails"() {
@@ -32,7 +32,7 @@ class UnionDataSourceSpec extends Specification {
         table1.getDimensions() >> [dimension1]
         table2.getDimensions() >> [dimension1]
 
-        Set<PhysicalTable> tables = [table1, table2]
+        Set<ConstrainedTable> tables = [table1, table2]
 
         when:
         new UnionDataSource(tables)
@@ -48,7 +48,7 @@ class UnionDataSourceSpec extends Specification {
         table1.getDimensions() >> [dimension1]
         table2.getDimensions() >> [dimension1]
 
-        Set<PhysicalTable> tables = [table1, table2]
+        Set<ConstrainedTable> tables = [table1, table2]
 
         when:
         new UnionDataSource(tables)
@@ -65,7 +65,7 @@ class UnionDataSourceSpec extends Specification {
         table1.getPhysicalColumnName("otherExample") >> "otherMapping"
         table2.getPhysicalColumnName("example") >> "woot"
 
-        Set<PhysicalTable> tables = [table1, table2]
+        Set<ConstrainedTable> tables = [table1, table2]
 
         when:
         new UnionDataSource(tables)
@@ -83,7 +83,7 @@ class UnionDataSourceSpec extends Specification {
         table1.getPhysicalColumnName("otherExample") >> "otherMapping"
         table2.getPhysicalColumnName("example") >> "woot"
 
-        Set<PhysicalTable> tables = [table1, table2]
+        Set<ConstrainedTable> tables = [table1, table2]
 
         when:
         new UnionDataSource(tables)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/DruidSearchQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/DruidSearchQuerySpec.groovy
@@ -2,11 +2,8 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.query
 
-
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 
-import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionField
 import com.yahoo.bard.webservice.data.dimension.MapStore
@@ -16,6 +13,8 @@ import com.yahoo.bard.webservice.druid.model.DefaultQueryType
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
 import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter
 import com.yahoo.bard.webservice.druid.model.orderby.DefaultSearchSortDirection
+import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
+import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -46,7 +45,7 @@ class DruidSearchQuerySpec extends Specification {
     DruidSearchQuery defaultQuery(Map vars) {
         vars.queryType = DefaultQueryType.SEARCH
         vars.dataSource = vars.dataSource ?: new TableDataSource(
-                new ConcretePhysicalTable(
+                TableTestUtils.buildTable(
                         "table_name",
                         DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                         [] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
@@ -73,13 +73,6 @@ class GroupByQuerySpec extends Specification {
             ArithmeticPostAggregation.ArithmeticPostAggregationFunction.DIVIDE,
             [postAggregation1, postAggregation2]
     )
-    ConstrainedTable constrainedTable = buildTable(
-            "table_name",
-            day,
-            [] as Set,
-            ["apiLocale": "locale", "apiPlatform": "platform", "apiProduct": "product"],
-            Mock(DataSourceMetadataService)
-    )
 
     def setup() {
         LinkedHashSet<DimensionField> dimensionFields = new LinkedHashSet<>()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.druid.model.query
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
+import static com.yahoo.bard.webservice.table.TableTestUtils.buildTable
 
 import com.yahoo.bard.webservice.data.dimension.BardDimensionField
 import com.yahoo.bard.webservice.data.dimension.Dimension
@@ -28,7 +29,7 @@ import com.yahoo.bard.webservice.druid.model.postaggregation.FieldAccessorPostAg
 import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.ConstrainedTable
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -72,7 +73,13 @@ class GroupByQuerySpec extends Specification {
             ArithmeticPostAggregation.ArithmeticPostAggregationFunction.DIVIDE,
             [postAggregation1, postAggregation2]
     )
-
+    ConstrainedTable constrainedTable = buildTable(
+            "table_name",
+            day,
+            [] as Set,
+            ["apiLocale": "locale", "apiPlatform": "platform", "apiProduct": "product"],
+            Mock(DataSourceMetadataService)
+    )
 
     def setup() {
         LinkedHashSet<DimensionField> dimensionFields = new LinkedHashSet<>()
@@ -103,16 +110,15 @@ class GroupByQuerySpec extends Specification {
     }
 
     GroupByQuery defaultQuery(Map vars) {
-
-        vars.dataSource = vars.dataSource ?: new TableDataSource<GroupByQuery>(
-                new ConcretePhysicalTable(
-                        "table_name",
-                        day,
-                        [] as Set,
-                        ["apiLocale": "locale", "apiPlatform": "platform", "apiProduct": "product"],
-                        Mock(DataSourceMetadataService)
-                )
+        ConstrainedTable constrainedTable = buildTable(
+                "table_name",
+                day,
+                [] as Set,
+                ["apiLocale": "locale", "apiPlatform": "platform", "apiProduct": "product"],
+                Mock(DataSourceMetadataService)
         )
+
+        vars.dataSource = vars.dataSource ?: new TableDataSource<GroupByQuery>(constrainedTable)
         vars.granularity = vars.granularity ?: DAY
         vars.dimensions = vars.dimensions ?: new ArrayList<Dimension>()
         vars.filter = vars.filter ?: null
@@ -192,7 +198,7 @@ class GroupByQuerySpec extends Specification {
 
     def "check dataSource serialization"() {
         //non nested query
-        DataSource ds1 = new TableDataSource(new ConcretePhysicalTable("table_name", day, [] as Set, [:], Mock(DataSourceMetadataService)))
+        DataSource ds1 = new TableDataSource(buildTable("table_name", day, [] as Set, [:], Mock(DataSourceMetadataService)))
         GroupByQuery dq1 = defaultQuery(dataSource: ds1)
 
         //nested query
@@ -478,8 +484,12 @@ class GroupByQuerySpec extends Specification {
 
     def "Check innermost query injection"() {
         setup:
-        TableDataSource inner1 = new TableDataSource(new ConcretePhysicalTable("inner1", day, [] as Set, [:], Mock(DataSourceMetadataService)))
-        TableDataSource inner2 = new TableDataSource(new ConcretePhysicalTable("inner2", day, [] as Set, [:], Mock(DataSourceMetadataService)))
+        TableDataSource inner1 = new TableDataSource(
+                buildTable("inner1", day, [] as Set, [:], Mock(DataSourceMetadataService))
+        )
+        TableDataSource inner2 = new TableDataSource(
+                buildTable("inner2", day, [] as Set, [:], Mock(DataSourceMetadataService))
+        )
         GroupByQuery dq1 = defaultQuery(dataSource: inner1)
         DataSource outer1 = new QueryDataSource(dq1)
         GroupByQuery dq2 = defaultQuery(dataSource: outer1)
@@ -500,7 +510,7 @@ class GroupByQuerySpec extends Specification {
         List<Interval> endingIntervals = [Interval.parse("2016/2017")]
 
         and: "A nested query"
-        TableDataSource table = new TableDataSource(new ConcretePhysicalTable("inner1", day, [] as Set, [:], Mock(DataSourceMetadataService)))
+        TableDataSource table = new TableDataSource(buildTable("inner1", day, [] as Set, [:], Mock(DataSourceMetadataService)))
         GroupByQuery inner = defaultQuery(dataSource: table, intervals: startingIntervals)
         GroupByQuery middle = defaultQuery(dataSource: new QueryDataSource<>(inner), intervals: startingIntervals)
         GroupByQuery outer = defaultQuery(dataSource: new QueryDataSource<>(middle), intervals: startingIntervals)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/SegmentMetadataQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/SegmentMetadataQuerySpec.groovy
@@ -6,7 +6,7 @@ import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -34,7 +34,7 @@ class SegmentMetadataQuerySpec extends Specification {
     def "SegmentMetadataQuery serializes to JSON correctly with one interval"() {
         given: "A Table data source and interval"
         String tableName = "basefact_network"
-        DataSource dataSource = new TableDataSource(new ConcretePhysicalTable(
+        DataSource dataSource = new TableDataSource(TableTestUtils.buildTable(
                 tableName,
                 DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                 [] as Set,
@@ -63,7 +63,7 @@ class SegmentMetadataQuerySpec extends Specification {
     def "SegmentMetadataQuery serializes to JSON correctly with multiple intervals"() {
         given: "A Table data source and interval"
         String tableName = "basefact_network"
-        DataSource dataSource = new TableDataSource(new ConcretePhysicalTable(
+        DataSource dataSource = new TableDataSource(TableTestUtils.buildTable(
                 tableName,
                 DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                 [] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeBoundaryQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeBoundaryQuerySpec.groovy
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.druid.model.query
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -23,7 +23,7 @@ class TimeBoundaryQuerySpec extends Specification {
         given: "A Table data source"
         String tableName = "basefact_network"
         TableDataSource dataSource = new TableDataSource(
-                new ConcretePhysicalTable(
+                TableTestUtils.buildTable(
                         tableName,
                         DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                         [] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuerySpec.groovy
@@ -8,7 +8,7 @@ import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
 import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -38,7 +38,7 @@ class TimeSeriesQuerySpec extends Specification {
 
     TimeSeriesQuery defaultQuery(Map vars) {
 
-        vars.dataSource = vars.dataSource ?: new TableDataSource(new ConcretePhysicalTable(
+        vars.dataSource = vars.dataSource ?: new TableDataSource(TableTestUtils.buildTable(
                 "table_name",
                 DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                 [] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TopNQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TopNQuerySpec.groovy
@@ -14,7 +14,7 @@ import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
 import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -44,7 +44,7 @@ class TopNQuerySpec extends Specification {
 
     TopNQuery defaultQuery(Map vars) {
 
-        vars.dataSource = vars.dataSource ?: new TableDataSource<TopNQuery>(new ConcretePhysicalTable(
+        vars.dataSource = vars.dataSource ?: new TableDataSource<TopNQuery>(TableTestUtils.buildTable(
                 "table_name",
                 DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                 [] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
@@ -14,8 +14,8 @@ import com.yahoo.bard.webservice.druid.model.query.LookbackQuery
 import com.yahoo.bard.webservice.druid.model.query.LookbackQuerySpec
 import com.yahoo.bard.webservice.druid.model.query.TimeSeriesQuery
 import com.yahoo.bard.webservice.druid.model.query.TimeSeriesQuerySpec
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary
+import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.DefaultingDictionary
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
@@ -102,7 +102,7 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
         timeSeriesQuery = timeSeriesQuerySpec.defaultQuery(
                 intervals: [interval2],
                 dataSource: new TableDataSource(
-                        new ConcretePhysicalTable(
+                        TableTestUtils.buildTable(
                                 tableName, DefaultTimeGrain.DAY.buildZonedTimeGrain(UTC),
                                 [] as Set,
                                 [:],

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/MetricUnionCompositeTableDefinitionSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/MetricUnionCompositeTableDefinitionSpec.groovy
@@ -26,7 +26,7 @@ class MetricUnionCompositeTableDefinitionSpec extends Specification {
                 [] as Set
         )
 
-        PhysicalTable physicalTable = Mock(PhysicalTable)
+        ConfigPhysicalTable physicalTable = Mock(ConfigPhysicalTable)
         ResourceDictionaries resourceDictionaries = Mock(ResourceDictionaries)
         resourceDictionaries.getPhysicalDictionary() >> [(existing.asName()) : physicalTable]
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/TableTestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/TableTestUtils.groovy
@@ -1,0 +1,22 @@
+//  Copyright 2017 Yahoo Inc.
+//  Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table
+
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain
+import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
+import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
+
+class TableTestUtils {
+
+    static List buildConcreteAndConstrained(String name, ZonedTimeGrain grain, Set<Column> columns, Map<String, String> nameMap, DataSourceMetadataService service) {
+        ConcretePhysicalTable table = new ConcretePhysicalTable( name, grain, columns, nameMap, service)
+        DataSourceConstraint constraint = DataSourceConstraint.emptyConstraint(table)
+        return [table, table.withConstraint(constraint)]
+    }
+
+    static ConstrainedTable buildTable(String name, ZonedTimeGrain grain, Set<Column> columns, Map<String, String> nameMap, DataSourceMetadataService service) {
+        ConcretePhysicalTable table = new ConcretePhysicalTable( name, grain, columns, nameMap, service)
+        DataSourceConstraint constraint = DataSourceConstraint.emptyConstraint(table)
+        return table.withConstraint(constraint)
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/TableTestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/TableTestUtils.groovy
@@ -10,13 +10,13 @@ class TableTestUtils {
 
     static List buildConcreteAndConstrained(String name, ZonedTimeGrain grain, Set<Column> columns, Map<String, String> nameMap, DataSourceMetadataService service) {
         ConcretePhysicalTable table = new ConcretePhysicalTable( name, grain, columns, nameMap, service)
-        DataSourceConstraint constraint = DataSourceConstraint.emptyConstraint(table)
+        DataSourceConstraint constraint = DataSourceConstraint.unconstrained(table)
         return [table, table.withConstraint(constraint)]
     }
 
     static ConstrainedTable buildTable(String name, ZonedTimeGrain grain, Set<Column> columns, Map<String, String> nameMap, DataSourceMetadataService service) {
         ConcretePhysicalTable table = new ConcretePhysicalTable( name, grain, columns, nameMap, service)
-        DataSourceConstraint constraint = DataSourceConstraint.emptyConstraint(table)
+        DataSourceConstraint constraint = DataSourceConstraint.unconstrained(table)
         return table.withConstraint(constraint)
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.table.availability
 import com.yahoo.bard.webservice.data.config.names.TableName
 import com.yahoo.bard.webservice.data.metric.MetricColumn
 import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.PhysicalTable
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
@@ -28,10 +28,10 @@ class MetricUnionAvailabilitySpec extends Specification {
     Column metricColumn1
     Column metricColumn2
 
-    PhysicalTable physicalTable1
-    PhysicalTable physicalTable2
+    ConfigPhysicalTable physicalTable1
+    ConfigPhysicalTable physicalTable2
 
-    Set<PhysicalTable> physicalTables
+    Set<ConfigPhysicalTable> physicalTables
 
     MetricUnionAvailability metricUnionAvailability
 
@@ -48,8 +48,8 @@ class MetricUnionAvailabilitySpec extends Specification {
         metricColumn1 = new MetricColumn(metric1)
         metricColumn2 = new MetricColumn(metric2)
 
-        physicalTable1 = Mock(PhysicalTable)
-        physicalTable2 = Mock(PhysicalTable)
+        physicalTable1 = Mock(ConfigPhysicalTable)
+        physicalTable2 = Mock(ConfigPhysicalTable)
 
         physicalTable1.getAvailability() >> availability1
         physicalTable2.getAvailability() >> availability2
@@ -138,7 +138,7 @@ class MetricUnionAvailabilitySpec extends Specification {
 
         metricUnionAvailability = new MetricUnionAvailability(physicalTables, Collections.emptySet())
 
-        PhysicalTable physicalTable3 = Mock(PhysicalTable)
+        ConfigPhysicalTable physicalTable3 = Mock(ConfigPhysicalTable)
         physicalTable3.getAvailability() >> metricUnionAvailability
         MetricUnionAvailability outerMetricUnionAvailability = new MetricUnionAvailability(
                 [physicalTable3] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraintSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraintSpec.groovy
@@ -1,0 +1,26 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.resolver
+
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
+import com.yahoo.bard.webservice.util.ClassScanner
+import com.yahoo.bard.webservice.web.DataApiRequest
+
+import spock.lang.Specification
+
+class QueryPlanningConstraintSpec extends Specification {
+
+    def supplyDependencies() {
+        {
+            ClassScanner classScanner, Class aClass ->
+            DataApiRequest dataApiRequest = Mock(DataApiRequest)
+            dataApiRequest.getDimensions() >> ([] as Set)
+            dataApiRequest.getFilterDimensions() >> ([] as Set)
+            dataApiRequest.getFilters() >> [:]
+            dataApiRequest.getIntervals() >> ([] as Set)
+            dataApiRequest.getLogicalMetrics() >> ([] as Set)
+            dataApiRequest.getGranularity() >> (DefaultTimeGrain.DAY)
+            classScanner.putInArgumentValueCache(DataApiRequest.class, dataApiRequest)
+        }
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraintSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/QueryPlanningConstraintSpec.groovy
@@ -3,7 +3,6 @@
 package com.yahoo.bard.webservice.table.resolver
 
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
-import com.yahoo.bard.webservice.util.ClassScanner
 import com.yahoo.bard.webservice.web.DataApiRequest
 
 import spock.lang.Specification
@@ -11,16 +10,13 @@ import spock.lang.Specification
 class QueryPlanningConstraintSpec extends Specification {
 
     def supplyDependencies() {
-        {
-            ClassScanner classScanner, Class aClass ->
-            DataApiRequest dataApiRequest = Mock(DataApiRequest)
-            dataApiRequest.getDimensions() >> ([] as Set)
-            dataApiRequest.getFilterDimensions() >> ([] as Set)
-            dataApiRequest.getFilters() >> [:]
-            dataApiRequest.getIntervals() >> ([] as Set)
-            dataApiRequest.getLogicalMetrics() >> ([] as Set)
-            dataApiRequest.getGranularity() >> (DefaultTimeGrain.DAY)
-            classScanner.putInArgumentValueCache(DataApiRequest.class, dataApiRequest)
-        }
+        DataApiRequest dataApiRequest = Mock(DataApiRequest)
+        dataApiRequest.getDimensions() >> ([] as Set)
+        dataApiRequest.getFilterDimensions() >> ([] as Set)
+        dataApiRequest.getFilters() >> [:]
+        dataApiRequest.getIntervals() >> ([] as Set)
+        dataApiRequest.getLogicalMetrics() >> ([] as Set)
+        dataApiRequest.getGranularity() >> (DefaultTimeGrain.DAY)
+        [(DataApiRequest.class): dataApiRequest]
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
@@ -111,6 +111,13 @@ class ClassScannerSpec extends Specification {
     @IgnoreIf({ ClassScannerSpec.getClassesDeclaring("equals", Object.class).empty })
     @Unroll
     def "test equals #cls.simpleName"() {
+        setup:
+        try {
+            Class dependencyClass = Class.forName("${cls.name}Spec")
+            dependencyClass.newInstance()."supplyDependencies"().call(classScanner, cls);
+        } catch( Exception ignore ) {
+        }
+
         expect:
         // Create test object with default values
         Object obj1 = classScanner.constructObject( cls, ClassScanner.Args.VALUES )

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
@@ -113,8 +113,11 @@ class ClassScannerSpec extends Specification {
     def "test equals #cls.simpleName"() {
         setup:
         try {
-            Class dependencyClass = Class.forName("${cls.name}Spec")
-            dependencyClass.newInstance()."supplyDependencies"().call(classScanner, cls);
+            // Allow class specs to define well formed dependencies
+            Map<Class, Object> dependencies = Class.forName("${cls.name}Spec").newInstance().supplyDependencies()
+            dependencies.each {
+                classScanner.putInArgumentValueCache(it.key, it.value)
+            }
         } catch( Exception ignore ) {
         }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
@@ -107,6 +107,10 @@ class ClassScannerSpec extends Specification {
      * This method is ignored if no declaring classes will trigger the where block.
      * This is an issue because downstream developers may want to defensively deploy subclasses of this class to
      * ensure that any legitimate class scanner targets are picked up when discovered and appropriate.
+     * <p>
+     * This method also allows for supplying dependencies for the class under test. To do so, the method will call
+     * <tt>Map&lt;Class, Object&gt; supplyDependencies()</tt> on a Spec file for the class under test (eg.
+     * <tt>ClassUnderTestSpec</tt> if such a Spec exists with that method.
      */
     @IgnoreIf({ ClassScannerSpec.getClassesDeclaring("equals", Object.class).empty })
     @Unroll

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/RequestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/RequestUtils.groovy
@@ -15,9 +15,8 @@ import com.yahoo.bard.webservice.druid.model.orderby.TopNMetric
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.druid.model.query.TimeSeriesQuery
 import com.yahoo.bard.webservice.druid.model.query.TopNQuery
-import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.TableTestUtils
 
 import org.joda.time.DateTimeZone
 
@@ -30,7 +29,7 @@ class RequestUtils {
             List postAggregations = []
     ) {
         DataSource dataSource = new TableDataSource(
-                new ConcretePhysicalTable(
+                TableTestUtils.buildTable(
                         dataSourceName,
                         DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                         [] as Set,
@@ -61,7 +60,7 @@ class RequestUtils {
             List postAggregations = []
     ) {
         DataSource dataSource = new TableDataSource(
-                new ConcretePhysicalTable(
+                TableTestUtils.buildTable(
                         dataSourceName,
                         DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                         [] as Set,
@@ -90,7 +89,7 @@ class RequestUtils {
             List postAggregations = []
     ) {
         DataSource dataSource = new TableDataSource(
-                new ConcretePhysicalTable(
+                TableTestUtils.buildTable(
                         dataSourceName,
                         DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                         [] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandlerSpec.groovy
@@ -43,7 +43,6 @@ class PartialDataRequestHandlerSpec extends Specification {
     MappingResponseProcessor response = Mock(MappingResponseProcessor)
     SimplifiedIntervalList availableIntervals
 
-
     PartialDataRequestHandler handler = new PartialDataRequestHandler(
             next,
             partialDataHandler

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandlerSpec.groovy
@@ -10,8 +10,8 @@ import com.yahoo.bard.webservice.data.metric.mappers.PartialDataResultSetMapper
 import com.yahoo.bard.webservice.data.metric.mappers.ResultSetMapper
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
+import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.ConstrainedTable
-import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 import com.yahoo.bard.webservice.web.DataApiRequest
@@ -23,6 +23,8 @@ import org.joda.time.Interval
 
 import spock.lang.Specification
 
+import java.util.stream.Stream
+
 import javax.ws.rs.core.MultivaluedHashMap
 import javax.ws.rs.core.MultivaluedMap
 
@@ -32,7 +34,7 @@ class PartialDataRequestHandlerSpec extends Specification {
 
     DataRequestHandler next = Mock(DataRequestHandler)
     PhysicalTableDictionary physicalTableDictionary = Mock(PhysicalTableDictionary)
-    Set<? extends PhysicalTable> physicalTables = [Mock(ConstrainedTable)] as Set
+    Set<ConcretePhysicalTable> physicalTables = [Mock(ConstrainedTable)] as Set
     PartialDataHandler partialDataHandler = Mock(PartialDataHandler)
 
     RequestContext rc = Mock(RequestContext)
@@ -76,7 +78,7 @@ class PartialDataRequestHandlerSpec extends Specification {
         then:
         success
         1 * partialDataHandler.findMissingTimeGrainIntervals(
-                physicalTables,
+                _ as Stream<ConstrainedTable>,
                 new SimplifiedIntervalList(apiRequest.intervals),
                 apiRequest.granularity
         ) >> intervals
@@ -107,7 +109,7 @@ class PartialDataRequestHandlerSpec extends Specification {
         then:
         success
         1 * partialDataHandler.findMissingTimeGrainIntervals(
-                physicalTables,
+                _ as Stream<ConstrainedTable>,
                 new SimplifiedIntervalList(apiRequest.intervals),
                 apiRequest.granularity
         ) >> nonEmptyIntervals
@@ -151,7 +153,7 @@ class PartialDataRequestHandlerSpec extends Specification {
         then:
         success
         1 * partialDataHandler.findMissingTimeGrainIntervals(
-                physicalTables,
+                _ as Stream<ConstrainedTable>,
                 new SimplifiedIntervalList(apiRequest.intervals),
                 apiRequest.granularity
         ) >> nonEmptyIntervals

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandlerSpec.groovy
@@ -10,9 +10,9 @@ import com.yahoo.bard.webservice.data.metric.mappers.PartialDataResultSetMapper
 import com.yahoo.bard.webservice.data.metric.mappers.ResultSetMapper
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
+import com.yahoo.bard.webservice.table.ConstrainedTable
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary
-import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 import com.yahoo.bard.webservice.web.DataApiRequest
 import com.yahoo.bard.webservice.web.responseprocessors.MappingResponseProcessor
@@ -32,7 +32,7 @@ class PartialDataRequestHandlerSpec extends Specification {
 
     DataRequestHandler next = Mock(DataRequestHandler)
     PhysicalTableDictionary physicalTableDictionary = Mock(PhysicalTableDictionary)
-    Set<PhysicalTable> physicalTables = [Mock(PhysicalTable)] as Set
+    Set<? extends PhysicalTable> physicalTables = [Mock(ConstrainedTable)] as Set
     PartialDataHandler partialDataHandler = Mock(PartialDataHandler)
 
     RequestContext rc = Mock(RequestContext)
@@ -43,7 +43,6 @@ class PartialDataRequestHandlerSpec extends Specification {
 
     PartialDataRequestHandler handler = new PartialDataRequestHandler(
             next,
-            physicalTableDictionary,
             partialDataHandler
     )
 
@@ -55,8 +54,9 @@ class PartialDataRequestHandlerSpec extends Specification {
         groupByQuery.getDependentFieldNames() >> Collections.emptySet()
         groupByQuery.getInnermostQuery() >> groupByQuery
         groupByQuery.getDataSource() >> dataSource
-        physicalTableDictionary.get(_) >> physicalTables[0]
-        dataSource.getNames() >> ["name"]
+        //physicalTableDictionary.get(_) >> physicalTables[0]
+        //dataSource.getNames() >> ["name"]
+        dataSource.getPhysicalTables() >> physicalTables
     }
 
     def cleanup() {
@@ -76,7 +76,6 @@ class PartialDataRequestHandlerSpec extends Specification {
         then:
         success
         1 * partialDataHandler.findMissingTimeGrainIntervals(
-                _ as DataSourceConstraint,
                 physicalTables,
                 new SimplifiedIntervalList(apiRequest.intervals),
                 apiRequest.granularity
@@ -108,7 +107,6 @@ class PartialDataRequestHandlerSpec extends Specification {
         then:
         success
         1 * partialDataHandler.findMissingTimeGrainIntervals(
-                _ as DataSourceConstraint,
                 physicalTables,
                 new SimplifiedIntervalList(apiRequest.intervals),
                 apiRequest.granularity
@@ -153,7 +151,6 @@ class PartialDataRequestHandlerSpec extends Specification {
         then:
         success
         1 * partialDataHandler.findMissingTimeGrainIntervals(
-                _ as DataSourceConstraint,
                 physicalTables,
                 new SimplifiedIntervalList(apiRequest.intervals),
                 apiRequest.granularity

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
@@ -29,8 +29,8 @@ import com.yahoo.bard.webservice.druid.model.query.Granularity
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.logging.RequestLog
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.Schema
+import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.web.DataApiRequest
 import com.yahoo.bard.webservice.web.ResponseFormatType
 
@@ -146,7 +146,9 @@ class ResultSetResponseProcessorSpec extends Specification {
         groupByQuery.getDimensions() >> dimensions
         groupByQuery.getAggregations() >> aggregations
         groupByQuery.getPostAggregations() >> postAggs
-        groupByQuery.getDataSource() >> new TableDataSource(new ConcretePhysicalTable("table_name", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [] as Set, ["dimension1":"dimension1"], Mock(DataSourceMetadataService)))
+        groupByQuery.getDataSource() >> new TableDataSource(
+                TableTestUtils.buildTable("table_name", DAY.buildZonedTimeGrain(DateTimeZone.UTC), [] as Set, ["dimension1":"dimension1"], Mock(DataSourceMetadataService))
+        )
 
         ResultSetSchema schema = new ResultSetSchema(DAY, Sets.newHashSet(new MetricColumn("lm1")))
 


### PR DESCRIPTION
Create a ConstrainedTable that applies DataSourceConstraints to a Table and caches and closes over that constraint.

Switch to using the ConstrainedTable in the post-query space.

Remove getAvailability from the general TableSpace and make a ConfigPhysicalTable subinterface to expose availability.

This feature is necessary to allow `DataSourceConstraint` filtered datasources on query serialization.