### PR TITLE
Fix data sourec name disparity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,10 @@ Current
 
 ### Deprecated:
 
+- [Remove `PhysicalTable::getTableName` to use `getName` instead](https://github.com/yahoo/fili/pull/263)
+    * Having more than 1 method for the same concept (ie. what's the name of this physical table) was confusing and not
+      very useful.
+
 - [Remove `PhysicalTableDictionary` dependency from `SegmentIntervalHashIdGenerator`](https://github.com/yahoo/fili/pull/263)
     * Constructors taking the dictionary have been deprecated, since it is not used any more
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Current
 -------
 ### Added:
 
+- [Add `DataSourceName` concept, removing responsibility from `TableName`](https://github.com/yahoo/fili/pull/263)
+    * `TableName` was serving double-duty, and it was causing problems and confusion. Splitting the concepts fixes it.
+
+- [Add a `BaseMetadataAvailability` as a parallel to `BaseCompositeAvailability`](https://github.com/yahoo/fili/pull/263)
+    * `Concrete` and `PermissiveAvailability` both extend this new base `Availability`
+
 - [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
     * Add ConstrainedTable which closes over a physical table and an availability, caching all availability merges.
     * Add PartialDataHandler method to use `ConstrainedTable`
@@ -114,6 +120,22 @@ Current
 - [Support timeouts for lucene search provider](https://github.com/yahoo/fili/pull/183)
 
 ### Changed:
+
+- [Make `PermissiveConcretePhysicalTable` a sibling, instead of extend from, `ConcretePhysicalTable`](https://github.com/yahoo/fili/pull/263)
+    * The main difference is in the accepted availabilities, so make the class structure match that.
+
+- [Make `MetricUnionAvailability` take a set of `Availability` instead of `PhysicalTable`](https://github.com/yahoo/fili/pull/263)
+    * Since it was just unwrapping anyways, simplifying the dependency and pushing the unwrap up-stream makes sense
+
+- [Add `DataSourceName` concept, removing responsibility from `TableName`](https://github.com/yahoo/fili/pull/263)
+    * Impacts:
+        - `DataSource` & children
+        - `DataSourceMetadataService` & `DataSourceMetadataLoader`
+        - `SegmentIntervalsHashIdGenerator`
+        - `PhysicalTable` & children
+        - `Availability` & children
+        - `ErrorMessageFormat`
+        - `SlicesApiRequest`
 
 - [Force `ConcretePhysicalTable` only take a `ConcreteAvailability`](https://github.com/yahoo/fili/pull/263)
     * Only a `ConcreteAvailability` makes sense, so let the types enforce it
@@ -311,6 +333,11 @@ Current
     * Converted to 404 when error was cause by not finding a path element
 
 ### Deprecated:
+
+- [Add `DataSourceName` concept, removing responsibility from `TableName`](https://github.com/yahoo/fili/pull/263)
+    * Impacts:
+        - `DataSourceMetadataService` & `DataSourceMetadataLoader`
+        - `ConcretePhysicalTable`
 
 - [Deprecate old static `TableName` comparator](https://github.com/yahoo/fili/pull/263)
     * Change to `AS_NAME_COMPARATOR`, so the old name is deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,9 +130,8 @@ Current
     * `UnionDataSource` now accepts only single tables instead of sets of tables.
     * `DataSource` now supports getDataSource() operation
     * `IntervalUtils.collectBucketedIntervalsNotInIntervalList` moved to `PartialDataHandler`
-    
-    
-- [Druid filters are now lazy.](https://github.com/yahoo/fili/pull/269)
+
+- [Druid filters are now lazy](https://github.com/yahoo/fili/pull/269)
     - The Druid filter is built when requested, NOT at DatApiRequest construction. This will
         make it easier to write performant `DataApiRequest` mappers.
 
@@ -140,6 +139,9 @@ Current
     * Customers who aren't using the asynchronous infrastructure shouldn't be seeing spurious warnings about a failure
         to execute one step (which is a no-op for them) in a complex system they aren't using. Until we can revisit how
         we log report asynchronous errors, we reduce the log level to `DEBUG` to reduce noise.
+
+- [Make `BasePhysicalTable` take a more extension-friendly set of `PhysicalTable`s](https://github.com/yahoo/fili/pull/263)
+    * Take `<? extends PhysicalTable>` instead of just `PhysicalTable`
 
 - [Update availabilities for PartitionAvailability](https://github.com/yahoo/fili/pull/244)
     * Created `BaseCompositeAvailability` for common features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ Current
 - [Make `PermissiveConcretePhysicalTable` and `ConcretePhysicalTable` extend from a common base](https://github.com/yahoo/fili/pull/263)
     * Makes the structure match that for composite tables, so they can be reasoned about together.
 
-- [Make `PermissiveConcretePhysicalTable` a sibling, instead of extend from, `ConcretePhysicalTable`](https://github.com/yahoo/fili/pull/263)
+- [Make `PermissiveConcretePhysicalTable` (now just `PermissivePhysicalTable`) a sibling, instead of extend from, `ConcretePhysicalTable`](https://github.com/yahoo/fili/pull/263)
     * The main difference is in the accepted availabilities, so make the class structure match that.
 
 - [Make `MetricUnionAvailability` take a set of `Availability` instead of `PhysicalTable`](https://github.com/yahoo/fili/pull/263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,9 @@ Current
 
 ### Deprecated:
 
+- [Remove `PhysicalTableDictionary` dependency from `SegmentIntervalHashIdGenerator`](https://github.com/yahoo/fili/pull/263)
+    * Constructors taking the dictionary have been deprecated, since it is not used any more
+
 - [Add `DataSourceName` concept, removing responsibility from `TableName`](https://github.com/yahoo/fili/pull/263)
     * Impacts:
         - `DataSourceMetadataService` & `DataSourceMetadataLoader`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,9 @@ Current
 
 ### Changed:
 
+- [Rename `Concrete` to `Strict` for the respective `PhysicalTable` and `Availability`](https://github.com/yahoo/fili/pull/263)
+    * The main difference is in the availability reduction, so make the class name match that.
+
 - [Make `PermissiveConcretePhysicalTable` and `ConcretePhysicalTable` extend from a common base](https://github.com/yahoo/fili/pull/263)
     * Makes the structure match that for composite tables, so they can be reasoned about together.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ Current
 
 ### Changed:
 
+- [Force `ConcretePhysicalTable` only take a `ConcreteAvailability`](https://github.com/yahoo/fili/pull/263)
+    * Only a `ConcreteAvailability` makes sense, so let the types enforce it
+
 - [Clarify name of built-in static `TableName` comparator](https://github.com/yahoo/fili/pull/263)
     * Change to `AS_NAME_COMPARATOR`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@ Current
         to execute one step (which is a no-op for them) in a complex system they aren't using. Until we can revisit how
         we log report asynchronous errors, we reduce the log level to `DEBUG` to reduce noise.
 
+- [Clean up `BaseDataSourceComponentSpec`](https://github.com/yahoo/fili/pull/263)
+    * Drop a log from `error` to `trace` when a response comes back as an error
+    * Make JSON validation helpers return `boolean` instead of `def`
+
 - [Make `BasePhysicalTable` take a more extension-friendly set of `PhysicalTable`s](https://github.com/yahoo/fili/pull/263)
     * Take `<? extends PhysicalTable>` instead of just `PhysicalTable`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ Current
 
 ### Changed:
 
+- [Clarify name of built-in static `TableName` comparator](https://github.com/yahoo/fili/pull/263)
+    * Change to `AS_NAME_COMPARATOR`
+
 - [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
     * Switched `PartialDataRequestHandler` to use the table from the query rather than the `PhysicalTableDictionary`
     * `DruidQueryBuilder` uses constrained tables to dynamically pick between Union and Table DataSource implementations
@@ -305,6 +308,9 @@ Current
     * Converted to 404 when error was cause by not finding a path element
 
 ### Deprecated:
+
+- [Deprecate old static `TableName` comparator](https://github.com/yahoo/fili/pull/263)
+    * Change to `AS_NAME_COMPARATOR`, so the old name is deprecated
 
 - [Constrained Table Support for Table Serialization](https://github.com/yahoo/fili/pull/262/files)
     * Deprecated static empty instance of SimplifiedIntervalList.NO_INTERVALS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,9 @@ Current
 
 ### Changed:
 
+- [Make `PermissiveConcretePhysicalTable` and `ConcretePhysicalTable` extend from a common base](https://github.com/yahoo/fili/pull/263)
+    * Makes the structure match that for composite tables, so they can be reasoned about together.
+
 - [Make `PermissiveConcretePhysicalTable` a sibling, instead of extend from, `ConcretePhysicalTable`](https://github.com/yahoo/fili/pull/263)
     * The main difference is in the accepted availabilities, so make the class structure match that.
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -624,11 +624,7 @@ public abstract class AbstractBinderFactory implements BinderFactory {
             PhysicalTableDictionary physicalTableDictionary,
             DataSourceMetadataService dataSourceMetadataService
     ) {
-        return new SegmentIntervalsHashIdGenerator(
-                physicalTableDictionary,
-                dataSourceMetadataService,
-                buildSigningFunctions()
-        );
+        return new SegmentIntervalsHashIdGenerator(dataSourceMetadataService, buildSigningFunctions());
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -312,7 +312,7 @@ public abstract class AbstractBinderFactory implements BinderFactory {
                 if (SYSTEM_CONFIG.getBooleanProperty(DEPRECATED_PERMISSIVE_AVAILABILITY_FLAG, false)) {
                     LOG.warn(
                             "Permissive column availability feature flag is no longer supported, please use " +
-                                    "PermissiveConcretePhysicalTable to enable permissive column availability.");
+                                    "PermissivePhysicalTable to enable permissive column availability.");
                 }
                 // Call post-binding hook to allow for additional binding
                 afterBinding(this);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -785,7 +785,7 @@ public abstract class AbstractBinderFactory implements BinderFactory {
      * @return The list of valid feature flags
      */
     protected List<FeatureFlag> collectFeatureFlags() {
-        return Collections.<FeatureFlag>emptyList();
+        return Collections.emptyList();
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/DruidDimensionsLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/DruidDimensionsLoader.java
@@ -17,8 +17,8 @@ import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.DruidSearchQuery;
 import com.yahoo.bard.webservice.druid.model.query.RegexSearchQuerySpec;
 import com.yahoo.bard.webservice.druid.model.query.SearchQuerySpec;
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
+import com.yahoo.bard.webservice.table.StrictPhysicalTable;
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
 import com.yahoo.bard.webservice.web.handlers.RequestContext;
 
@@ -134,7 +134,7 @@ public class DruidDimensionsLoader extends Loader<Boolean> {
                 .collect(Collectors.toList());
 
         this.dataSources = physicalTableDictionary.values().stream()
-                .filter(physicalTable -> physicalTable instanceof ConcretePhysicalTable)
+                .filter(physicalTable -> physicalTable instanceof StrictPhysicalTable)
                 .map(table -> table.withConstraint(DataSourceConstraint.unconstrained(table)))
                 .map(TableDataSource::new)
                 .collect(Collectors.toList());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/DruidDimensionsLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/DruidDimensionsLoader.java
@@ -17,8 +17,8 @@ import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.DruidSearchQuery;
 import com.yahoo.bard.webservice.druid.model.query.RegexSearchQuerySpec;
 import com.yahoo.bard.webservice.druid.model.query.SearchQuerySpec;
+import com.yahoo.bard.webservice.table.ConcretePhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
-import com.yahoo.bard.webservice.table.availability.ConcreteAvailability;
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
 import com.yahoo.bard.webservice.web.handlers.RequestContext;
 
@@ -134,7 +134,7 @@ public class DruidDimensionsLoader extends Loader<Boolean> {
                 .collect(Collectors.toList());
 
         this.dataSources = physicalTableDictionary.values().stream()
-                .filter(physicalTable -> physicalTable.getAvailability() instanceof ConcreteAvailability)
+                .filter(physicalTable -> physicalTable instanceof ConcretePhysicalTable)
                 .map(table -> table.withConstraint(DataSourceConstraint.unconstrained(table)))
                 .map(TableDataSource::new)
                 .collect(Collectors.toList());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/DataSourceName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/DataSourceName.java
@@ -1,26 +1,18 @@
-// Copyright 2016 Yahoo Inc.
+// Copyright 2017 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.config.names;
 
 import java.util.Comparator;
 
 /**
- * Marker interface for objects that can be treated as a table name.
+ * Marker interface for objects that can be treated as a data source name in druid.
  */
-public interface TableName {
+public interface DataSourceName {
 
     /**
-     * Comparator to order TableNames by their asName methods, using the native String comparator.
+     * Comparator to order DataSourceNames by their asName methods, using the native String comparator.
      */
-    Comparator<TableName> AS_NAME_COMPARATOR = Comparator.comparing(TableName::asName);
-
-    /**
-     * Comparator to order TableNames by their asName methods, using the native String comparator.
-     *
-     * @deprecated due to name change. Use AS_NAME_COMPARATOR instead.
-     */
-    @Deprecated
-    Comparator<TableName> COMPARATOR = Comparator.comparing(TableName::asName);
+    Comparator<DataSourceName> AS_NAME_COMPARATOR = Comparator.comparing(DataSourceName::asName);
 
     /**
      * Return a string representation of a table name.
@@ -33,12 +25,12 @@ public interface TableName {
      * Wrap a string in an anonymous instance of TableName.
      * Rather than make heavy use of this, instead make a class.
      *
-     * @param name the name being wrapped
+     * @param name   The name being wrapped
      *
      * @return an anonymous subclass instance of TableName
      */
-    static TableName of(String name) {
-        return new TableName() {
+    static DataSourceName of(String name) {
+        return new DataSourceName() {
             @Override
             public String asName() {
                 return name;
@@ -51,8 +43,8 @@ public interface TableName {
 
             @Override
             public boolean equals(Object o) {
-                if (o != null && o instanceof TableName) {
-                    return name.equals(((TableName) o).asName());
+                if (o != null && o instanceof DataSourceName) {
+                    return name.equals(((DataSourceName) o).asName());
                 }
                 return false;
             }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/TableName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/TableName.java
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.data.config.names;
 import java.util.Comparator;
 
 /**
- * Marker interface for objects that can be treated as a table name in druid or web services.
+ * Marker interface for objects that can be treated as a table name.
  */
 public interface TableName {
 
@@ -54,5 +54,13 @@ public interface TableName {
     /**
      * Comparator to order TableNames by their asName methods, using the native String comparator.
      */
+    Comparator<TableName> AS_NAME_COMPARATOR = Comparator.comparing(TableName::asName);
+
+    /**
+     * Comparator to order TableNames by their asName methods, using the native String comparator.
+     *
+     * @deprecated due to name change. Use AS_NAME_COMPARATOR instead.
+     */
+    @Deprecated
     Comparator<TableName> COMPARATOR = Comparator.comparing(TableName::asName);
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/TableName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/TableName.java
@@ -51,5 +51,8 @@ public interface TableName {
         };
     }
 
+    /**
+     * Comparator to order TableNames by their asName methods, using the native String comparator.
+     */
     Comparator<TableName> COMPARATOR = Comparator.comparing(TableName::asName);
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
@@ -8,8 +8,8 @@ import com.yahoo.bard.webservice.data.config.names.FieldName;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable;
 import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
+import com.yahoo.bard.webservice.table.StrictPhysicalTable;
 
 import java.util.Collections;
 import java.util.Map;
@@ -63,7 +63,7 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
 
     @Override
     public ConfigPhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
-        return new ConcretePhysicalTable(
+        return new StrictPhysicalTable(
                         getName(),
                         getTimeGrain(),
                         buildColumns(dictionaries.getDimensionDictionary()),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PermissivePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PermissivePhysicalTableDefinition.java
@@ -9,25 +9,25 @@ import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
-import com.yahoo.bard.webservice.table.PermissiveConcretePhysicalTable;
+import com.yahoo.bard.webservice.table.PermissivePhysicalTable;
 
 import java.util.Map;
 import java.util.Set;
 
 /**
- * Holds the fields needed to define a Permissive Concrete Physical Table.
+ * Holds the fields needed to define a Permissive Physical Table.
  */
-public class PermissiveConcretePhysicalTableDefinition extends ConcretePhysicalTableDefinition {
+public class PermissivePhysicalTableDefinition extends ConcretePhysicalTableDefinition {
 
     /**
-     * Define a permissive concrete physical table.
+     * Define a permissive physical table.
      *
      * @param name  The table name
      * @param timeGrain  The zoned time grain
      * @param metricNames  The Set of metric names on the table
      * @param dimensionConfigs  The dimension configurations
      */
-    public PermissiveConcretePhysicalTableDefinition(
+    public PermissivePhysicalTableDefinition(
             TableName name,
             ZonedTimeGrain timeGrain,
             Set<FieldName> metricNames,
@@ -37,7 +37,7 @@ public class PermissiveConcretePhysicalTableDefinition extends ConcretePhysicalT
     }
 
     /**
-     * Define a permissive concrete physical table with provided logical to physical column name mappings.
+     * Define a permissive physical table with provided logical to physical column name mappings.
      *
      * @param name  The table name
      * @param timeGrain  The zoned time grain
@@ -45,7 +45,7 @@ public class PermissiveConcretePhysicalTableDefinition extends ConcretePhysicalT
      * @param dimensionConfigs  The dimension configurations
      * @param logicalToPhysicalNames  A map from logical column names to physical column names
      */
-    public PermissiveConcretePhysicalTableDefinition(
+    public PermissivePhysicalTableDefinition(
             TableName name,
             ZonedTimeGrain timeGrain,
             Set<FieldName> metricNames,
@@ -62,7 +62,7 @@ public class PermissiveConcretePhysicalTableDefinition extends ConcretePhysicalT
             ResourceDictionaries dictionaries,
             DataSourceMetadataService metadataService
     ) {
-        return new PermissiveConcretePhysicalTable(
+        return new PermissivePhysicalTable(
                 getName(),
                 getTimeGrain(),
                 buildColumns(dictionaries.getDimensionDictionary()),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -68,10 +68,14 @@ public abstract class DataSource {
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Set<String> getNames() {
-        return Collections.unmodifiableSet((LinkedHashSet<String>) getPhysicalTable().getDataSourceNames().stream()
+        return getPhysicalTable().getDataSourceNames().stream()
                 .map(TableName::asName)
-                .collect(Collectors.toCollection(LinkedHashSet::new))
-        );
+                .collect(
+                        Collectors.collectingAndThen(
+                                Collectors.toCollection(LinkedHashSet::new),
+                                Collections::unmodifiableSet
+                        )
+                );
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/DataSource.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.datasource;
 
-import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 import com.yahoo.bard.webservice.table.ConstrainedTable;
 
@@ -69,7 +69,7 @@ public abstract class DataSource {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public Set<String> getNames() {
         return getPhysicalTable().getDataSourceNames().stream()
-                .map(TableName::asName)
+                .map(DataSourceName::asName)
                 .collect(
                         Collectors.collectingAndThen(
                                 Collectors.toCollection(LinkedHashSet::new),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/datasource/TableDataSource.java
@@ -2,9 +2,15 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.datasource;
 
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.TOO_FEW_BACKING_DATA_SOURCES;
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.TOO_MANY_BACKING_DATA_SOURCES;
+
 import com.yahoo.bard.webservice.table.ConstrainedTable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 
@@ -13,17 +19,27 @@ import java.util.Set;
  */
 public class TableDataSource extends DataSource {
 
+    private static final Logger LOG = LoggerFactory.getLogger(TableDataSource.class);
+
     /**
      * Constructor.
      *
-     * @param physicalTable  The physical table of the data source
+     * @param physicalTable  The physical table of the data source. It must have only 1 backing data source.
      */
     public TableDataSource(ConstrainedTable physicalTable) {
         super(DefaultDataSourceType.TABLE, physicalTable);
+        if (physicalTable.getDataSourceNames().size() > 1) {
+            LOG.error(TOO_MANY_BACKING_DATA_SOURCES.logFormat(getPhysicalTable()));
+            throw new IllegalArgumentException(TOO_MANY_BACKING_DATA_SOURCES.format(getPhysicalTable()));
+        }
     }
 
     public String getName() {
-        return getPhysicalTable().getTableName().asName();
+        return getPhysicalTable().getDataSourceNames().stream().findFirst()
+                .orElseThrow(() -> {
+                    LOG.error(TOO_FEW_BACKING_DATA_SOURCES.logFormat(getPhysicalTable()));
+                    return new IllegalArgumentException(TOO_FEW_BACKING_DATA_SOURCES.format(getPhysicalTable()));
+                }).asName();
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoader.java
@@ -13,9 +13,9 @@ import com.yahoo.bard.webservice.druid.client.DruidWebService;
 import com.yahoo.bard.webservice.druid.client.FailureCallback;
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
 import com.yahoo.bard.webservice.druid.client.SuccessCallback;
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
+import com.yahoo.bard.webservice.table.SingleDataSourcePhysicalTable;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -115,7 +115,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
      * @deprecated  Pass the DataSourceName directly, rather than via the PhysicalTable
      */
     @Deprecated
-    protected void queryDataSourceMetadata(ConcretePhysicalTable table) {
+    protected void queryDataSourceMetadata(SingleDataSourcePhysicalTable table) {
         queryDataSourceMetadata(table.getDataSourceName());
     }
 
@@ -192,7 +192,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
      * @deprecated  Pass the DataSourceName directly, rather than via the PhysicalTable
      */
     @Deprecated
-    protected final SuccessCallback buildDataSourceMetadataSuccessCallback(ConcretePhysicalTable table) {
+    protected final SuccessCallback buildDataSourceMetadataSuccessCallback(SingleDataSourcePhysicalTable table) {
         return buildDataSourceMetadataSuccessCallback(table.getDataSourceName());
     }
 
@@ -282,7 +282,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
      * @deprecated  Pass the DataSourceName directly, rather than via the PhysicalTable
      */
     @Deprecated
-    protected HttpErrorCallback getErrorCallback(ConcretePhysicalTable table) {
+    protected HttpErrorCallback getErrorCallback(SingleDataSourcePhysicalTable table) {
         return getErrorCallback(table.getDataSourceName());
     }
 
@@ -311,7 +311,7 @@ public class DataSourceMetadataLoader extends Loader<Boolean> {
          * @deprecated  Pass the DataSourceName directly, rather than via the PhysicalTable
          */
         @Deprecated
-        TaskHttpErrorCallback(ConcretePhysicalTable table) {
+        TaskHttpErrorCallback(SingleDataSourcePhysicalTable table) {
             this(table.getDataSourceName());
         }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataService.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataService.java
@@ -77,7 +77,7 @@ public class DataSourceMetadataService {
      *
      * @param physicalTableName  The table to get the column and availability for
      *
-     * @return a map of column name to a set of avialable intervals
+     * @return a map of column name to a set of available intervals
      */
     public Map<String, SimplifiedIntervalList> getAvailableIntervalsByTable(TableName physicalTableName) {
         if (!allSegmentsByColumn.containsKey(physicalTableName)) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGenerator.java
@@ -30,11 +30,6 @@ public class SegmentIntervalsHashIdGenerator implements QuerySigningService<Long
     private static final Logger LOG = LoggerFactory.getLogger(SegmentIntervalsHashIdGenerator.class);
 
     /**
-     * The dictionary of the physical tables.
-     */
-    private final PhysicalTableDictionary physicalTableDictionary;
-
-    /**
      * Maps a Class (type of query) to the Function that should be used to compute requestedIntervals for a given query.
      */
     private final Map<Class, RequestedIntervalsFunction> requestedIntervalsQueryExtractionFunctions;
@@ -51,13 +46,29 @@ public class SegmentIntervalsHashIdGenerator implements QuerySigningService<Long
      * @param dataSourceMetadataService  A Service to get information about segment metadata
      * @param requestedIntervalsQueryExtractionFunctions  Maps a Class to the Function that should be used to compute
      * requestedIntervals for a given query
+     *
+     * @deprecated  phyiscalTableDictionary is not used
      */
+    @Deprecated
     public SegmentIntervalsHashIdGenerator(
             PhysicalTableDictionary physicalTableDictionary,
             DataSourceMetadataService dataSourceMetadataService,
             Map<Class, RequestedIntervalsFunction> requestedIntervalsQueryExtractionFunctions
     ) {
-        this.physicalTableDictionary = physicalTableDictionary;
+        this(dataSourceMetadataService, requestedIntervalsQueryExtractionFunctions);
+    }
+
+    /**
+     * Build a SegmentIntervalsHashIdGenerator that generates a segmentId using the provided signingFunctions.
+     *
+     * @param dataSourceMetadataService  A Service to get information about segment metadata
+     * @param requestedIntervalsQueryExtractionFunctions  Maps a Class to the Function that should be used to compute
+     * requestedIntervals for a given query
+     */
+    public SegmentIntervalsHashIdGenerator(
+            DataSourceMetadataService dataSourceMetadataService,
+            Map<Class, RequestedIntervalsFunction> requestedIntervalsQueryExtractionFunctions
+    ) {
         this.dataSourceMetadataService = dataSourceMetadataService;
         this.requestedIntervalsQueryExtractionFunctions = requestedIntervalsQueryExtractionFunctions;
     }
@@ -66,15 +77,27 @@ public class SegmentIntervalsHashIdGenerator implements QuerySigningService<Long
      * Build a SegmentIntervalsHashIdGenerator that uses the raw simplified intervals of a druidAggregationQuery to
      * create a segmentId.
      *
-     * @param physicalTableDictionary  The dictionary of the physical tables
-     * @param dataSourceMetadataService  A Service to get information about segment metadata
+     * @param physicalTableDictionary The dictionary of the physical tables
+     * @param dataSourceMetadataService A Service to get information about segment metadata
+     *
+     * @deprecated  phyiscalTableDictionary is not used
      */
+    @Deprecated
     public SegmentIntervalsHashIdGenerator(
             PhysicalTableDictionary physicalTableDictionary,
             DataSourceMetadataService dataSourceMetadataService
     ) {
+        this(dataSourceMetadataService);
+    }
+
+    /**
+     * Build a SegmentIntervalsHashIdGenerator that uses the raw simplified intervals of a druidAggregationQuery to
+     * create a segmentId.
+     *
+     * @param dataSourceMetadataService A Service to get information about segment metadata
+     */
+    public SegmentIntervalsHashIdGenerator(DataSourceMetadataService dataSourceMetadataService) {
         this(
-                physicalTableDictionary,
                 dataSourceMetadataService,
                 new DefaultingDictionary<>(
                         druidAggregationQuery -> new SimplifiedIntervalList(druidAggregationQuery.getIntervals())

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGenerator.java
@@ -4,8 +4,8 @@ package com.yahoo.bard.webservice.metadata;
 
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.DRUID_METADATA_SEGMENTS_MISSING;
 
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
-import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
 import com.yahoo.bard.webservice.util.DefaultingDictionary;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
@@ -84,23 +84,22 @@ public class SegmentIntervalsHashIdGenerator implements QuerySigningService<Long
 
     @Override
     public Optional<Long> getSegmentSetId(DruidAggregationQuery<?> query) {
-        //get physical tables
-        Set<String> tableNames = query.getInnermostQuery().getDataSource().getNames();
-        Set<PhysicalTable> physicalTables = tableNames.stream()
-                .map(physicalTableDictionary::get)
+        // Gather the data source names backing the query
+        Set<DataSourceName> dataSourceNames = query.getInnermostQuery()
+                .getDataSource()
+                .getPhysicalTable()
+                .getDataSourceNames()
+                .stream()
                 .collect(Collectors.toSet());
 
-        //get all table segments
-        Set<SortedMap<DateTime, Map<String, SegmentInfo>>> tableSegments =
-                dataSourceMetadataService.getTableSegments(
-                        physicalTables.stream()
-                                .map(PhysicalTable::getTableName)
-                                .collect(Collectors.toSet())
-                );
+        // Get all the segments for the data sources of the query's physical tables
+        Set<SortedMap<DateTime, Map<String, SegmentInfo>>> tableSegments = dataSourceMetadataService.getSegments(
+                dataSourceNames
+        );
 
         // Check if we have no tables with segments
         if (tableSegments.isEmpty()) {
-            LOG.warn(DRUID_METADATA_SEGMENTS_MISSING.logFormat(tableNames));
+            LOG.warn(DRUID_METADATA_SEGMENTS_MISSING.logFormat(dataSourceNames));
             return Optional.empty();
         }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
@@ -71,8 +71,7 @@ public abstract class BaseCompositePhysicalTable extends BasePhysicalTable {
 
         Set<String> unsatisfied = physicalTables.stream()
                 .filter(tableDoesNotSatisfy)
-                .map(PhysicalTable::getTableName)
-                .map(TableName::asName)
+                .map(PhysicalTable::getName)
                 .collect(Collectors.toSet());
 
         if (!unsatisfied.isEmpty()) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
@@ -53,29 +53,29 @@ public abstract class BaseCompositePhysicalTable extends BasePhysicalTable {
     }
 
     /**
-     * Verifies that the coarsest ZonedTimeGrain satisfies all tables.
+     * Verifies that the ZonedTimeGrain satisfies all tables.
      *
-     * @param timeGrain  The coarsest ZonedTimeGrain being validated
-     * @param physicalTables  A set of PhysicalTables whose ZonedTimeGrains are checked to make sure
-     * they all satisfies with the given coarsest ZonedTimeGrain
+     * @param timeGrain  The ZonedTimeGrain being validated
+     * @param physicalTables  A set of PhysicalTables whose ZonedTimeGrains are checked to make sure they all satisfy
+     * the given ZonedTimeGrain
      *
-     * @throws IllegalArgumentException when there is no mutually satisfying grain among the table's time grains
+     * @throws IllegalArgumentException when the grain is not satisfied by the tables' time grains
      */
     private void verifyGrainSatisfiesAllSourceTables(
             ZonedTimeGrain timeGrain,
             Set<? extends PhysicalTable> physicalTables
     ) throws IllegalArgumentException {
-        Predicate<PhysicalTable> tableDoesNotSatisfyFilter = (physicalTable) -> ! physicalTable.getSchema()
+        Predicate<PhysicalTable> tableDoesNotSatisfy = physicalTable -> !physicalTable.getSchema()
                 .getTimeGrain()
                 .satisfies(timeGrain);
 
         Set<String> unsatisfied = physicalTables.stream()
-                .filter(tableDoesNotSatisfyFilter)
+                .filter(tableDoesNotSatisfy)
                 .map(PhysicalTable::getTableName)
                 .map(TableName::asName)
                 .collect(Collectors.toSet());
 
-        if (! unsatisfied.isEmpty()) {
+        if (!unsatisfied.isEmpty()) {
             String message = String.format(
                     "Time grain: '%s' cannot be satisfied by source table(s) %s",
                     timeGrain,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table;
 
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.table.availability.Availability;
@@ -14,6 +15,7 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -63,13 +65,20 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
     }
 
     @Override
-    public Availability getAvailability() {
-        return availability;
+    public Set<DataSourceName> getDataSourceNames() {
+        // TODO: Once the availability setter is removed from this class, move this to the constructor
+        return getAvailability().getDataSourceNames().stream()
+                .collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
     }
 
     @Override
     public PhysicalTableSchema getSchema() {
         return schema;
+    }
+
+    @Override
+    public Availability getAvailability() {
+        return availability;
     }
 
     @Override
@@ -130,11 +139,6 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
     public ConstrainedTable withConstraint(DataSourceConstraint constraint) {
         validateConstraintSchema(constraint);
         return new ConstrainedTable(this, new PhysicalDataSourceConstraint(constraint, getSchema()));
-    }
-
-    @Override
-    public Set<TableName> getDataSourceNames() {
-        return getAvailability().getDataSourceNames();
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BasePhysicalTable.java
@@ -29,7 +29,8 @@ import javax.validation.constraints.NotNull;
 public abstract class BasePhysicalTable implements ConfigPhysicalTable {
     private static final Logger LOG = LoggerFactory.getLogger(BasePhysicalTable.class);
 
-    private final TableName name;
+    private final String name;
+    private final TableName tableName;
     private final PhysicalTableSchema schema;
     private Availability availability;
 
@@ -49,19 +50,20 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
             @NotNull Map<String, String> logicalToPhysicalColumnNames,
             @NotNull Availability availability
     ) {
-        this.name = name;
+        this.name = name.asName();
+        this.tableName = name;
         this.availability = availability;
         this.schema = new PhysicalTableSchema(timeGrain, columns, logicalToPhysicalColumnNames);
     }
 
     @Override
     public TableName getTableName() {
-        return name;
+        return tableName;
     }
 
     @Override
     public String getName() {
-        return getTableName().asName();
+        return name;
     }
 
     @Override
@@ -170,7 +172,7 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
         }
         if (obj instanceof BasePhysicalTable) {
             BasePhysicalTable that = (BasePhysicalTable) obj;
-            return Objects.equals(name.asName(), that.name.asName())
+            return Objects.equals(name, that.name)
                     && Objects.equals(schema, that.schema)
                     && Objects.equals(availability, that.availability);
         }
@@ -179,14 +181,14 @@ public abstract class BasePhysicalTable implements ConfigPhysicalTable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name.asName(), schema, availability);
+        return Objects.hash(name, schema, availability);
     }
 
     @Override
     public String toString() {
         return String.format(
                 "Physical table: '%s', schema: '%s', availability: '%s'",
-                name.asName(),
+                name,
                 schema,
                 availability
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
@@ -23,7 +23,7 @@ public class ConcretePhysicalTable extends BasePhysicalTable {
     /**
      * Create a concrete physical table.
      *
-     * @param name  Name of the physical table as TableName, also used as fact table name
+     * @param name  Name of the physical table as TableName, also used as data source name
      * @param timeGrain  time grain of the table
      * @param columns  The columns for this table
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table;
 
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
@@ -17,7 +18,7 @@ import javax.validation.constraints.NotNull;
  */
 public class ConcretePhysicalTable extends BasePhysicalTable {
 
-    private final String factTableName;
+    private final DataSourceName dataSourceName;
 
     /**
      * Create a concrete physical table.
@@ -40,7 +41,7 @@ public class ConcretePhysicalTable extends BasePhysicalTable {
                 timeGrain,
                 columns,
                 logicalToPhysicalColumnNames,
-                new ConcreteAvailability(name, metadataService)
+                new ConcreteAvailability(DataSourceName.of(name.asName()), metadataService)
         );
     }
 
@@ -67,7 +68,7 @@ public class ConcretePhysicalTable extends BasePhysicalTable {
                 logicalToPhysicalColumnNames,
                 availability
         );
-        this.factTableName = name.asName();
+        this.dataSourceName = availability.getDataSourceName();
     }
 
     /**
@@ -93,7 +94,24 @@ public class ConcretePhysicalTable extends BasePhysicalTable {
         this(TableName.of(name), timeGrain, columns, logicalToPhysicalColumnNames, metadataService);
     }
 
+    /**
+     * Get the name of the fact table.
+     *
+     * @return the name of the fact table.
+     *
+     * @deprecated  Use getDataSourceName instead.
+     */
+    @Deprecated
     public String getFactTableName() {
-        return factTableName;
+        return getDataSourceName().asName();
+    }
+
+    public DataSourceName getDataSourceName() {
+        return dataSourceName;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " datasourceName: " + getDataSourceName();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
@@ -5,7 +5,6 @@ package com.yahoo.bard.webservice.table;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
-import com.yahoo.bard.webservice.table.availability.Availability;
 import com.yahoo.bard.webservice.table.availability.ConcreteAvailability;
 
 import java.util.Map;
@@ -59,7 +58,7 @@ public class ConcretePhysicalTable extends BasePhysicalTable {
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,
             @NotNull Map<String, String> logicalToPhysicalColumnNames,
-            @NotNull Availability availability
+            @NotNull ConcreteAvailability availability
     ) {
         super(
                 name,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConcretePhysicalTable.java
@@ -16,9 +16,7 @@ import javax.validation.constraints.NotNull;
 /**
  * An implementation of Physical table that is backed by a single fact table.
  */
-public class ConcretePhysicalTable extends BasePhysicalTable {
-
-    private final DataSourceName dataSourceName;
+public class ConcretePhysicalTable extends SingleDataSourcePhysicalTable {
 
     /**
      * Create a concrete physical table.
@@ -68,7 +66,6 @@ public class ConcretePhysicalTable extends BasePhysicalTable {
                 logicalToPhysicalColumnNames,
                 availability
         );
-        this.dataSourceName = availability.getDataSourceName();
     }
 
     /**
@@ -104,10 +101,6 @@ public class ConcretePhysicalTable extends BasePhysicalTable {
     @Deprecated
     public String getFactTableName() {
         return getDataSourceName().asName();
-    }
-
-    public DataSourceName getDataSourceName() {
-        return dataSourceName;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConfigPhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConfigPhysicalTable.java
@@ -10,9 +10,9 @@ import com.yahoo.bard.webservice.table.availability.Availability;
 public interface ConfigPhysicalTable extends PhysicalTable  {
 
     /**
-     * Get the value of the actual availability for this physical table.
+     * Get the value of the backing availability instance for this physical table.
      *
-     * @return The current actual physical availability or a runtime exception if there isn't one yet.
+     * @return The availability or a runtime exception if there isn't one.
      */
     Availability getAvailability();
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/ConstrainedTable.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table;
 
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.table.availability.Availability;
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
@@ -22,7 +23,7 @@ public class ConstrainedTable implements PhysicalTable {
 
     private final DataSourceConstraint constraint;
     private final PhysicalTable sourceTable;
-    private final Set<TableName> dataSourceNames;
+    private final Set<DataSourceName> dataSourceNames;
     private final SimplifiedIntervalList availableIntervals;
     private final Map<Column, SimplifiedIntervalList> allAvailableIntervals;
 
@@ -62,7 +63,7 @@ public class ConstrainedTable implements PhysicalTable {
         return constraint;
     }
 
-    private PhysicalTable getSourceTable() {
+    public PhysicalTable getSourceTable() {
         return sourceTable;
     }
 
@@ -77,7 +78,7 @@ public class ConstrainedTable implements PhysicalTable {
     }
 
     @Override
-    public Set<TableName> getDataSourceNames() {
+    public Set<DataSourceName> getDataSourceNames() {
         return dataSourceNames;
     }
 
@@ -129,7 +130,7 @@ public class ConstrainedTable implements PhysicalTable {
      * @return A set of tablenames for backing dataSources
      */
     @Override
-    public Set<TableName> getDataSourceNames(DataSourceConstraint constraint) {
+    public Set<DataSourceName> getDataSourceNames(DataSourceConstraint constraint) {
         if (getConstraint().equals(constraint)) {
             return getDataSourceNames();
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
@@ -51,8 +51,8 @@ public class MetricUnionCompositeTable extends BaseCompositePhysicalTable {
      * @param name  Name that represents set of fact table names joined together
      * @param timeGrain  The time grain of the table. The time grain has to satisfy all grains of the tables
      * @param columns  The columns for this table
-     * @param physicalTables  A set of PhysicalTables that are put together under this table. The
-     * tables shall have zoned time grains that all satisfy the provided timeGrain
+     * @param physicalTables  A set of PhysicalTables that are put together under this table. The tables shall have
+     * zoned time grains that all satisfy the provided timeGrain
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
      */
     public MetricUnionCompositeTable(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
@@ -8,6 +8,7 @@ import com.yahoo.bard.webservice.table.availability.MetricUnionAvailability;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
@@ -68,7 +69,10 @@ public class MetricUnionCompositeTable extends BaseCompositePhysicalTable {
                 columns,
                 physicalTables,
                 logicalToPhysicalColumnNames,
-                new MetricUnionAvailability(physicalTables, columns)
+                new MetricUnionAvailability(
+                        physicalTables.stream().map(ConfigPhysicalTable::getAvailability).collect(Collectors.toSet()),
+                        columns
+                )
         );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
@@ -15,12 +15,12 @@ import javax.validation.constraints.NotNull;
 /**
  * An implementation of concrete physical table with permissive availability.
  * <p>
- * This is different from its parent <tt>ConcretePhysicalTable</tt>. <tt>PermissiveConcretePhysicalTable</tt>
- * is backed <tt>PermissiveAvailability</tt>. As a result, {@link ConfigPhysicalTable#getAvailability()} will return
- * the <tt>PermissiveAvailability</tt>. Returning a different <tt>Availability</tt> affects how available intervals
- * of a table are calculated and returned.
- * For example see {@link PhysicalTable#getAvailableIntervals()}
- * {@link PhysicalTable#getAllAvailableIntervals()}, and {@link PhysicalTable#getTableAlignment()}.
+ * This is different from its parent {@link ConcretePhysicalTable}. {@link PermissiveConcretePhysicalTable} is backed
+ * {@link PermissiveAvailability}. The different {@link Availability} affects how available intervals of a table are
+ * calculated and returned.
+ * <p>
+ * For example see {@link PhysicalTable#getAvailableIntervals()}, {@link PhysicalTable#getAllAvailableIntervals()}, and
+ * {@link PhysicalTable#getTableAlignment()}.
  */
 public class PermissiveConcretePhysicalTable extends ConcretePhysicalTable {
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissiveConcretePhysicalTable.java
@@ -23,9 +23,7 @@ import javax.validation.constraints.NotNull;
  * For example see {@link PhysicalTable#getAvailableIntervals()}, {@link PhysicalTable#getAllAvailableIntervals()}, and
  * {@link PhysicalTable#getTableAlignment()}.
  */
-public class PermissiveConcretePhysicalTable extends BasePhysicalTable {
-
-    private final DataSourceName dataSourceName;
+public class PermissiveConcretePhysicalTable extends SingleDataSourcePhysicalTable {
 
     /**
      * Create a permissive concrete physical table.
@@ -75,11 +73,6 @@ public class PermissiveConcretePhysicalTable extends BasePhysicalTable {
                 logicalToPhysicalColumnNames,
                 availability
         );
-        this.dataSourceName = availability.getDataSourceName();
-    }
-
-    public DataSourceName getDataSourceName() {
-        return dataSourceName;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissivePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissivePhysicalTable.java
@@ -14,9 +14,9 @@ import java.util.Set;
 import javax.validation.constraints.NotNull;
 
 /**
- * A sibling of concrete physical table, but with permissive availability.
+ * A sibling of strict physical table, but with permissive availability.
  * <p>
- * This is different from {@link ConcretePhysicalTable}. {@link PermissivePhysicalTable} is backed by
+ * This is different from {@link StrictPhysicalTable}. {@link PermissivePhysicalTable} is backed by
  * {@link PermissiveAvailability}. The different Availability affects how available intervals of the table are
  * calculated and returned.
  * <p>

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissivePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PermissivePhysicalTable.java
@@ -16,17 +16,17 @@ import javax.validation.constraints.NotNull;
 /**
  * A sibling of concrete physical table, but with permissive availability.
  * <p>
- * This is different from {@link ConcretePhysicalTable}. {@link PermissiveConcretePhysicalTable} is backed by
+ * This is different from {@link ConcretePhysicalTable}. {@link PermissivePhysicalTable} is backed by
  * {@link PermissiveAvailability}. The different Availability affects how available intervals of the table are
  * calculated and returned.
  * <p>
  * For example see {@link PhysicalTable#getAvailableIntervals()}, {@link PhysicalTable#getAllAvailableIntervals()}, and
  * {@link PhysicalTable#getTableAlignment()}.
  */
-public class PermissiveConcretePhysicalTable extends SingleDataSourcePhysicalTable {
+public class PermissivePhysicalTable extends SingleDataSourcePhysicalTable {
 
     /**
-     * Create a permissive concrete physical table.
+     * Create a permissive physical table.
      *
      * @param name  Name of the physical table as TableName
      * @param timeGrain  time grain of the table
@@ -34,7 +34,7 @@ public class PermissiveConcretePhysicalTable extends SingleDataSourcePhysicalTab
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
      * @param metadataService  Data source metadata service containing availability data for the table
      */
-    public PermissiveConcretePhysicalTable(
+    public PermissivePhysicalTable(
             @NotNull TableName name,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,
@@ -51,7 +51,7 @@ public class PermissiveConcretePhysicalTable extends SingleDataSourcePhysicalTab
     }
 
     /**
-     * Create a permissive concrete physical table.
+     * Create a permissive physical table.
      *
      * @param name  Name of the physical table as TableName
      * @param timeGrain  time grain of the table
@@ -59,7 +59,7 @@ public class PermissiveConcretePhysicalTable extends SingleDataSourcePhysicalTab
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
      * @param availability  Availability that serves interval availability for columns
      */
-    public PermissiveConcretePhysicalTable(
+    public PermissivePhysicalTable(
             @NotNull TableName name,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -39,6 +39,16 @@ public interface PhysicalTable extends Table {
     }
 
     /**
+     * Get the name of the table.
+     *
+     * @return name of the table as TableName
+     *
+     * @deprecated  Use Table::getName instead
+     */
+    @Deprecated
+    TableName getTableName();
+
+    /**
      * Return a view of the available intervals for this table given a constraint.
      *
      * @param constraint  The constraint which limits available intervals
@@ -107,13 +117,6 @@ public interface PhysicalTable extends Table {
      * table's time grain.
      */
     DateTime getTableAlignment();
-
-    /**
-     * Get the name of the current table.
-     *
-     * @return name of the table as TableName
-     */
-    TableName getTableName();
 
     /**
      * Get the time grain from granularity.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/PhysicalTable.java
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.table;
 
 import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
@@ -62,20 +63,20 @@ public interface PhysicalTable extends Table {
     }
 
     /**
-     * Return the {@link TableName} of the dataSources which back this table.
+     * Get the names of the data sources that back this physical table.
      *
-     * @return A set of tablenames for backing dataSources
+     * @return the names of all data sources that back this physical table.
      */
-    Set<TableName> getDataSourceNames();
+    Set<DataSourceName> getDataSourceNames();
 
     /**
-     * Return the {@link TableName} of the dataSources which back this table given a constraint.
+     * Return the {@link DataSourceName} of the dataSources which back this table given a constraint.
      *
      * @param constraint  A constraint which may narrow the data sources participating.
      *
-     * @return A set of tablenames for backing dataSources, given the constraints
+     * @return A set of names for backing dataSources, given the constraints
      */
-    default Set<TableName> getDataSourceNames(DataSourceConstraint constraint) {
+    default Set<DataSourceName> getDataSourceNames(DataSourceConstraint constraint) {
         return getDataSourceNames();
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/SingleDataSourcePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/SingleDataSourcePhysicalTable.java
@@ -1,0 +1,47 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table;
+
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
+import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
+import com.yahoo.bard.webservice.table.availability.BaseMetadataAvailability;
+
+import java.util.Map;
+
+/**
+ * A Physical Table that should be backed by a Metadata-based Availability that has only a single data source.
+ */
+public abstract class SingleDataSourcePhysicalTable extends BasePhysicalTable {
+
+    private final DataSourceName dataSourceName;
+
+    /**
+     * Constructor.
+     *
+     * @param name  Name of the physical table as TableName
+     * @param timeGrain  time grain of the table
+     * @param columns  The columns for this table
+     * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
+     * @param availability  Availability that serves interval availability for columns
+     */
+    public SingleDataSourcePhysicalTable(
+            TableName name,
+            ZonedTimeGrain timeGrain,
+            Iterable<Column> columns,
+            Map<String, String> logicalToPhysicalColumnNames,
+            BaseMetadataAvailability availability
+    ) {
+        super(name, timeGrain, columns, logicalToPhysicalColumnNames, availability);
+        this.dataSourceName = availability.getDataSourceName();
+    }
+
+    public DataSourceName getDataSourceName() {
+        return dataSourceName;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s datasourceName: %s ", super.toString(), getDataSourceName());
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/StrictPhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/StrictPhysicalTable.java
@@ -6,7 +6,7 @@ import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
-import com.yahoo.bard.webservice.table.availability.ConcreteAvailability;
+import com.yahoo.bard.webservice.table.availability.StrictAvailability;
 
 import java.util.Map;
 import java.util.Set;
@@ -14,12 +14,12 @@ import java.util.Set;
 import javax.validation.constraints.NotNull;
 
 /**
- * An implementation of Physical table that is backed by a single fact table.
+ * An implementation of Physical table that is backed by a single fact table and has intersect availability.
  */
-public class ConcretePhysicalTable extends SingleDataSourcePhysicalTable {
+public class StrictPhysicalTable extends SingleDataSourcePhysicalTable {
 
     /**
-     * Create a concrete physical table.
+     * Create a strict physical table.
      *
      * @param name  Name of the physical table as TableName, also used as data source name
      * @param timeGrain  time grain of the table
@@ -27,7 +27,7 @@ public class ConcretePhysicalTable extends SingleDataSourcePhysicalTable {
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
      * @param metadataService  Datasource metadata service containing availability data for the table
      */
-    public ConcretePhysicalTable(
+    public StrictPhysicalTable(
             @NotNull TableName name,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,
@@ -39,12 +39,12 @@ public class ConcretePhysicalTable extends SingleDataSourcePhysicalTable {
                 timeGrain,
                 columns,
                 logicalToPhysicalColumnNames,
-                new ConcreteAvailability(DataSourceName.of(name.asName()), metadataService)
+                new StrictAvailability(DataSourceName.of(name.asName()), metadataService)
         );
     }
 
     /**
-     * Create a concrete physical table, the availability on this table is built externally.
+     * Create a strict physical table with the availability on this table built externally.
      *
      * @param name  Name of the physical table as TableName, also used as fact table name
      * @param timeGrain  time grain of the table
@@ -52,12 +52,12 @@ public class ConcretePhysicalTable extends SingleDataSourcePhysicalTable {
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
      * @param availability  Availability that serves interval availability for columns
      */
-    public ConcretePhysicalTable(
+    public StrictPhysicalTable(
             @NotNull TableName name,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,
             @NotNull Map<String, String> logicalToPhysicalColumnNames,
-            @NotNull ConcreteAvailability availability
+            @NotNull StrictAvailability availability
     ) {
         super(
                 name,
@@ -69,7 +69,7 @@ public class ConcretePhysicalTable extends SingleDataSourcePhysicalTable {
     }
 
     /**
-     * Create a concrete physical table.
+     * Create a strict physical table.
      * The fact table name will be defaulted to the name and the availability initialized to empty intervals.
      *
      * @param name  Name of the physical table as String, also used as fact table name
@@ -81,7 +81,7 @@ public class ConcretePhysicalTable extends SingleDataSourcePhysicalTable {
      * @deprecated Should use constructor with TableName instead of String as table name
      */
     @Deprecated
-    private ConcretePhysicalTable(
+    private StrictPhysicalTable(
             @NotNull String name,
             @NotNull ZonedTimeGrain timeGrain,
             @NotNull Set<Column> columns,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.availability;
 
-import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
@@ -19,7 +19,7 @@ public interface Availability {
      *
      * @return A set of names for datasources backing this availability
      */
-    Set<TableName> getDataSourceNames();
+    Set<DataSourceName> getDataSourceNames();
 
     /**
      * The names of the data sources backing this availability as filtered by the constraint.
@@ -28,7 +28,7 @@ public interface Availability {
      *
      * @return A set of names for data sources backing this availability
      */
-    default Set<TableName> getDataSourceNames(PhysicalDataSourceConstraint constraint) {
+    default Set<DataSourceName> getDataSourceNames(PhysicalDataSourceConstraint constraint) {
         return getDataSourceNames();
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/BaseCompositeAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/BaseCompositeAvailability.java
@@ -27,8 +27,7 @@ public abstract class BaseCompositeAvailability implements Availability {
     protected BaseCompositeAvailability(Stream<Availability> availabilityStream) {
         sourceAvailabilities = StreamUtils.toUnmodifiableSet(availabilityStream);
         dataSourcesNames = StreamUtils.toUnmodifiableSet(
-                sourceAvailabilities.stream()
-                        .map(Availability::getDataSourceNames).flatMap(Set::stream)
+                sourceAvailabilities.stream().map(Availability::getDataSourceNames).flatMap(Set::stream)
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/BaseCompositeAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/BaseCompositeAvailability.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.availability;
 
-import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 import com.yahoo.bard.webservice.util.StreamUtils;
 
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 public abstract class BaseCompositeAvailability implements Availability {
 
     private final Set<Availability> sourceAvailabilities;
-    private final Set<TableName> dataSourcesNames;
+    private final Set<DataSourceName> dataSourcesNames;
 
     /**
      * Constructor.
@@ -41,7 +41,7 @@ public abstract class BaseCompositeAvailability implements Availability {
     };
 
     @Override
-    public Set<TableName> getDataSourceNames() {
+    public Set<DataSourceName> getDataSourceNames() {
         return dataSourcesNames;
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/BaseMetadataAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/BaseMetadataAvailability.java
@@ -1,0 +1,83 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.availability;
+
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
+import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
+import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * An availability based on a DataSourceMetadataService backed by a single data source.
+ */
+public abstract class BaseMetadataAvailability implements Availability {
+
+    private final DataSourceName dataSourceName;
+    private final Set<DataSourceName> dataSourceNames;
+    private final DataSourceMetadataService metadataService;
+
+    /**
+     * Constructor.
+     *
+     * @param dataSourceName  The name of the data source associated with this Availability
+     * @param metadataService  A service containing the datasource segment data
+     */
+    public BaseMetadataAvailability(
+            @NotNull DataSourceName dataSourceName,
+            @NotNull DataSourceMetadataService metadataService
+    ) {
+        this.metadataService = metadataService;
+        this.dataSourceName = dataSourceName;
+        this.dataSourceNames = Collections.singleton(dataSourceName);
+    }
+
+    public DataSourceName getDataSourceName() {
+        return dataSourceName;
+    }
+
+    @Override
+    public Set<DataSourceName> getDataSourceNames() {
+        return dataSourceNames;
+    }
+
+    public DataSourceMetadataService getDataSourceMetadataService() {
+        return metadataService;
+    }
+
+    @Override
+    public Map<String, SimplifiedIntervalList> getAllAvailableIntervals() {
+        return getDataSourceMetadataService().getAvailableIntervalsByDataSource(getDataSourceName());
+    }
+
+    @Override
+    public abstract SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint);
+
+    @Override
+    public String toString() {
+        return String.format("BaseMetadataAvailability for data source = %s", getDataSourceName().asName());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BaseMetadataAvailability && this.getClass().equals(obj.getClass())) {
+            BaseMetadataAvailability that = (BaseMetadataAvailability) obj;
+            return Objects.equals(getDataSourceName().asName(), that.getDataSourceName().asName())
+                    // Since metadata service is mutable, use instance equality to ensure table equality is stable
+                    && getDataSourceMetadataService() == that.getDataSourceMetadataService();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        // Leave metadataService out of hash because it is mutable
+        return Objects.hash(getDataSourceName());
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -54,7 +54,6 @@ public class ConcreteAvailability implements Availability {
     public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
 
         Set<String> requestColumns = constraint.getAllColumnPhysicalNames();
-
         if (requestColumns.isEmpty()) {
             return new SimplifiedIntervalList();
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/ConcreteAvailability.java
@@ -2,14 +2,11 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.availability;
 
-import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.validation.constraints.NotNull;
@@ -17,37 +14,18 @@ import javax.validation.constraints.NotNull;
 /**
  * An availability that provides column and table available interval services for concrete physical table.
  */
-public class ConcreteAvailability implements Availability {
-
-    private final TableName name;
-    private final DataSourceMetadataService metadataService;
-
-    private final Set<TableName> dataSourceNames;
-
+public class ConcreteAvailability extends BaseMetadataAvailability {
     /**
      * Constructor.
      *
-     * @param tableName  The name of the table and data source associated with this Availability
+     * @param dataSourceName  The name of the data source associated with this Availability
      * @param metadataService  A service containing the datasource segment data
      */
     public ConcreteAvailability(
-            @NotNull TableName tableName,
+            @NotNull DataSourceName dataSourceName,
             @NotNull DataSourceMetadataService metadataService
     ) {
-        this.name = tableName;
-        this.metadataService = metadataService;
-
-        this.dataSourceNames = Collections.singleton(name);
-    }
-
-    @Override
-    public Set<TableName> getDataSourceNames() {
-        return dataSourceNames;
-    }
-
-    @Override
-    public Map<String, SimplifiedIntervalList> getAllAvailableIntervals() {
-        return metadataService.getAvailableIntervalsByTable(name);
+        super(dataSourceName, metadataService);
     }
 
     @Override
@@ -63,42 +41,13 @@ public class ConcreteAvailability implements Availability {
                 .map(physicalName -> getAllAvailableIntervals().getOrDefault(
                         physicalName,
                         new SimplifiedIntervalList()
-                )).reduce(SimplifiedIntervalList::intersect).orElse(new SimplifiedIntervalList());
-    }
-
-    /**
-     * Returns the name of the table and data source associated with this Availability.
-     *
-     * @return the name of the table and data source associated with this Availability
-     */
-    protected TableName getName() {
-        return name;
+                ))
+                .reduce(SimplifiedIntervalList::intersect)
+                .orElse(new SimplifiedIntervalList());
     }
 
     @Override
     public String toString() {
-        return String.format(
-                "ConcreteAvailability for table: %s with data source names %s",
-                name.asName(),
-                dataSourceNames
-        );
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof ConcreteAvailability) {
-            ConcreteAvailability that = (ConcreteAvailability) obj;
-            return Objects.equals(name.asName(), that.name.asName())
-                    && Objects.equals(dataSourceNames, that.dataSourceNames)
-                    // Since metadata service is mutable, use instance equality to ensure table equality is stable
-                    && metadataService == that.metadataService;
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        // Leave metadataService out of hash because it is mutable
-        return Objects.hash(name.asName(), dataSourceNames);
+        return "Concrete " + super.toString();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -147,7 +147,6 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
      */
     private static boolean isMetricUnique(Map<Availability, Set<String>> availabilityToMetricNames) {
         Set<String> uniqueMetrics = new HashSet<>();
-
         return availabilityToMetricNames.values().stream()
                 .flatMap(Set::stream)
                 .allMatch(uniqueMetrics::add);
@@ -182,12 +181,11 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
 
     @Override
     public String toString() {
-        return String.format("MetricUnionAvailability with data source names: [%s] and Configured metric columns: [%s]",
+        return String.format("MetricUnionAvailability with data source names: [%s] and Configured metric columns: %s",
                 getDataSourceNames().stream()
                         .map(TableName::asName)
                         .collect(Collectors.joining(", ")),
-                metricNames.stream()
-                        .collect(Collectors.joining(", "))
+                metricNames
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.availability;
 
-import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.table.Column;
 import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
@@ -113,7 +113,7 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
                 String message = String.format(
                         "Metric columns must be unique across the metric union data sources, but duplicate was found " +
                                 "across the following data sources: %s",
-                        getDataSourceNames().stream().map(TableName::asName).collect(Collectors.joining(", "))
+                        getDataSourceNames().stream().map(DataSourceName::asName).collect(Collectors.joining(", "))
                 );
                 LOG.error(message);
                 throw new RuntimeException(message);
@@ -183,7 +183,7 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
     public String toString() {
         return String.format("MetricUnionAvailability with data source names: [%s] and Configured metric columns: %s",
                 getDataSourceNames().stream()
-                        .map(TableName::asName)
+                        .map(DataSourceName::asName)
                         .collect(Collectors.joining(", ")),
                 metricNames
         );

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -5,7 +5,6 @@ package com.yahoo.bard.webservice.table.availability;
 import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.data.metric.MetricColumn;
 import com.yahoo.bard.webservice.table.Column;
-import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 import com.yahoo.bard.webservice.util.Utils;
@@ -80,22 +79,20 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
     /**
      * Constructor.
      *
-     * @param physicalTables  A set of <tt>PhysicalTable</tt>s whose dimension schemas are (typically) the same and
-     *  Metric columns are unique(i.e. no overlap) on every table
+     * @param availabilities  A set of <tt>Availabilities</tt> whose Dimension schemas are (typically) the same and
+     * the Metric columns are unique(i.e. no overlap) on every availability
      * @param columns  The set of all configured columns, including dimension columns, that metric union availability
      * will respond with
      */
-    public MetricUnionAvailability(@NotNull Set<ConfigPhysicalTable> physicalTables, @NotNull Set<Column> columns) {
-        super(physicalTables.stream().map(ConfigPhysicalTable::getAvailability));
-
+    public MetricUnionAvailability(@NotNull Set<Availability> availabilities, @NotNull Set<Column> columns) {
+        super(availabilities.stream());
         metricNames = Utils.getSubsetByType(columns, MetricColumn.class).stream()
                 .map(MetricColumn::getName)
                 .collect(Collectors.toSet());
 
         // Construct a map of availability to its assigned metric
         // by intersecting its underlying datasource metrics with table configured metrics
-        availabilitiesToMetricNames = physicalTables.stream()
-                .map(ConfigPhysicalTable::getAvailability)
+        availabilitiesToMetricNames = availabilities.stream()
                 .collect(
                         Collectors.toMap(
                                 Function.identity(),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
@@ -12,10 +12,9 @@ import javax.validation.constraints.NotNull;
 /**
  * An availability which allows missing intervals, i.e. returns union of available intervals, on its contents.
  * This availability returns available intervals without restrictions from <tt>DataSourceConstraint</tt>, because the
- * nature of this availability is to returns as much available intervals as possible.
+ * nature of this availability is to returns as many available intervals as possible.
  */
 public class PermissiveAvailability extends ConcreteAvailability {
-
     /**
      * Constructor.
      *
@@ -39,9 +38,9 @@ public class PermissiveAvailability extends ConcreteAvailability {
      * )};
      * Instead of returning the intersection of all available intervals, this method returns the union of them.
      *
-     * @param ignoredConstraint  Data constraint containing columns and api filters. Constrains are ignored, because
-     * <tt>PermissiveAvailability</tt> returns as much available intervals as possible by, for example, allowing
-     * missing intervals and returning unions of available intervals
+     * @param ignoredConstraint  Constrains are ignored, because <tt>PermissiveAvailability</tt> returns as many
+     * available intervals as possible by, for example, allowing missing intervals and returning unions of available
+     * intervals
      *
      * @return the union of all available intervals
      */

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
@@ -33,7 +33,7 @@ public class PermissiveAvailability extends BaseMetadataAvailability {
      * <p>
      * This is different from its parent's
      * {@link
-     * com.yahoo.bard.webservice.table.availability.ConcreteAvailability#getAvailableIntervals(
+     * StrictAvailability#getAvailableIntervals(
      * PhysicalDataSourceConstraint
      * )};
      * Instead of returning the intersection of all available intervals, this method returns the union of them.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PermissiveAvailability.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.availability;
 
-import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
@@ -14,18 +14,18 @@ import javax.validation.constraints.NotNull;
  * This availability returns available intervals without restrictions from <tt>DataSourceConstraint</tt>, because the
  * nature of this availability is to returns as many available intervals as possible.
  */
-public class PermissiveAvailability extends ConcreteAvailability {
+public class PermissiveAvailability extends BaseMetadataAvailability {
     /**
      * Constructor.
      *
-     * @param tableName  The name of the data source
+     * @param dataSourceName  The name of the data source associated with this Availability
      * @param metadataService  A service containing the data source segment data
      */
     public PermissiveAvailability(
-            @NotNull TableName tableName,
+            @NotNull DataSourceName dataSourceName,
             @NotNull DataSourceMetadataService metadataService
     ) {
-        super(tableName, metadataService);
+        super(dataSourceName, metadataService);
     }
 
     /**
@@ -53,6 +53,6 @@ public class PermissiveAvailability extends ConcreteAvailability {
 
     @Override
     public String toString() {
-        return String.format("PermissiveAvailability with table name = %s", getName().asName());
+        return "Permissive " + super.toString();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/StrictAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/StrictAvailability.java
@@ -12,16 +12,18 @@ import java.util.Set;
 import javax.validation.constraints.NotNull;
 
 /**
- * An availability that provides column and table available interval services for concrete physical table.
+ * An availability that provides column and table available interval services for strict physical tables.
+ * <p>
+ * This availability uses column intersections to determine it's sigular availability.
  */
-public class ConcreteAvailability extends BaseMetadataAvailability {
+public class StrictAvailability extends BaseMetadataAvailability {
     /**
      * Constructor.
      *
      * @param dataSourceName  The name of the data source associated with this Availability
      * @param metadataService  A service containing the datasource segment data
      */
-    public ConcreteAvailability(
+    public StrictAvailability(
             @NotNull DataSourceName dataSourceName,
             @NotNull DataSourceMetadataService metadataService
     ) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalDataSourceConstraint.java
@@ -47,7 +47,6 @@ public class PhysicalDataSourceConstraint extends DataSourceConstraint {
     ) {
         super(dataSourceConstraint);
         this.allColumnPhysicalNames = allColumnPhysicalNames;
-
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -118,7 +118,7 @@ public enum ErrorMessageFormat implements MessageFormatter {
     LOGINFO_CLASS_INVALID("Invalid LogInfo class: %s. Cannot define its order. Ignoring."),
 
     DRUID_METADATA_READ_ERROR("Unable to read metadata for: '%s'."),
-    DRUID_METADATA_SEGMENTS_MISSING("No segment metadata available for tables: '%s'."),
+    DRUID_METADATA_SEGMENTS_MISSING("No segment metadata available for data sources: '%s'."),
 
     DRUID_URL_INVALID("Druid %s url is unset."),
 
@@ -230,7 +230,10 @@ public enum ErrorMessageFormat implements MessageFormatter {
             "More than %s interval missing information received from druid, inspect if query " +
                     "expects more than %s missing intervals or increase " +
                     "uncoveredIntervalsLimit configuration value"
-    )
+    ),
+
+    TOO_MANY_BACKING_DATA_SOURCES("TableDataSource built with too many backing data sources: %s"),
+    TOO_FEW_BACKING_DATA_SOURCES("TableDataSource built with insufficient backing data sources: %s")
     ;
 
     private final String messageFormat;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
@@ -20,7 +20,6 @@ import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
@@ -189,8 +188,8 @@ public class SlicesApiRequest extends ApiRequest {
                 }
         );
 
-        Set<SortedMap<DateTime, Map<String, SegmentInfo>>> sliceMetadata = dataSourceMetadataService.getTableSegments(
-                Collections.singleton(table.getTableName())
+        Set<SortedMap<DateTime, Map<String, SegmentInfo>>> sliceMetadata = dataSourceMetadataService.getSegments(
+                table.getDataSourceNames()
         );
 
         Map<String, Object> generated = new LinkedHashMap<>();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
@@ -93,10 +93,11 @@ public class CacheV2RequestHandler extends BaseDataRequestHandler {
                 if (cacheEntry != null) {
                     // Make sure that if the optional return value is empty, the statement always evaluates to false
                     // Metadata type needs to be int.
-                    if (Objects.equals(
-                            cacheEntry.getMeta(),
-                            querySigningService.getSegmentSetId(druidQuery).orElse(null)
-                    )) {
+                    if (
+                            querySigningService.getSegmentSetId(druidQuery)
+                                    .map(id -> Objects.equals(cacheEntry.getMeta(), id))
+                                    .orElse(false)
+                    ) {
                         try {
                             if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
                                 RequestLog.record(new BardQueryInfo(druidQuery.getQueryType().toJson(), true));

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
@@ -350,10 +350,9 @@ class DruidQueryBuilderSpec extends Specification {
     def "Test top level buildQuery with multiple dimensions/single sort top N query"() {
         setup:
         apiRequest = Mock(DataApiRequest)
-
-        apiRequest.getDimensions() >> ([resources.d1, resources.d2] as Set)
-        apiRequest.getTopN() >> OptionalInt.of(5)
-        apiRequest.getSorts() >> ([new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC)] as Set)
+        apiRequest.dimensions >> ([resources.d1, resources.d2] as Set)
+        apiRequest.topN >> OptionalInt.of(5)
+        apiRequest.sorts >> ([new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC)] as Set)
 
         initDefault(apiRequest)
 
@@ -367,9 +366,8 @@ class DruidQueryBuilderSpec extends Specification {
     def "Test top level buildQuery with single dimension/multiple sorts top N query"() {
         setup:
         apiRequest = Mock(DataApiRequest)
-
-        apiRequest.getTopN() >> OptionalInt.of(5)
-        apiRequest.getSorts() >> ([
+        apiRequest.topN >> OptionalInt.of(5)
+        apiRequest.sorts >> ([
                 new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC),
                 new OrderByColumn(new LogicalMetric(null, null, "m2"), SortDirection.ASC)
         ] as Set)
@@ -380,17 +378,15 @@ class DruidQueryBuilderSpec extends Specification {
         DruidAggregationQuery<?> dq = builder.buildQuery(apiRequest, resources.simpleTemplateQuery)
 
         then:
-        dq?.getQueryType() == DefaultQueryType.GROUP_BY
+        dq?.queryType == DefaultQueryType.GROUP_BY
     }
 
     def "Test top level buildQuery with multiple dimension/multiple sorts top N query"() {
         setup:
         apiRequest = Mock(DataApiRequest)
-
-        apiRequest.getDimensions() >> ([resources.d1, resources.d2] as Set)
-
-        apiRequest.getTopN() >> OptionalInt.of(5)
-        apiRequest.getSorts() >> ([
+        apiRequest.dimensions >> ([resources.d1, resources.d2] as Set)
+        apiRequest.topN >> OptionalInt.of(5)
+        apiRequest.sorts >> ([
                 new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.ASC),
                 new OrderByColumn(new LogicalMetric(null, null, "m2"), SortDirection.DESC)
         ] as Set)
@@ -401,19 +397,17 @@ class DruidQueryBuilderSpec extends Specification {
         DruidAggregationQuery<?> dq = builder.buildQuery(apiRequest, resources.simpleTemplateQuery)
 
         then:
-        dq?.getQueryType() == DefaultQueryType.GROUP_BY
-
+        dq?.queryType == DefaultQueryType.GROUP_BY
     }
 
     @Unroll
     def "A #tsDruid query is built when there #isIsNot a having clause"() {
         setup:
         apiRequest = Mock(DataApiRequest)
-
-        apiRequest.getDimensions() >> ([] as Set)
-        apiRequest.getLogicalMetrics() >> ([resources.m1] as Set)
-        apiRequest.getHavings() >> havingMap
-        apiRequest.getHaving() >> { DruidHavingBuilder.buildHavings(havingMap) }
+        apiRequest.dimensions >> ([] as Set)
+        apiRequest.logicalMetrics >> ([resources.m1] as Set)
+        apiRequest.havings >> havingMap
+        apiRequest.having >> { DruidHavingBuilder.buildHavings(havingMap) }
 
         initDefault(apiRequest)
 
@@ -421,7 +415,7 @@ class DruidQueryBuilderSpec extends Specification {
         DruidAggregationQuery<?> dq = builder.buildQuery(apiRequest, resources.simpleTemplateQuery)
 
         then:
-        dq?.getQueryType() == queryType
+        dq?.queryType == queryType
 
         where:
         queryType                   | havingMap                         | tsDruid      | isIsNot
@@ -430,22 +424,22 @@ class DruidQueryBuilderSpec extends Specification {
     }
 
     @Unroll
-    def """TopN maps to druid #query when nDim:#nDims, nesting:#nested, nSorts:#nSorts, topN flag:#flag,
-havingMap:#havingMap"""() {
+    def "TopN maps to druid #query when nDim:#nDims, nesting:#nested, nSorts:#nSorts, topN flag:#flag, havingMap:#havingMap"() {
         setup:
         apiRequest = Mock(DataApiRequest)
 
-        apiRequest.getDimensions() >> { nDims > 1 ? ([resources.d1, resources.d2] as Set) : [resources.d1] as Set }
-        apiRequest.getTopN() >> OptionalInt.of(5)
-        apiRequest.getSorts() >> {
-            nSorts > 1 ? [
-                    new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC),
-                    new OrderByColumn(new LogicalMetric(null, null, "m2"), SortDirection.ASC)
-            ] as Set :
+        apiRequest.dimensions >> { nDims > 1 ? ([resources.d1, resources.d2] as Set) : [resources.d1] as Set }
+        apiRequest.topN >> OptionalInt.of(5)
+        apiRequest.sorts >> {
+            nSorts > 1 ?
+                    [
+                            new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC),
+                            new OrderByColumn(new LogicalMetric(null, null, "m2"), SortDirection.ASC)
+                    ] as Set :
                     [new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC)] as Set
         }
-        apiRequest.getHavings() >> havingMap
-        apiRequest.getHaving() >> { DruidHavingBuilder.buildHavings(havingMap) }
+        apiRequest.havings >> havingMap
+        apiRequest.having >> { DruidHavingBuilder.buildHavings(havingMap) }
 
         initDefault(apiRequest)
 
@@ -457,7 +451,7 @@ havingMap:#havingMap"""() {
         DruidAggregationQuery<?> dq = builder.buildQuery(apiRequest, getTDQ(nested))
 
         then:
-        dq?.getQueryType() == queryType
+        dq?.queryType == queryType
 
         where:
         queryType                 | havingMap                         | nDims | nested | nSorts | flag  | query
@@ -474,15 +468,15 @@ havingMap:#havingMap"""() {
         setup:
         apiRequest = Mock(DataApiRequest)
 
-        apiRequest.getDimensions() >> { nDims > 0 ? [resources.d1] as Set : [] as Set }
+        apiRequest.dimensions >> { nDims > 0 ? [resources.d1] as Set : [] as Set }
 
-        apiRequest.getSorts() >> {
+        apiRequest.sorts >> {
             nSorts > 0 ?
                     [new OrderByColumn(new LogicalMetric(null, null, "m1"), SortDirection.DESC)] as Set :
                     [] as Set
         }
-        apiRequest.getHavings() >> havingMap
-        apiRequest.getHaving() >> { DruidHavingBuilder.buildHavings(havingMap) }
+        apiRequest.havings >> havingMap
+        apiRequest.having >> { DruidHavingBuilder.buildHavings(havingMap) }
 
         initDefault(apiRequest)
 
@@ -492,7 +486,7 @@ havingMap:#havingMap"""() {
         DruidAggregationQuery<?> dq = builder.buildQuery(apiRequest, getTDQ(nested))
 
         then:
-        dq?.getQueryType() == queryType
+        dq?.queryType == queryType
 
         where:
         queryType                   | havingMap                         | nDims | nested | nSorts | query

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
@@ -31,6 +31,8 @@ import com.yahoo.bard.webservice.druid.model.query.TopNQuery
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.table.ConstrainedTable
 import com.yahoo.bard.webservice.table.TableTestUtils
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
+import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.resolver.DefaultPhysicalTableResolver
 import com.yahoo.bard.webservice.web.ApiFilter
 import com.yahoo.bard.webservice.web.ApiHaving
@@ -131,7 +133,7 @@ class DruidQueryBuilderSpec extends Specification {
     def "Test recursive buildQueryMethods"() {
         setup:
         Set apiSet = (["abie1234", "abde1129"].collect() { apiFilters.get(it) }) as Set
-        ConstrainedTable tab = TableTestUtils.buildTable(
+        ConstrainedTable table = TableTestUtils.buildTable(
                 "tab1",
                 DAY.buildZonedTimeGrain(UTC),
                 [] as Set,
@@ -147,7 +149,7 @@ class DruidQueryBuilderSpec extends Specification {
         when:
         GroupByQuery dq = builder.buildGroupByQuery(
                 resources.simpleTemplateQuery,
-                tab,
+                table,
                 granularity,
                 UTC,
                 [] as Set,
@@ -160,13 +162,13 @@ class DruidQueryBuilderSpec extends Specification {
         then:
         dq?.filter == filter
         dq.dataSource.type == DefaultDataSourceType.TABLE
-        dq.dataSource.name == tab.name
+        dq.dataSource.name == table.name
         granularity.withZone(UTC)
 
         when:
         GroupByQuery dq1 = builder.buildGroupByQuery(
                 resources.complexTemplateQuery,
-                tab,
+                table,
                 granularity,
                 UTC,
                 [] as Set,
@@ -184,13 +186,13 @@ class DruidQueryBuilderSpec extends Specification {
         GroupByQuery dq2 = dq1.dataSource.query
         dq2.filter == filter
         dq2.dataSource.type == DefaultDataSourceType.TABLE
-        dq2.dataSource.name == tab.name
+        dq2.dataSource.name == table.name
         dq2.granularity == granularity.withZone(UTC)
 
         when:
         TopNQuery topNQuery = builder.buildTopNQuery(
                 resources.simpleTemplateQuery,
-                tab,
+                table,
                 granularity,
                 UTC,
                 dimension,
@@ -204,13 +206,13 @@ class DruidQueryBuilderSpec extends Specification {
         topNQuery != null
         topNQuery.filter == filter
         topNQuery.dataSource.type == DefaultDataSourceType.TABLE
-        topNQuery.dataSource.name == tab.name
+        topNQuery.dataSource.name == table.name
         topNQuery.granularity == granularity.withZone(UTC)
 
         when:
         TimeSeriesQuery timeseriesQuery = builder.buildTimeSeriesQuery(
                 resources.simpleTemplateQuery,
-                tab,
+                table,
                 granularity,
                 UTC,
                 filter,
@@ -221,7 +223,7 @@ class DruidQueryBuilderSpec extends Specification {
         timeseriesQuery != null
         timeseriesQuery.filter == filter
         timeseriesQuery.dataSource.type == DefaultDataSourceType.TABLE
-        timeseriesQuery.dataSource.name == tab.name
+        timeseriesQuery.dataSource.name == table.name
         timeseriesQuery.granularity == granularity.withZone(UTC)
     }
 
@@ -232,7 +234,7 @@ class DruidQueryBuilderSpec extends Specification {
 
         when:
         Set apiSet = (["abie1234", "abde1129"].collect() { apiFilters.get(it) }) as Set
-        ConstrainedTable tab = TableTestUtils.buildTable(
+        ConstrainedTable table = TableTestUtils.buildTable(
                 "tab1",
                 DAY.buildZonedTimeGrain(UTC),
                 [] as Set,
@@ -244,7 +246,7 @@ class DruidQueryBuilderSpec extends Specification {
         TemplateDruidQuery simpleQuery = resources.simpleTemplateWithGrainQuery
         GroupByQuery dq = builder.buildGroupByQuery(
                 simpleQuery,
-                tab,
+                table,
                 granularity,
                 UTC,
                 [] as Set,
@@ -257,14 +259,14 @@ class DruidQueryBuilderSpec extends Specification {
         then:
         dq?.filter == filter
         dq.dataSource.type == DefaultDataSourceType.TABLE
-        dq.dataSource.name == tab.name
+        dq.dataSource.name == table.name
         dq.granularity == simpleQuery.getTimeGrain().buildZonedTimeGrain(UTC)
 
         when:
         TemplateDruidQuery outerQuery = resources.complexTemplateWithInnerGrainQuery
         GroupByQuery dq1 = builder.buildGroupByQuery(
                 outerQuery,
-                tab,
+                table,
                 granularity,
                 UTC,
                 [] as Set,
@@ -280,14 +282,14 @@ class DruidQueryBuilderSpec extends Specification {
         dq1.dataSource.type == DefaultDataSourceType.QUERY
         dq2.filter == filter
         dq2.dataSource.type == DefaultDataSourceType.TABLE
-        dq2.dataSource.name == tab.name
+        dq2.dataSource.name == table.name
         dq2.granularity == simpleQuery.timeGrain.buildZonedTimeGrain(UTC)
 
         when:
         outerQuery = resources.complexTemplateWithDoubleGrainQuery
         dq1 = builder.buildGroupByQuery(
                 resources.complexTemplateWithDoubleGrainQuery,
-                tab,
+                table,
                 granularity,
                 UTC,
                 [] as Set,
@@ -305,7 +307,7 @@ class DruidQueryBuilderSpec extends Specification {
         dq1.dataSource.type == DefaultDataSourceType.QUERY
         dq2.filter == filter
         dq2.dataSource.type == DefaultDataSourceType.TABLE
-        dq2.dataSource.name == tab.name
+        dq2.dataSource.name == table.name
         dq2.granularity == simpleQuery.timeGrain.buildZonedTimeGrain(UTC)
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/PartialDataHandlerSpec.groovy
@@ -19,7 +19,7 @@ import com.yahoo.bard.webservice.druid.model.query.Granularity
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
 import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.resolver.QueryPlanningConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
@@ -37,7 +37,7 @@ class PartialDataHandlerSpec extends Specification {
     PartialDataHandler partialDataHandler = new PartialDataHandler()
 
     Dimension dim1, dim2, dim3
-    ConcretePhysicalTable table
+    StrictPhysicalTable table
 
     Set<String> columnNames
     GroupByQuery groupByQuery = Mock(GroupByQuery.class)
@@ -83,7 +83,7 @@ class PartialDataHandlerSpec extends Specification {
                 'page_views': buildIntervals(["2014-07-04/2014-07-29"]) as Set
         ]
 
-        table = new ConcretePhysicalTable(
+        table = new StrictPhysicalTable(
                 TableName.of("basefact_network"),
                 DAY.buildZonedTimeGrain(UTC),
                 [new Column("userDeviceType"), new Column("property"), new Column("os"), new Column("page_views")] as Set,
@@ -177,7 +177,13 @@ class PartialDataHandlerSpec extends Specification {
     }
 
     @Unroll
-    def "Complement cuts out the correct hole(s) when #comment"() {
+    def "Complement cuts out the correct hole(s) when #comment"(
+            Granularity granularity,
+            String comment,
+            List<String> fromAsStrings,
+            List<String> removeAsStrings,
+            List<String> expectedAsStrings
+    ) {
         given:
         SimplifiedIntervalList from = buildIntervalList(fromAsStrings)
         SimplifiedIntervalList remove = buildIntervalList(removeAsStrings)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
@@ -110,9 +110,7 @@ public class QueryBuildingTestingResources {
 
         metadataService = new TestDataSourceMetadataService([:])
 
-        LinkedHashSet<DimensionField> dimensionFields = new LinkedHashSet<>()
-        dimensionFields.add(BardDimensionField.ID)
-        dimensionFields.add(BardDimensionField.DESC)
+        LinkedHashSet<DimensionField> dimensionFields = [BardDimensionField.ID, BardDimensionField.DESC] as LinkedHashSet
 
         LinkedHashSet<DimensionConfig> lookupDimConfig = new TestLookupDimensions().getDimensionConfigurationsByApiName(SIZE, SHAPE, COLOR)
         LinkedHashSet<DimensionConfig> registeredLookupDimConfig = new TestRegisteredLookupDimensions().getDimensionConfigurationsByApiName(BREED, SPECIES, OTHER);
@@ -178,8 +176,6 @@ public class QueryBuildingTestingResources {
                 ScanSearchProviderManager.getInstance("dim7"),
                 false
         )
-
-        LinkedHashSet<DimensionConfig> dimConfig = new TestLookupDimensions().getDimensionConfigurationsByApiName(SIZE, SHAPE, COLOR)
 
         // lookup dimensions with multiple, one, and none lookups
         d8 = new LookupDimension(lookupDimConfig.getAt(0))
@@ -251,15 +247,15 @@ public class QueryBuildingTestingResources {
 
         setupPartialData()
 
-        tg1h = new TableGroup([t1h, t1d, t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [d1] as Set)
-        tg1d = new TableGroup([t1d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [d1] as Set)
-        tg1Short = new TableGroup([t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
-        tg2h = new TableGroup([t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
-        tg3d = new TableGroup([t3d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
-        tg4h = new TableGroup([t1h, t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
-        tg5h = new TableGroup([t2h, t1h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tg1h = new TableGroup([t1h, t1d, t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.name)} as Set, [d1] as Set)
+        tg1d = new TableGroup([t1d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.name)} as Set, [d1] as Set)
+        tg1Short = new TableGroup([t1hShort] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.name)} as Set, [] as Set)
+        tg2h = new TableGroup([t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.name)} as Set, [] as Set)
+        tg3d = new TableGroup([t3d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.name)} as Set, [] as Set)
+        tg4h = new TableGroup([t1h, t2h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.name)} as Set, [] as Set)
+        tg5h = new TableGroup([t2h, t1h] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.name)} as Set, [] as Set)
         tg6h = new TableGroup([t5h] as LinkedHashSet, [] as Set, [] as Set)
-        tgna = new TableGroup([tna1236d, tna1237d, tna167d, tna267d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.getName())} as Set, [] as Set)
+        tgna = new TableGroup([tna1236d, tna1237d, tna167d, tna267d] as LinkedHashSet, [m1, m2, m3].collect {buildMockName(it.name)} as Set, [] as Set)
 
         lt12 = new LogicalTable("base12", HOUR, tg1h, metricDictionary)
         lt13 = new LogicalTable("base13", DAY, tg1d, metricDictionary)
@@ -285,25 +281,25 @@ public class QueryBuildingTestingResources {
         logicalDictionary = new LogicalTableDictionary()
         logicalDictionary.putAll(baseMap)
 
-        simpleTemplateQuery = new TemplateDruidQuery(new LinkedHashSet(), new LinkedHashSet(), null, null)
+        simpleTemplateQuery = new TemplateDruidQuery([] as LinkedHashSet, [] as LinkedHashSet, null, null)
         simpleNestedTemplateQuery = simpleTemplateQuery.nest()
         complexTemplateQuery = new TemplateDruidQuery(
-                new LinkedHashSet(),
-                new LinkedHashSet(),
+                [] as LinkedHashSet,
+                [] as LinkedHashSet,
                 simpleTemplateQuery,
                 null
         )
 
-        simpleTemplateWithGrainQuery = new TemplateDruidQuery(new LinkedHashSet(), new LinkedHashSet(), DAY)
+        simpleTemplateWithGrainQuery = new TemplateDruidQuery([] as LinkedHashSet, [] as LinkedHashSet, DAY)
         complexTemplateWithInnerGrainQuery = new TemplateDruidQuery(
-                new LinkedHashSet(),
-                new LinkedHashSet(),
+                [] as LinkedHashSet,
+                [] as LinkedHashSet,
                 simpleTemplateWithGrainQuery,
                 null
         )
         complexTemplateWithDoubleGrainQuery = new TemplateDruidQuery(
-                new LinkedHashSet(),
-                new LinkedHashSet(),
+                [] as LinkedHashSet,
+                [] as LinkedHashSet,
                 simpleTemplateWithGrainQuery,
                 WEEK
         )
@@ -324,9 +320,9 @@ public class QueryBuildingTestingResources {
         Map<String, Set<Interval>> availabilityMap3 = [:]
 
         [d1, d2, m1, m2, m3].each {
-            availabilityMap1.put(toColumn(it).getName(), [new Interval("2015/2015")] as Set)
-            availabilityMap2.put(toColumn(it).getName(), [new Interval("2015/2016")] as Set)
-            availabilityMap3.put(toColumn(it).getName(), [new Interval("2011/2016")] as Set)
+            availabilityMap1.put(toColumn(it).name, [new Interval("2015/2015")] as Set)
+            availabilityMap2.put(toColumn(it).name, [new Interval("2015/2016")] as Set)
+            availabilityMap3.put(toColumn(it).name, [new Interval("2011/2016")] as Set)
         }
         emptyFirst.setAvailability(new ConcreteAvailability(emptyFirst.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
         emptyLast.setAvailability(new ConcreteAvailability(emptyLast.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
@@ -351,9 +347,9 @@ public class QueryBuildingTestingResources {
                     new ConcreteAvailability(
                             table.getTableName(),
                             new TestDataSourceMetadataService(
-                                [new DimensionColumn(d1).getName(), new LogicalMetricColumn(m1).getName()].collectEntries() {
-                                    [(it): [availability]]
-                                }
+                                    [new DimensionColumn(d1).name, new LogicalMetricColumn(m1).name].collectEntries() {
+                                        [(it): [availability]]
+                                    }
                             )
                     )
             )

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
@@ -43,13 +43,13 @@ import com.yahoo.bard.webservice.druid.model.query.AllGranularity
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
 import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.LogicalTableDictionary
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.TableGroup
 import com.yahoo.bard.webservice.table.TableIdentifier
-import com.yahoo.bard.webservice.table.availability.ConcreteAvailability
+import com.yahoo.bard.webservice.table.availability.StrictAvailability
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
 import org.joda.time.DateTimeZone
@@ -70,16 +70,16 @@ public class QueryBuildingTestingResources {
     public Interval interval1, interval2, interval3
 
     // tables are enumerated by dimension set number, d or h for day or hour
-    public ConcretePhysicalTable t1h, t1d, t1hShort, t2h, t3d, t4h1, t4h2, t4d1, t4d2, t5h
+    public StrictPhysicalTable t1h, t1d, t1hShort, t2h, t3d, t4h1, t4h2, t4d1, t4d2, t5h
 
     // table used to test ordering, empty has no availability, partial some, whole largest availability
-    public ConcretePhysicalTable emptyFirst, partialSecond, wholeThird, emptyLast
+    public StrictPhysicalTable emptyFirst, partialSecond, wholeThird, emptyLast
 
     // Tables with not aggregatable dimensions, numbers indicate the dimension set
-    public ConcretePhysicalTable tna1236d, tna1237d, tna167d, tna267d
+    public StrictPhysicalTable tna1236d, tna1237d, tna167d, tna267d
 
     // Tables with volatile hour and volatile day
-    public ConcretePhysicalTable volatileHourTable, volatileDayTable
+    public StrictPhysicalTable volatileHourTable, volatileDayTable
 
     public VolatileIntervalsService volatileIntervalsService
 
@@ -211,25 +211,25 @@ public class QueryBuildingTestingResources {
         TimeGrain utcHour = HOUR.buildZonedTimeGrain(UTC)
         TimeGrain utcDay = DAY.buildZonedTimeGrain(UTC)
 
-        volatileHourTable = new ConcretePhysicalTable(TableName.of("hour"), HOUR.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
-        volatileDayTable = new ConcretePhysicalTable(TableName.of("day"), DAY.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
+        volatileHourTable = new StrictPhysicalTable(TableName.of("hour"), HOUR.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
+        volatileDayTable = new StrictPhysicalTable(TableName.of("day"), DAY.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t1h = new ConcretePhysicalTable(TableName.of("table1h"), utcHour, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
-        t1d = new ConcretePhysicalTable(TableName.of("table1d"), utcDay, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
-        t1hShort = new ConcretePhysicalTable(TableName.of("table1Short"), utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t1h = new StrictPhysicalTable(TableName.of("table1h"), utcHour, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        t1d = new StrictPhysicalTable(TableName.of("table1d"), utcDay, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        t1hShort = new StrictPhysicalTable(TableName.of("table1Short"), utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t2h = new ConcretePhysicalTable(TableName.of("table2"), utcHour, [d1, d2, d4, m1, m4, m5].collect{toColumn(it)} as Set, [:], metadataService)
-        t3d = new ConcretePhysicalTable(TableName.of("table3"), utcDay, [d1, d2, d5, m6].collect{toColumn(it)} as Set, [:], metadataService)
+        t2h = new StrictPhysicalTable(TableName.of("table2"), utcHour, [d1, d2, d4, m1, m4, m5].collect{toColumn(it)} as Set, [:], metadataService)
+        t3d = new StrictPhysicalTable(TableName.of("table3"), utcDay, [d1, d2, d5, m6].collect{toColumn(it)} as Set, [:], metadataService)
 
-        tna1236d = new ConcretePhysicalTable(TableName.of("tableNA1236"), utcDay, [d1, d2, d3, d6].collect{toColumn(it)} as Set,["ageBracket":"age_bracket"], metadataService)
-        tna1237d = new ConcretePhysicalTable(TableName.of("tableNA1237"), utcDay, [d1, d2, d3, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
-        tna167d = new ConcretePhysicalTable(TableName.of("tableNA167"), utcDay, [d1, d6, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket", "dim7":"dim_7"], metadataService)
-        tna267d = new ConcretePhysicalTable(TableName.of("tableNA267"), utcDay, [d2, d6, d7].collect{toColumn(it)} as Set, ["dim7":"dim_7"], metadataService)
+        tna1236d = new StrictPhysicalTable(TableName.of("tableNA1236"), utcDay, [d1, d2, d3, d6].collect{toColumn(it)} as Set,["ageBracket":"age_bracket"], metadataService)
+        tna1237d = new StrictPhysicalTable(TableName.of("tableNA1237"), utcDay, [d1, d2, d3, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        tna167d = new StrictPhysicalTable(TableName.of("tableNA167"), utcDay, [d1, d6, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket", "dim7":"dim_7"], metadataService)
+        tna267d = new StrictPhysicalTable(TableName.of("tableNA267"), utcDay, [d2, d6, d7].collect{toColumn(it)} as Set, ["dim7":"dim_7"], metadataService)
 
-        t4h1 = new ConcretePhysicalTable(TableName.of("table4h1"), utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        t4h2 = new ConcretePhysicalTable(TableName.of("table4h2"), utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        t4d1 = new ConcretePhysicalTable(TableName.of("table4d1"), utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        t4d2 = new ConcretePhysicalTable(TableName.of("table4d2"), utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4h1 = new StrictPhysicalTable(TableName.of("table4h1"), utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4h2 = new StrictPhysicalTable(TableName.of("table4h2"), utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4d1 = new StrictPhysicalTable(TableName.of("table4d1"), utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4d2 = new StrictPhysicalTable(TableName.of("table4d2"), utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
         Map<String, Set<Interval>> availabilityMap1 = [:]
         Map<String, Set<Interval>> availabilityMap2 = [:]
@@ -239,13 +239,13 @@ public class QueryBuildingTestingResources {
             availabilityMap2.put(toColumn(it).getName(), [interval2] as Set)
         }
 
-        t4h1.setAvailability(new ConcreteAvailability(DataSourceName.of(t4h1.name), new TestDataSourceMetadataService(availabilityMap1)))
-        t4d1.setAvailability(new ConcreteAvailability(DataSourceName.of(t4d1.name), new TestDataSourceMetadataService(availabilityMap1)))
+        t4h1.setAvailability(new StrictAvailability(DataSourceName.of(t4h1.name), new TestDataSourceMetadataService(availabilityMap1)))
+        t4d1.setAvailability(new StrictAvailability(DataSourceName.of(t4d1.name), new TestDataSourceMetadataService(availabilityMap1)))
 
-        t5h = new ConcretePhysicalTable(TableName.of("table5d"), utcHour, [d8, d9, d10, d11, d12, d13, m1].collect{toColumn(it)} as Set, [:], metadataService)
+        t5h = new StrictPhysicalTable(TableName.of("table5d"), utcHour, [d8, d9, d10, d11, d12, d13, m1].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t4h2.setAvailability(new ConcreteAvailability(DataSourceName.of(t4h2.name), new TestDataSourceMetadataService(availabilityMap2)))
-        t4d2.setAvailability(new ConcreteAvailability(DataSourceName.of(t4d1.name), new TestDataSourceMetadataService(availabilityMap2)))
+        t4h2.setAvailability(new StrictAvailability(DataSourceName.of(t4h2.name), new TestDataSourceMetadataService(availabilityMap2)))
+        t4d2.setAvailability(new StrictAvailability(DataSourceName.of(t4d1.name), new TestDataSourceMetadataService(availabilityMap2)))
 
         setupPartialData()
 
@@ -312,10 +312,10 @@ public class QueryBuildingTestingResources {
     def setupPartialData() {
         // In the event of partiality on all data, the coarsest table will be selected and the leftmost of the
         // coarsest tables should be selected
-        emptyFirst = new ConcretePhysicalTable(TableName.of("emptyFirst"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        emptyLast = new ConcretePhysicalTable(TableName.of("emptyLast"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        partialSecond = new ConcretePhysicalTable(TableName.of("partialSecond"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        wholeThird = new ConcretePhysicalTable(TableName.of("wholeThird"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        emptyFirst = new StrictPhysicalTable(TableName.of("emptyFirst"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        emptyLast = new StrictPhysicalTable(TableName.of("emptyLast"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        partialSecond = new StrictPhysicalTable(TableName.of("partialSecond"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        wholeThird = new StrictPhysicalTable(TableName.of("wholeThird"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
         Map<String, Set<Interval>> availabilityMap1 = [:]
         Map<String, Set<Interval>> availabilityMap2 = [:]
@@ -326,10 +326,10 @@ public class QueryBuildingTestingResources {
             availabilityMap2.put(toColumn(it).name, [new Interval("2015/2016")] as Set)
             availabilityMap3.put(toColumn(it).name, [new Interval("2011/2016")] as Set)
         }
-        emptyFirst.setAvailability(new ConcreteAvailability(DataSourceName.of(emptyFirst.name), new TestDataSourceMetadataService(availabilityMap1)))
-        emptyLast.setAvailability(new ConcreteAvailability(DataSourceName.of(emptyLast.name), new TestDataSourceMetadataService(availabilityMap1)))
-        partialSecond.setAvailability(new ConcreteAvailability(DataSourceName.of(partialSecond.name), new TestDataSourceMetadataService(availabilityMap2)))
-        wholeThird.setAvailability(new ConcreteAvailability(DataSourceName.of(wholeThird.name), new TestDataSourceMetadataService(availabilityMap3)))
+        emptyFirst.setAvailability(new StrictAvailability(DataSourceName.of(emptyFirst.name), new TestDataSourceMetadataService(availabilityMap1)))
+        emptyLast.setAvailability(new StrictAvailability(DataSourceName.of(emptyLast.name), new TestDataSourceMetadataService(availabilityMap1)))
+        partialSecond.setAvailability(new StrictAvailability(DataSourceName.of(partialSecond.name), new TestDataSourceMetadataService(availabilityMap2)))
+        wholeThird.setAvailability(new StrictAvailability(DataSourceName.of(wholeThird.name), new TestDataSourceMetadataService(availabilityMap3)))
 
         tg1All = new TableGroup([emptyFirst, partialSecond, wholeThird, emptyLast] as LinkedHashSet, [] as Set, [] as Set)
         ti1All = new TableIdentifier("base1All", AllGranularity.INSTANCE)
@@ -344,9 +344,9 @@ public class QueryBuildingTestingResources {
      * availability, and volatility information
      */
     def setupVolatileTables(Collection<Collection> physicalTableAvailabilityVolatilityTriples) {
-        physicalTableAvailabilityVolatilityTriples.each { ConcretePhysicalTable table, Interval availability, _ ->
+        physicalTableAvailabilityVolatilityTriples.each { StrictPhysicalTable table, Interval availability, _ ->
             table.setAvailability(
-                    new ConcreteAvailability(
+                    new StrictAvailability(
                             DataSourceName.of(table.name),
                             new TestDataSourceMetadataService(
                                     [new DimensionColumn(d1).name, new LogicalMetricColumn(m1).name].collectEntries() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
@@ -18,6 +18,8 @@ import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig
 import com.yahoo.bard.webservice.data.config.dimension.TestLookupDimensions
 import com.yahoo.bard.webservice.data.config.dimension.TestRegisteredLookupDimensions
 import com.yahoo.bard.webservice.data.config.names.ApiMetricName
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
+import com.yahoo.bard.webservice.data.config.names.TableName
 import com.yahoo.bard.webservice.data.dimension.BardDimensionField
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionColumn
@@ -209,25 +211,25 @@ public class QueryBuildingTestingResources {
         TimeGrain utcHour = HOUR.buildZonedTimeGrain(UTC)
         TimeGrain utcDay = DAY.buildZonedTimeGrain(UTC)
 
-        volatileHourTable = new ConcretePhysicalTable("hour", HOUR.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
-        volatileDayTable = new ConcretePhysicalTable("day", DAY.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
+        volatileHourTable = new ConcretePhysicalTable(TableName.of("hour"), HOUR.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
+        volatileDayTable = new ConcretePhysicalTable(TableName.of("day"), DAY.buildZonedTimeGrain(UTC), [d1, m1].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t1h = new ConcretePhysicalTable("table1h", utcHour, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
-        t1d = new ConcretePhysicalTable("table1d", utcDay, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
-        t1hShort = new ConcretePhysicalTable("table1Short", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t1h = new ConcretePhysicalTable(TableName.of("table1h"), utcHour, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        t1d = new ConcretePhysicalTable(TableName.of("table1d"), utcDay, [d1, d2, d3, m1, m2, m3].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        t1hShort = new ConcretePhysicalTable(TableName.of("table1Short"), utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t2h = new ConcretePhysicalTable("table2", utcHour, [d1, d2, d4, m1, m4, m5].collect{toColumn(it)} as Set, [:], metadataService)
-        t3d = new ConcretePhysicalTable("table3", utcDay, [d1, d2, d5, m6].collect{toColumn(it)} as Set, [:], metadataService)
+        t2h = new ConcretePhysicalTable(TableName.of("table2"), utcHour, [d1, d2, d4, m1, m4, m5].collect{toColumn(it)} as Set, [:], metadataService)
+        t3d = new ConcretePhysicalTable(TableName.of("table3"), utcDay, [d1, d2, d5, m6].collect{toColumn(it)} as Set, [:], metadataService)
 
-        tna1236d = new ConcretePhysicalTable("tableNA1236", utcDay, [d1, d2, d3, d6].collect{toColumn(it)} as Set,["ageBracket":"age_bracket"], metadataService)
-        tna1237d = new ConcretePhysicalTable("tableNA1237", utcDay, [d1, d2, d3, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
-        tna167d = new ConcretePhysicalTable("tableNA167", utcDay, [d1, d6, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket", "dim7":"dim_7"], metadataService)
-        tna267d = new ConcretePhysicalTable("tableNA267", utcDay, [d2, d6, d7].collect{toColumn(it)} as Set, ["dim7":"dim_7"], metadataService)
+        tna1236d = new ConcretePhysicalTable(TableName.of("tableNA1236"), utcDay, [d1, d2, d3, d6].collect{toColumn(it)} as Set,["ageBracket":"age_bracket"], metadataService)
+        tna1237d = new ConcretePhysicalTable(TableName.of("tableNA1237"), utcDay, [d1, d2, d3, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket"], metadataService)
+        tna167d = new ConcretePhysicalTable(TableName.of("tableNA167"), utcDay, [d1, d6, d7].collect{toColumn(it)} as Set, ["ageBracket":"age_bracket", "dim7":"dim_7"], metadataService)
+        tna267d = new ConcretePhysicalTable(TableName.of("tableNA267"), utcDay, [d2, d6, d7].collect{toColumn(it)} as Set, ["dim7":"dim_7"], metadataService)
 
-        t4h1 = new ConcretePhysicalTable("table4h1", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        t4h2 = new ConcretePhysicalTable("table4h2", utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        t4d1 = new ConcretePhysicalTable("table4d1", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        t4d2 = new ConcretePhysicalTable("table4d2", utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4h1 = new ConcretePhysicalTable(TableName.of("table4h1"), utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4h2 = new ConcretePhysicalTable(TableName.of("table4h2"), utcHour, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4d1 = new ConcretePhysicalTable(TableName.of("table4d1"), utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        t4d2 = new ConcretePhysicalTable(TableName.of("table4d2"), utcDay, [d1, d2, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
         Map<String, Set<Interval>> availabilityMap1 = [:]
         Map<String, Set<Interval>> availabilityMap2 = [:]
@@ -237,13 +239,13 @@ public class QueryBuildingTestingResources {
             availabilityMap2.put(toColumn(it).getName(), [interval2] as Set)
         }
 
-        t4h1.setAvailability(new ConcreteAvailability(t4h1.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
-        t4d1.setAvailability(new ConcreteAvailability(t4d1.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
+        t4h1.setAvailability(new ConcreteAvailability(DataSourceName.of(t4h1.name), new TestDataSourceMetadataService(availabilityMap1)))
+        t4d1.setAvailability(new ConcreteAvailability(DataSourceName.of(t4d1.name), new TestDataSourceMetadataService(availabilityMap1)))
 
-        t5h = new ConcretePhysicalTable("table5d", utcHour, [d8, d9, d10, d11, d12, d13, m1].collect{toColumn(it)} as Set, [:], metadataService)
+        t5h = new ConcretePhysicalTable(TableName.of("table5d"), utcHour, [d8, d9, d10, d11, d12, d13, m1].collect{toColumn(it)} as Set, [:], metadataService)
 
-        t4h2.setAvailability(new ConcreteAvailability(t4h2.getTableName(), new TestDataSourceMetadataService(availabilityMap2)))
-        t4d2.setAvailability(new ConcreteAvailability(t4d1.getTableName(), new TestDataSourceMetadataService(availabilityMap2)))
+        t4h2.setAvailability(new ConcreteAvailability(DataSourceName.of(t4h2.name), new TestDataSourceMetadataService(availabilityMap2)))
+        t4d2.setAvailability(new ConcreteAvailability(DataSourceName.of(t4d1.name), new TestDataSourceMetadataService(availabilityMap2)))
 
         setupPartialData()
 
@@ -310,10 +312,10 @@ public class QueryBuildingTestingResources {
     def setupPartialData() {
         // In the event of partiality on all data, the coarsest table will be selected and the leftmost of the
         // coarsest tables should be selected
-        emptyFirst = new ConcretePhysicalTable("emptyFirst", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        emptyLast = new ConcretePhysicalTable("emptyLast", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        partialSecond = new ConcretePhysicalTable("partialSecond", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
-        wholeThird = new ConcretePhysicalTable("wholeThird", MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        emptyFirst = new ConcretePhysicalTable(TableName.of("emptyFirst"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        emptyLast = new ConcretePhysicalTable(TableName.of("emptyLast"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        partialSecond = new ConcretePhysicalTable(TableName.of("partialSecond"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
+        wholeThird = new ConcretePhysicalTable(TableName.of("wholeThird"), MONTH.buildZonedTimeGrain(UTC), [d1, m1, m2, m3].collect{toColumn(it)} as Set, [:], metadataService)
 
         Map<String, Set<Interval>> availabilityMap1 = [:]
         Map<String, Set<Interval>> availabilityMap2 = [:]
@@ -324,10 +326,10 @@ public class QueryBuildingTestingResources {
             availabilityMap2.put(toColumn(it).name, [new Interval("2015/2016")] as Set)
             availabilityMap3.put(toColumn(it).name, [new Interval("2011/2016")] as Set)
         }
-        emptyFirst.setAvailability(new ConcreteAvailability(emptyFirst.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
-        emptyLast.setAvailability(new ConcreteAvailability(emptyLast.getTableName(), new TestDataSourceMetadataService(availabilityMap1)))
-        partialSecond.setAvailability(new ConcreteAvailability(partialSecond.getTableName(), new TestDataSourceMetadataService(availabilityMap2)))
-        wholeThird.setAvailability(new ConcreteAvailability(wholeThird.getTableName(), new TestDataSourceMetadataService(availabilityMap3)))
+        emptyFirst.setAvailability(new ConcreteAvailability(DataSourceName.of(emptyFirst.name), new TestDataSourceMetadataService(availabilityMap1)))
+        emptyLast.setAvailability(new ConcreteAvailability(DataSourceName.of(emptyLast.name), new TestDataSourceMetadataService(availabilityMap1)))
+        partialSecond.setAvailability(new ConcreteAvailability(DataSourceName.of(partialSecond.name), new TestDataSourceMetadataService(availabilityMap2)))
+        wholeThird.setAvailability(new ConcreteAvailability(DataSourceName.of(wholeThird.name), new TestDataSourceMetadataService(availabilityMap3)))
 
         tg1All = new TableGroup([emptyFirst, partialSecond, wholeThird, emptyLast] as LinkedHashSet, [] as Set, [] as Set)
         ti1All = new TableIdentifier("base1All", AllGranularity.INSTANCE)
@@ -345,7 +347,7 @@ public class QueryBuildingTestingResources {
         physicalTableAvailabilityVolatilityTriples.each { ConcretePhysicalTable table, Interval availability, _ ->
             table.setAvailability(
                     new ConcreteAvailability(
-                            table.getTableName(),
+                            DataSourceName.of(table.name),
                             new TestDataSourceMetadataService(
                                     [new DimensionColumn(d1).name, new LogicalMetricColumn(m1).name].collectEntries() {
                                         [(it): [availability]]

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
@@ -112,7 +112,7 @@ class BaseTableLoaderSpec extends Specification {
         physicalTableSchema.getColumns(DimensionColumn.class) >> []
 
         physicalTable = Mock(ConfigPhysicalTable)
-        physicalTable.getTableName() >> TableName.of('definition2')
+        physicalTable.name >> 'definition2'
         physicalTable.schema >> physicalTableSchema
 
         dependentDefinition1 = new SimpleDependencyPhysicalTableDefinition('definition1', 'definition2')
@@ -151,7 +151,7 @@ class BaseTableLoaderSpec extends Specification {
 
         then:
         dicts.physicalDictionary.size() == 6
-        group.physicalTables.collect {it.getTableName()} as Set == tableNames
+        group.physicalTables.name == tableNames*.asName()
     }
 
     def "loading physical tables with dependency loads all satisfied dependency physical tables"() {
@@ -168,7 +168,7 @@ class BaseTableLoaderSpec extends Specification {
 
         then:
         dicts.physicalDictionary.size() == 3
-        group.physicalTables.collect {it.getTableName()} as Set == currentTableNames
+        group.physicalTables.name == currentTableNames*.asName()
     }
 
     def "loading a physical table with dependency outside of the current table group will be loaded successfully"() {
@@ -185,7 +185,7 @@ class BaseTableLoaderSpec extends Specification {
 
         then:
         dicts.physicalDictionary.size() == 3
-        group.physicalTables.collect { it.getTableName() } as Set == currentTableNames
+        group.physicalTables.collect { it.name } as Set == currentTableNames*.asName() as Set
     }
 
     def "unsatisfied dependency physical table definition loading will throw an exception"() {
@@ -267,7 +267,7 @@ class BaseTableLoaderSpec extends Specification {
 
         then:
         dicts.physicalDictionary.size() == 6
-        group1.physicalTables.collect {it.getTableName()} as Set == tableNames
-        group2.physicalTables.collect {it.getTableName()} as Set == tableNames
+        group1.physicalTables.name == tableNames*.asName()
+        group2.physicalTables.name == tableNames*.asName()
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
@@ -17,8 +17,8 @@ import com.yahoo.bard.webservice.data.dimension.DimensionColumn
 import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.ConfigPhysicalTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableSchema
 import com.yahoo.bard.webservice.table.TableGroup
 
@@ -64,7 +64,7 @@ class BaseTableLoaderSpec extends Specification {
         @Override
         ConfigPhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
             physicalTable ?:
-                    new ConcretePhysicalTable(
+                    new StrictPhysicalTable(
                             TableName.of(getName().asName()),
                             DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                             [] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/config/table/BaseTableLoaderSpec.groovy
@@ -19,7 +19,6 @@ import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.ConfigPhysicalTable
-import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableSchema
 import com.yahoo.bard.webservice.table.TableGroup
 
@@ -45,41 +44,33 @@ class BaseTableLoaderSpec extends Specification {
 
     private static class SimpleDependencyPhysicalTableDefinition extends PhysicalTableDefinition {
         String dependentTableName
-        PhysicalTable physicalTable
+        ConfigPhysicalTable physicalTable
 
         SimpleDependencyPhysicalTableDefinition(String tableName, String dependentTableName) {
             super(TableName.of(tableName), DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC), [] as Set, [] as Set)
             this.dependentTableName = dependentTableName
         }
 
-        SimpleDependencyPhysicalTableDefinition(String tableName, PhysicalTable physicalTable) {
+        SimpleDependencyPhysicalTableDefinition(String tableName, ConfigPhysicalTable physicalTable) {
             super(TableName.of(tableName), DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC), [] as Set, [] as Set)
             this.physicalTable = physicalTable
         }
 
         @Override
         Set<TableName> getDependentTableNames() {
-            if (Objects.isNull(dependentTableName)) {
-                return Collections.emptySet()
-            }
-            return Collections.singleton(TableName.of(dependentTableName));
+            Objects.isNull(dependentTableName) ? [] : [TableName.of(dependentTableName)]
         }
 
         @Override
-        ConfigPhysicalTable build(
-                ResourceDictionaries dictionaries,
-                DataSourceMetadataService metadataService
-        ) {
-            if (!Objects.isNull(physicalTable)) {
-                return physicalTable
-            }
-            return new ConcretePhysicalTable(
-                    TableName.of(getName().asName()),
-                    DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC),
-                    [] as Set,
-                    [:],
-                    metadataService
-            )
+        ConfigPhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
+            physicalTable ?:
+                    new ConcretePhysicalTable(
+                            TableName.of(getName().asName()),
+                            DefaultTimeGrain.DAY.buildZonedTimeGrain(DateTimeZone.UTC),
+                            [] as Set,
+                            [:],
+                            metadataService
+                    )
         }
     }
 
@@ -110,19 +101,19 @@ class BaseTableLoaderSpec extends Specification {
         metricNames = TestDruidMetricName.getByLogicalTable(SHAPES)
         physDefs = TestPhysicalTableDefinitionUtils.buildShapeTableDefinitions(new TestDimensions(), metricNames)
         dimNames = TestApiDimensionName.getByLogicalTable(SHAPES)
-        tableNames = physDefs.collect {it.name} as Set
+        tableNames = physDefs.name as Set
 
         dims = dimNames.collect {
             name -> new KeyValueStoreDimension(TestDimensions.buildStandardDimensionConfig(name))
         }
-        dicts.getDimensionDictionary().addAll(dims)
+        dicts.dimensionDictionary.addAll(dims)
 
         physicalTableSchema = Mock(PhysicalTableSchema)
         physicalTableSchema.getColumns(DimensionColumn.class) >> []
 
         physicalTable = Mock(ConfigPhysicalTable)
         physicalTable.getTableName() >> TableName.of('definition2')
-        physicalTable.getSchema() >> physicalTableSchema
+        physicalTable.schema >> physicalTableSchema
 
         dependentDefinition1 = new SimpleDependencyPhysicalTableDefinition('definition1', 'definition2')
         satisfiedDefinition2 = new SimpleDependencyPhysicalTableDefinition('definition2', physicalTable)
@@ -149,7 +140,6 @@ class BaseTableLoaderSpec extends Specification {
         group.apiMetricNames == apiNames
     }
 
-
     def "loading distinct physical tables without dependency results in correct tables in dictionary and table group"() {
         when:
         TableGroup group = loader.buildDimensionSpanningTableGroup(
@@ -166,7 +156,7 @@ class BaseTableLoaderSpec extends Specification {
 
     def "loading physical tables with dependency loads all satisfied dependency physical tables"() {
         given:
-        Set<TableName> currentTableNames = [dependentDefinition1.name, satisfiedDefinition2.name, dependentDefinition3.name]
+        Set<TableName> currentTableNames = [dependentDefinition1, satisfiedDefinition2, dependentDefinition3].name
 
         when:
         TableGroup group = loader.buildDimensionSpanningTableGroup(
@@ -183,7 +173,7 @@ class BaseTableLoaderSpec extends Specification {
 
     def "loading a physical table with dependency outside of the current table group will be loaded successfully"() {
         given:
-        Set<TableName> currentTableNames = [satisfiedDefinition2.name, dependentDefinition3.name]
+        Set<TableName> currentTableNames = [satisfiedDefinition2, dependentDefinition3].name
 
         when:
         TableGroup group = loader.buildDimensionSpanningTableGroup(
@@ -200,7 +190,7 @@ class BaseTableLoaderSpec extends Specification {
 
     def "unsatisfied dependency physical table definition loading will throw an exception"() {
         given:
-        Set<TableName> currentTableNames = [satisfiedDefinition2.name, dependentDefinition3.name]
+        Set<TableName> currentTableNames = [satisfiedDefinition2, dependentDefinition3].name
 
         when:
         loader.buildDimensionSpanningTableGroup(
@@ -217,7 +207,13 @@ class BaseTableLoaderSpec extends Specification {
 
     def "circular dependency physical table definition loading will throw an exception"() {
         given:
-        Set<TableName> currentTableNames = [dependentDefinition1.name, satisfiedDefinition2.name, dependentDefinition3.name, circularDependentDefinition5.name, circularDependentDefinition6.name]
+        Set<TableName> currentTableNames = [
+                dependentDefinition1,
+                satisfiedDefinition2,
+                dependentDefinition3,
+                circularDependentDefinition5,
+                circularDependentDefinition6
+        ].name
 
         when:
         loader.buildDimensionSpanningTableGroup(
@@ -234,7 +230,12 @@ class BaseTableLoaderSpec extends Specification {
 
     def "self dependency physical table definition loading will throw an exception"() {
         given:
-        Set<TableName> currentTableNames = [dependentDefinition1.name, satisfiedDefinition2.name, dependentDefinition3.name, selfDependentDefinition4.name]
+        Set<TableName> currentTableNames = [
+                dependentDefinition1,
+                satisfiedDefinition2,
+                dependentDefinition3,
+                selfDependentDefinition4
+        ].name
 
         when:
         loader.buildDimensionSpanningTableGroup(

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/FilteredAggregationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/FilteredAggregationSpec.groovy
@@ -23,7 +23,7 @@ import com.yahoo.bard.webservice.druid.model.filter.Filter
 import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.web.ApiFilter
 import com.yahoo.bard.webservice.web.FilteredThetaSketchMetricsHelper
@@ -63,7 +63,7 @@ class FilteredAggregationSpec extends Specification{
 
         Set<Column> columns = [new DimensionColumn(ageDimension)] as Set
 
-        PhysicalTable physicalTable = new ConcretePhysicalTable(
+        PhysicalTable physicalTable = new StrictPhysicalTable(
                 "NETWORK",
                 DAY.buildZonedTimeGrain(UTC),
                 columns,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSourceSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/datasource/UnionDataSourceSpec.groovy
@@ -2,8 +2,8 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.datasource
 
-import com.yahoo.bard.webservice.data.config.names.TableName
 import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
 import com.yahoo.bard.webservice.table.ConstrainedTable
 
 import spock.lang.Specification
@@ -28,9 +28,9 @@ class UnionDataSourceSpec extends Specification {
     def "Test simple construction"() {
         setup:
         Set<String> expectedNames = ["test1", "test2"] as Set
-        table.getDataSourceNames() >> ((expectedNames.collect {TableName.of(it)} ) as Set)
+        table.getDataSourceNames() >> (expectedNames.collect {DataSourceName.of(it)} as Set)
 
         expect:
-        (new UnionDataSource(table)).getNames() == expectedNames
+        new UnionDataSource(table).names == expectedNames
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
@@ -111,7 +111,7 @@ class GroupByQuerySpec extends Specification {
                 Mock(DataSourceMetadataService)
         )
 
-        vars.dataSource = vars.dataSource ?: new TableDataSource<GroupByQuery>(constrainedTable)
+        vars.dataSource = vars.dataSource ?: new TableDataSource(constrainedTable)
         vars.granularity = vars.granularity ?: DAY
         vars.dimensions = vars.dimensions ?: new ArrayList<Dimension>()
         vars.filter = vars.filter ?: null
@@ -214,7 +214,6 @@ class GroupByQuerySpec extends Specification {
         expect:
         GroovyTestUtils.compareJson(druidQuery1, queryString1)
         GroovyTestUtils.compareJson(druidQuery2, queryString2)
-
     }
 
     def "check filter serialization"() {
@@ -282,7 +281,6 @@ class GroupByQuerySpec extends Specification {
         GroovyTestUtils.compareJson(druidQuery1, queryString1)
         GroovyTestUtils.compareJson(druidQuery2, queryString2)
         GroovyTestUtils.compareJson(druidQuery3, queryString3)
-
     }
 
     def "check aggregation serialization"() {
@@ -328,13 +326,9 @@ class GroupByQuerySpec extends Specification {
         GroovyTestUtils.compareJson(druidQuery1, queryString1)
         GroovyTestUtils.compareJson(druidQuery2, queryString2)
         GroovyTestUtils.compareJson(druidQuery3, queryString3)
-
     }
 
     def "check post aggregation serialization"() {
-        Aggregation aggregation1 = new LongSumAggregation("pageViewsSum", "pageViews")
-        Aggregation aggregation2 = new LongSumAggregation("timeSpentSum", "timeSpent")
-
         List<PostAggregation> postAggregations1 = []
         List<PostAggregation> postAggregations2 = [postAggregation1]
         List<PostAggregation> postAggregations3 = [postAggregation1, postAggregation3]
@@ -525,7 +519,7 @@ class GroupByQuerySpec extends Specification {
 
         GroupByQuery query = defaultQuery(dimensions: dimensions, aggregations: aggregations, postAggregations: postAggregations )
         List<Column> columns = [dimension1, dimension2].collect {new DimensionColumn(it)}
-        columns.addAll([aggregation1, aggregation2, postAggregation3].collect {new MetricColumn(it.getName())})
+        columns.addAll([aggregation1, aggregation2, postAggregation3].collect {new MetricColumn(it.name)})
 
         expect:
         query.buildSchemaColumns().collect(Collectors.toList()) == columns

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuerySpec.groovy
@@ -37,7 +37,6 @@ class TimeSeriesQuerySpec extends Specification {
     }
 
     TimeSeriesQuery defaultQuery(Map vars) {
-
         vars.dataSource = vars.dataSource ?: new TableDataSource(TableTestUtils.buildTable(
                 "table_name",
                 DAY.buildZonedTimeGrain(DateTimeZone.UTC),

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TopNQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TopNQuerySpec.groovy
@@ -43,8 +43,7 @@ class TopNQuerySpec extends Specification {
     }
 
     TopNQuery defaultQuery(Map vars) {
-
-        vars.dataSource = vars.dataSource ?: new TableDataSource<TopNQuery>(TableTestUtils.buildTable(
+        vars.dataSource = vars.dataSource ?: new TableDataSource(TableTestUtils.buildTable(
                 "table_name",
                 DAY.buildZonedTimeGrain(DateTimeZone.UTC),
                 [] as Set,
@@ -109,9 +108,10 @@ class TopNQuerySpec extends Specification {
     }
 
     def "check dimension serialization"() {
-        LinkedHashSet<DimensionField> dimensionFields = new LinkedHashSet<>()
-        dimensionFields.add(BardDimensionField.ID)
-        dimensionFields.add(BardDimensionField.DESC)
+        LinkedHashSet<DimensionField> dimensionFields = [
+                BardDimensionField.ID,
+                BardDimensionField.DESC
+        ] as LinkedHashSet
 
         Dimension dimension1 = new KeyValueStoreDimension(
                 "apiLocale",
@@ -124,7 +124,7 @@ class TopNQuerySpec extends Specification {
         TopNQuery dq1 = defaultQuery(dimension: dimension1)
         String druidQuery1 = MAPPER.writeValueAsString(dq1)
 
-        String queryString1 = stringQuery(dimension: '{ "dimension":"locale","outputName":"apiLocale","type":"default" }')
+        String queryString1 = stringQuery(dimension: '{"dimension":"locale","outputName":"apiLocale","type":"default"}')
 
         expect:
         GroovyTestUtils.compareJson(druidQuery1, queryString1)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 
 class BaseDataSourceMetadataSpec extends Specification {
     @Shared
-    String tableName = TestDruidTableName.ALL_PETS.asName();
+    String tableName = TestDruidTableName.ALL_PETS.asName()
 
     @Shared
     String intervalString1
@@ -72,7 +72,7 @@ class BaseDataSourceMetadataSpec extends Specification {
 
     def setupSpec() {
         currentTZ = DateTimeZone.getDefault()
-        DateTimeZone.setDefault(DateTimeZone.UTC);
+        DateTimeZone.setDefault(DateTimeZone.UTC)
 
         intervalString1 = "2015-01-01T00:00:00.000Z/2015-01-02T00:00:00.000Z"
         intervalString2 = "2015-01-02T00:00:00.000Z/2015-01-03T00:00:00.000Z"

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoaderSpec.groovy
@@ -20,8 +20,8 @@ import com.yahoo.bard.webservice.druid.model.datasource.DataSource
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery
 import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
 import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.ConstrainedTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary
 
 import org.joda.time.DateTime
@@ -35,7 +35,7 @@ import spock.lang.Specification
 class DataSourceMetadataLoaderSpec extends Specification {
     private static final ObjectMappersSuite MAPPERS = new ObjectMappersSuite()
 
-    String tableName = TestDruidTableName.ALL_PETS.asName();
+    String tableName = TestDruidTableName.ALL_PETS.asName()
 
     Interval interval1 = Interval.parse("2015-01-01T00:00:00.000Z/2015-01-02T00:00:00.000Z")
     Interval interval2 = Interval.parse("2015-01-02T00:00:00.000Z/2015-01-03T00:00:00.000Z")
@@ -214,7 +214,7 @@ class DataSourceMetadataLoaderSpec extends Specification {
                 MAPPERS.mapper
         )
         druidWS.jsonResponse = {gappyDataSourceMetadataJson}
-        ConcretePhysicalTable table = Mock(ConcretePhysicalTable)
+        StrictPhysicalTable table = Mock(StrictPhysicalTable)
         table.dataSourceName >> DataSourceName.of("test")
         DataSourceMetadata capture
 
@@ -246,7 +246,7 @@ class DataSourceMetadataLoaderSpec extends Specification {
                 testWs,
                 MAPPERS.mapper
         )
-        ConcretePhysicalTable table = Mock(ConcretePhysicalTable)
+        StrictPhysicalTable table = Mock(StrictPhysicalTable)
         table.dataSourceName >> DataSourceName.of("test")
 
         when: "loader issues a metadata query"

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoaderSpec.groovy
@@ -7,6 +7,7 @@ import static com.yahoo.bard.webservice.data.Columns.METRICS
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
 import com.yahoo.bard.webservice.application.ObjectMappersSuite
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
 import com.yahoo.bard.webservice.data.config.names.TestApiDimensionName
 import com.yahoo.bard.webservice.data.config.names.TestApiMetricName
 import com.yahoo.bard.webservice.data.config.names.TestDruidTableName
@@ -20,6 +21,7 @@ import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery
 import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
 import com.yahoo.bard.webservice.table.Column
 import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.ConstrainedTable
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary
 
 import org.joda.time.DateTime
@@ -187,7 +189,10 @@ class DataSourceMetadataLoaderSpec extends Specification {
                 MAPPERS.mapper
         )
         DataSource dataSource = Mock(DataSource)
-        dataSource.getNames() >> ([tableName] as Set)
+        dataSource.physicalTable >> Mock(ConstrainedTable) {
+            getDataSourceNames() >> ([DataSourceName.of(tableName)] as Set)
+        }
+
         DruidAggregationQuery<?> query = Mock(DruidAggregationQuery)
         query.intervals >> [interval1, interval2]
         query.innermostQuery >> query
@@ -210,15 +215,15 @@ class DataSourceMetadataLoaderSpec extends Specification {
         )
         druidWS.jsonResponse = {gappyDataSourceMetadataJson}
         ConcretePhysicalTable table = Mock(ConcretePhysicalTable)
-        table.getFactTableName() >> "test"
+        table.dataSourceName >> DataSourceName.of("test")
         DataSourceMetadata capture
 
         when: "JSON metadata return successfully"
-        SuccessCallback success = loader.buildDataSourceMetadataSuccessCallback(table)
+        SuccessCallback success = loader.buildDataSourceMetadataSuccessCallback(table.dataSourceName)
         success.invoke(MAPPERS.mapper.readTree(gappyDataSourceMetadataJson))
 
         then: "the segment metadata are loaded to the metadata service as expected"
-        1 * localMetadataService.update(table, _) >> { physicalTable, dataSourceMetadata ->
+        1 * localMetadataService.update(table.dataSourceName, _ as DataSourceMetadata) >> { physicalTable, dataSourceMetadata ->
             capture = dataSourceMetadata
         }
         def intervals = DataSourceMetadata.getIntervalLists(capture)
@@ -242,10 +247,10 @@ class DataSourceMetadataLoaderSpec extends Specification {
                 MAPPERS.mapper
         )
         ConcretePhysicalTable table = Mock(ConcretePhysicalTable)
-        table.getFactTableName() >> "test"
+        table.dataSourceName >> DataSourceName.of("test")
 
         when: "loader issues a metadata query"
-        loader.queryDataSourceMetadata(table)
+        loader.queryDataSourceMetadata(table.dataSourceName)
 
         then: "the query is issued to the webservice that was specified to query the druid metadata endpoint"
         1 * testWs.getJsonObject(_, _, _, _)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataServiceSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataServiceSpec.groovy
@@ -3,8 +3,7 @@
 package com.yahoo.bard.webservice.metadata
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
-import com.yahoo.bard.webservice.data.config.names.TableName
-import com.yahoo.bard.webservice.table.PhysicalTableDictionary
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
 
 import org.joda.time.DateTime
 import org.joda.time.Interval
@@ -24,20 +23,19 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
     def "test metadata service updates segment availability for physical tables and access methods behave correctly"() {
         setup:
         JerseyTestBinder jtb = new JerseyTestBinder()
-        PhysicalTableDictionary tableDict = jtb.configurationLoader.getPhysicalTableDictionary()
+        DataSourceName dataSourceName = DataSourceName.of(tableName)
 
         DataSourceMetadataService metadataService = new DataSourceMetadataService()
-        TableName currentTableName = tableDict.get(tableName).getTableName()
 
         when:
-        metadataService.update(tableDict.get(tableName), metadata)
+        metadataService.update(dataSourceName, metadata)
 
         then:
-        metadataService.allSegmentsByTime.get(currentTableName) instanceof AtomicReference
-        metadataService.allSegmentsByColumn.get(currentTableName) instanceof AtomicReference
+        metadataService.allSegmentsByTime.get(dataSourceName) instanceof AtomicReference
+        metadataService.allSegmentsByColumn.get(dataSourceName) instanceof AtomicReference
 
         and:
-        metadataService.getTableSegments(Collections.singleton(currentTableName)).stream()
+        metadataService.getSegments([dataSourceName] as Set).stream()
                 .map({it.values()})
                 .flatMap({it.stream()})
                 .map({it.values()})
@@ -48,7 +46,7 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
                 ]
 
         and: "all the intervals by column in metadata service are simplified to interval12"
-        [[interval12]].containsAll(metadataService.getAvailableIntervalsByTable(currentTableName).values())
+        [[interval12]].containsAll(metadataService.getAvailableIntervalsByDataSource(dataSourceName).values())
 
         cleanup:
         jtb.tearDown()
@@ -79,11 +77,10 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
         DataSourceMetadataService metadataService = new DataSourceMetadataService()
 
         when:
-        metadataService.getAvailableIntervalsByTable(TableName.of("InvalidTable"))
+        metadataService.getAvailableIntervalsByDataSource(DataSourceName.of("InvalidTable"))
 
         then:
         IllegalStateException e = thrown()
-        e.message == 'Trying to access InvalidTable physical table datasource that is not available in metadata service'
-
+        e.message == "Datasource 'InvalidTable' is not available in the metadata service"
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataServiceSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataServiceSpec.groovy
@@ -25,6 +25,7 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
         setup:
         JerseyTestBinder jtb = new JerseyTestBinder()
         PhysicalTableDictionary tableDict = jtb.configurationLoader.getPhysicalTableDictionary()
+
         DataSourceMetadataService metadataService = new DataSourceMetadataService()
         TableName currentTableName = tableDict.get(tableName).getTableName()
 
@@ -40,8 +41,11 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
                 .map({it.values()})
                 .flatMap({it.stream()})
                 .map({it.values()})
-                .collect(Collectors.toList()).toString()  == [[segment1.getIdentifier(), segment2.getIdentifier()],
-                                                              [segment3.getIdentifier(), segment4.getIdentifier()]].toString()
+                .map({it.collect {it.identifier}})
+                .collect(Collectors.toList())  == [
+                        [segment1.identifier, segment2.identifier],
+                        [segment3.identifier, segment4.identifier]
+                ]
 
         and: "all the intervals by column in metadata service are simplified to interval12"
         [[interval12]].containsAll(metadataService.getAvailableIntervalsByTable(currentTableName).values())
@@ -53,24 +57,22 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
     def "grouping segment data by date time behave as expected"() {
         given:
         ConcurrentSkipListMap<DateTime, Map<String, SegmentInfo>> segmentByTime = DataSourceMetadataService.groupSegmentByTime(metadata)
-        DateTime dateTime1 = new DateTime(interval1.getStart())
-        DateTime dateTime2 = new DateTime(interval2.getStart())
+        DateTime dateTime1 = new DateTime(interval1.start)
+        DateTime dateTime2 = new DateTime(interval2.start)
 
         expect:
         segmentByTime.keySet() == [dateTime1, dateTime2] as Set
-        segmentByTime.get(new DateTime(interval2.getStart())).keySet() == [segment3.getIdentifier(), segment4.getIdentifier()] as Set
+        segmentByTime.get(new DateTime(interval2.start)).keySet() == [segment3.identifier, segment4.identifier] as Set
     }
-
 
     def "grouping intervals by column behave as expected"() {
         given:
-        Map<String, Set<Interval>> intervalByColumn = DataSourceMetadataService.groupIntervalByColumn(metadata)
+        Map<String, List<Interval>> intervalByColumn = DataSourceMetadataService.groupIntervalByColumn(metadata)
 
         expect:
         intervalByColumn.keySet() == (dimensions123 + metrics123) as Set
         intervalByColumn.get(dimensions123.get(0)) == [interval12]
     }
-
 
     def "accessing availability by column throws exception if the table does not exist in datasource metadata service"() {
         setup:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
@@ -137,18 +137,20 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
     @Unroll
     def "test getSegmentHash produces the #expectedHash for #requestedSegment"() {
         expect:
-        segmentSetIdGenerator.getSegmentHash(requestedSegment) == expectedHash
+        segmentSetIdGenerator.getSegmentHash(requestedSegment.stream()) == expectedHash
 
         where:
-        requestedSegment                                | expectedHash
-        [] as Set                                       | 0 as Long
+        requestedSegment                                | expectedValue
+        [] as Set                                       | null
         [availabilityList1] as Set                      | availabilityList1.hashCode()
-        [availabilityList2, availabilityList1] as Set   | (availabilityList2.hashCode() + availabilityList1.hashCode()) as long
+        [availabilityList2, availabilityList1] as Set   | availabilityList2.hashCode() + availabilityList1.hashCode()
+
+        expectedHash = !expectedValue ? Optional.empty() : Optional.of(expectedValue as long)
     }
 
     def "test different segments have different hashcodes"() {
         expect:
-        segmentSetIdGenerator.getSegmentHash([availabilityList1] as Set) != segmentSetIdGenerator.getSegmentHash([availabilityList2] as Set)
+        segmentSetIdGenerator.getSegmentHash([availabilityList1].stream()).get() != segmentSetIdGenerator.getSegmentHash([availabilityList2].stream()).get()
     }
 
     @Unroll

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
@@ -98,7 +98,8 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
                 intervals: [interval2],
                 dataSource: new TableDataSource(
                         TableTestUtils.buildTable(
-                                tableName, DefaultTimeGrain.DAY.buildZonedTimeGrain(UTC),
+                                tableName,
+                                DefaultTimeGrain.DAY.buildZonedTimeGrain(UTC),
                                 [] as Set,
                                 [:],
                                 Mock(DataSourceMetadataService)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
@@ -70,19 +70,15 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
         tableDict = jtb.configurationLoader.physicalTableDictionary
         metadataService = new DataSourceMetadataService()
 
-        segmentSetIdGenerator = new SegmentIntervalsHashIdGenerator(
-                tableDict,
-                metadataService
-        )
+        segmentSetIdGenerator = new SegmentIntervalsHashIdGenerator(metadataService)
 
-        Map<Class, RequestedIntervalsFunction> signingFunctions = new DefaultingDictionary<>({new SimplifiedIntervalList(it.getIntervals())} as RequestedIntervalsFunction)
-        signingFunctions.put(LookbackQuery.class, new LookbackQuery.LookbackQueryRequestedIntervalsFunction())
-
-        customSegmentSetIdGenerator = new SegmentIntervalsHashIdGenerator(
-                tableDict,
-                metadataService,
-                signingFunctions
+        Map<Class, RequestedIntervalsFunction> signingFunctions = new DefaultingDictionary<>(
+                { DruidAggregationQuery query -> new SimplifiedIntervalList(query.intervals) } as RequestedIntervalsFunction
         )
+        signingFunctions.put(LookbackQuery, new LookbackQuery.LookbackQueryRequestedIntervalsFunction())
+
+        customSegmentSetIdGenerator = new SegmentIntervalsHashIdGenerator(metadataService, signingFunctions)
+
         availabilityList1 = [
                 (interval1.start): segmentInfoMap1,
                 (interval2.start): segmentInfoMap2

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.metadata
 import static org.joda.time.DateTimeZone.UTC
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource
 import com.yahoo.bard.webservice.druid.model.datasource.QueryDataSource
@@ -14,6 +15,7 @@ import com.yahoo.bard.webservice.druid.model.query.LookbackQuery
 import com.yahoo.bard.webservice.druid.model.query.LookbackQuerySpec
 import com.yahoo.bard.webservice.druid.model.query.TimeSeriesQuery
 import com.yahoo.bard.webservice.druid.model.query.TimeSeriesQuerySpec
+import com.yahoo.bard.webservice.table.ConstrainedTable
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary
 import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.DefaultingDictionary
@@ -92,7 +94,7 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
         atomicRef.set(availabilityList1)
 
         metadataService.allSegmentsByTime.put(
-                tableDict.get(tableName).getTableName(),
+                tableDict.get(tableName).dataSourceNames[0],
                 atomicRef
         )
 
@@ -120,8 +122,11 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
 
     def "test metadata service returns valid segment ids"() {
         setup:
-        DataSource<?> dataSource = Mock(DataSource)
-        dataSource.getNames() >> ([tableName] as Set)
+        DataSource dataSource = Mock(DataSource)
+        dataSource.physicalTable >> Mock(ConstrainedTable) {
+            getDataSourceNames() >> ([DataSourceName.of(tableName)] as Set)
+        }
+
         DruidAggregationQuery<?> query = Mock(DruidAggregationQuery)
         query.intervals >> [interval1, interval2]
         query.innermostQuery >> query

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/BaseCompositePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/BaseCompositePhysicalTableSpec.groovy
@@ -16,8 +16,8 @@ class BaseCompositePhysicalTableSpec extends Specification {
         ZonedTimeGrain coarsestTimeGrain = Mock(ZonedTimeGrain) {
             toString() >> "MockTimeGrain"
         }
-        TableName tableName1 = TableName.of("satisfyingTable")
-        TableName tableName2 = TableName.of("notMatchingTimeGrainTable")
+        String tableName1 = "satisfyingTable"
+        String tableName2 = "notMatchingTimeGrainTable"
 
         ZonedTimeGrain satisfyingGrain = Mock(ZonedTimeGrain) {
             satisfies(coarsestTimeGrain) >> true
@@ -35,11 +35,11 @@ class BaseCompositePhysicalTableSpec extends Specification {
 
         PhysicalTable physicalTable1 = Mock(PhysicalTable) {
             getSchema() >> schema1
-            getTableName() >> tableName1
+            getName() >> tableName1
         }
         PhysicalTable physicalTable2 = Mock(PhysicalTable) {
             getSchema() >> schema2
-            getTableName() >> tableName2
+            getName() >> tableName2
         }
 
         when:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/ConcretePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/ConcretePhysicalTableSpec.groovy
@@ -76,22 +76,22 @@ class ConcretePhysicalTableSpec extends Specification {
     def "Physical table getAvailableIntervals returns #expected for column #column"() {
         setup:
         DataSourceConstraint constraints = Mock(DataSourceConstraint)
-        constraints.getAllColumnNames() >> [column.name]
+        constraints.allColumnNames >> [column.name]
 
         expect:
         physicalTable.getAvailableIntervals(constraints) as List == new SimplifiedIntervalList(expected) as List
 
         where:
-        column                      | expected
-        dimensionColumn             | intervalSet1
-        metricColumn1               | intervalSet2
-        metricColumn2               | intervalSet3
+        column          | expected
+        dimensionColumn | intervalSet1
+        metricColumn1   | intervalSet2
+        metricColumn2   | intervalSet3
     }
 
     def "Physical table getAvailableIntervals throws exception when requesting a column not on the table"() {
         given:
         DataSourceConstraint constraints = Mock(DataSourceConstraint)
-        constraints.getAllColumnNames() >> ['un_configured']
+        constraints.allColumnNames >> ['un_configured']
 
         when:
         physicalTable.getAvailableIntervals(constraints)
@@ -107,7 +107,7 @@ class ConcretePhysicalTableSpec extends Specification {
         PhysicalTable table
         Map<String, Set<Interval>> noMetricMetadata = ['dimension_one' : (intervalSet3)]
         DataSourceConstraint constraints = Mock(DataSourceConstraint)
-        constraints.getAllColumnNames() >> [metricColumn1.name]
+        constraints.allColumnNames >> [metricColumn1.name]
 
         when:
         table = new ConcretePhysicalTable(
@@ -119,9 +119,9 @@ class ConcretePhysicalTableSpec extends Specification {
         )
 
         then:
-        table.getAllAvailableIntervals().containsKey(dimensionColumn)
-        table.getAllAvailableIntervals().get(dimensionColumn) as List == new SimplifiedIntervalList(intervalSet3) as List
-        table.getDimensions() == [dimension] as Set
+        table.allAvailableIntervals.containsKey(dimensionColumn)
+        table.allAvailableIntervals.get(dimensionColumn) as List == new SimplifiedIntervalList(intervalSet3) as List
+        table.dimensions == [dimension] as Set
 
         when:
         table.setAvailability(new ConcreteAvailability(physicalTable.getTableName(), new TestDataSourceMetadataService(segmentMetadata)))
@@ -134,7 +134,7 @@ class ConcretePhysicalTableSpec extends Specification {
     def "test the getIntervalsByColumnName() method"() {
         setup:
         DataSourceConstraint constraints = Mock(DataSourceConstraint)
-        constraints.getAllColumnNames() >> [metricColumn2.name]
+        constraints.allColumnNames >> [metricColumn2.name]
 
         expect:
         physicalTable.getAvailableIntervals(constraints).asList() == new SimplifiedIntervalList(intervalSet3).toList()
@@ -142,7 +142,7 @@ class ConcretePhysicalTableSpec extends Specification {
 
     def "test the fetching of all dimensions from the table"() {
         expect:
-        physicalTable.getDimensions() == [dimension] as Set
+        physicalTable.dimensions == [dimension] as Set
     }
 
     def "test physical to logical mapping is constructed correctly with multiple logical name to one physical name"() {
@@ -163,7 +163,7 @@ class ConcretePhysicalTableSpec extends Specification {
         )
 
         expect:
-        oneDimPhysicalTable.getSchema().getLogicalColumnNames('dimension_one') == ['dimensionOne'] as Set
-        twoDimPhysicalTable.getSchema().getLogicalColumnNames('dimension_one') == ['dimensionOne', 'dimensionTwo'] as Set
+        oneDimPhysicalTable.schema.getLogicalColumnNames('dimension_one') == ['dimensionOne'] as Set
+        twoDimPhysicalTable.schema.getLogicalColumnNames('dimension_one') == ['dimensionOne', 'dimensionTwo'] as Set
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/ConcretePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/ConcretePhysicalTableSpec.groovy
@@ -124,7 +124,12 @@ class ConcretePhysicalTableSpec extends Specification {
         table.dimensions == [dimension] as Set
 
         when:
-        table.setAvailability(new ConcreteAvailability(physicalTable.getTableName(), new TestDataSourceMetadataService(segmentMetadata)))
+        table.setAvailability(
+                new ConcreteAvailability(
+                        physicalTable.dataSourceName,
+                        new TestDataSourceMetadataService(segmentMetadata)
+                )
+        )
 
         then:
         table.getDimensions() == [dimension] as Set

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PermissivePhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/PermissivePhysicalTableSpec.groovy
@@ -22,8 +22,8 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class PermissiveConcretePhysicalTableSpec extends Specification {
-    @Shared PermissiveConcretePhysicalTable permissiveConcretePhysicalTable
+class PermissivePhysicalTableSpec extends Specification {
+    @Shared PermissivePhysicalTable permissivePhysicalTable
 
     @Shared DimensionColumn disjointIntervalColumn
     @Shared MetricColumn leftAbuttingIntervalColumn, rightAbuttingIntervalColumn
@@ -51,7 +51,7 @@ class PermissiveConcretePhysicalTableSpec extends Specification {
         rightAbuttingInterval = new Interval("2017-02-01/2017-03-01")
         invisibleInterval = new Interval("2016-01-01/2016-02-01")
 
-        permissiveConcretePhysicalTable = new PermissiveConcretePhysicalTable(
+        permissivePhysicalTable = new PermissivePhysicalTable(
                 TableName.of('test table'),
                 DAY.buildZonedTimeGrain(UTC),
                 [disjointIntervalColumn, leftAbuttingIntervalColumn, rightAbuttingIntervalColumn] as Set,
@@ -72,7 +72,7 @@ class PermissiveConcretePhysicalTableSpec extends Specification {
         constraints.getAllColumnNames() >> allColumnNames
 
         expect:
-        permissiveConcretePhysicalTable.getAvailableIntervals(constraints) == new SimplifiedIntervalList(expected)
+        permissivePhysicalTable.getAvailableIntervals(constraints) == new SimplifiedIntervalList(expected)
 
         where:
         allColumnNames                                                | expected

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/StrictPhysicalTableSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/StrictPhysicalTableSpec.groovy
@@ -17,7 +17,7 @@ import com.yahoo.bard.webservice.data.dimension.impl.ScanSearchProviderManager
 import com.yahoo.bard.webservice.data.metric.MetricColumn
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
-import com.yahoo.bard.webservice.table.availability.ConcreteAvailability
+import com.yahoo.bard.webservice.table.availability.StrictAvailability
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
@@ -27,9 +27,9 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class ConcretePhysicalTableSpec extends Specification {
+class StrictPhysicalTableSpec extends Specification {
 
-    @Shared ConcretePhysicalTable physicalTable
+    @Shared StrictPhysicalTable physicalTable
     @Shared DimensionDictionary dimensionDictionary
 
     @Shared Dimension dimension
@@ -63,7 +63,7 @@ class ConcretePhysicalTableSpec extends Specification {
                 'metric_two'    : (intervalSet3)
         ]
 
-        physicalTable = new ConcretePhysicalTable(
+        physicalTable = new StrictPhysicalTable(
                 TableName.of("test table"),
                 DAY.buildZonedTimeGrain(UTC),
                 [dimensionColumn, metricColumn1, metricColumn2] as Set,
@@ -110,7 +110,7 @@ class ConcretePhysicalTableSpec extends Specification {
         constraints.allColumnNames >> [metricColumn1.name]
 
         when:
-        table = new ConcretePhysicalTable(
+        table = new StrictPhysicalTable(
                 TableName.of(name),
                 YEAR.buildZonedTimeGrain(UTC),
                 [dimensionColumn, metricColumn1] as Set,
@@ -125,7 +125,7 @@ class ConcretePhysicalTableSpec extends Specification {
 
         when:
         table.setAvailability(
-                new ConcreteAvailability(
+                new StrictAvailability(
                         physicalTable.dataSourceName,
                         new TestDataSourceMetadataService(segmentMetadata)
                 )
@@ -152,14 +152,14 @@ class ConcretePhysicalTableSpec extends Specification {
 
     def "test physical to logical mapping is constructed correctly with multiple logical name to one physical name"() {
         setup:
-        PhysicalTable oneDimPhysicalTable = new ConcretePhysicalTable(
+        PhysicalTable oneDimPhysicalTable = new StrictPhysicalTable(
                 TableName.of("test table"),
                 DAY.buildZonedTimeGrain(UTC),
                 [dimensionColumn] as Set,
                 ['dimensionOne': 'dimension_one'],
                 Mock(DataSourceMetadataService)
         )
-        PhysicalTable twoDimPhysicalTable = new ConcretePhysicalTable(
+        PhysicalTable twoDimPhysicalTable = new StrictPhysicalTable(
                 TableName.of("test table"),
                 DAY.buildZonedTimeGrain(UTC),
                 [dimensionColumn] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/TableTestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/TableTestUtils.groovy
@@ -10,13 +10,13 @@ import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
 class TableTestUtils {
 
     static List buildConcreteAndConstrained(String name, ZonedTimeGrain grain, Set<Column> columns, Map<String, String> nameMap, DataSourceMetadataService service) {
-        ConcretePhysicalTable table = new ConcretePhysicalTable(TableName.of(name), grain, columns, nameMap, service)
+        StrictPhysicalTable table = new StrictPhysicalTable(TableName.of(name), grain, columns, nameMap, service)
         DataSourceConstraint constraint = DataSourceConstraint.unconstrained(table)
         return [table, table.withConstraint(constraint)]
     }
 
     static ConstrainedTable buildTable(String name, ZonedTimeGrain grain, Set<Column> columns, Map<String, String> nameMap, DataSourceMetadataService service) {
-        ConcretePhysicalTable table = new ConcretePhysicalTable(TableName.of(name), grain, columns, nameMap, service)
+        StrictPhysicalTable table = new StrictPhysicalTable(TableName.of(name), grain, columns, nameMap, service)
         DataSourceConstraint constraint = DataSourceConstraint.unconstrained(table)
         return table.withConstraint(constraint)
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/TableTestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/TableTestUtils.groovy
@@ -2,6 +2,7 @@
 //  Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table
 
+import com.yahoo.bard.webservice.data.config.names.TableName
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
@@ -9,13 +10,13 @@ import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
 class TableTestUtils {
 
     static List buildConcreteAndConstrained(String name, ZonedTimeGrain grain, Set<Column> columns, Map<String, String> nameMap, DataSourceMetadataService service) {
-        ConcretePhysicalTable table = new ConcretePhysicalTable( name, grain, columns, nameMap, service)
+        ConcretePhysicalTable table = new ConcretePhysicalTable(TableName.of(name), grain, columns, nameMap, service)
         DataSourceConstraint constraint = DataSourceConstraint.unconstrained(table)
         return [table, table.withConstraint(constraint)]
     }
 
     static ConstrainedTable buildTable(String name, ZonedTimeGrain grain, Set<Column> columns, Map<String, String> nameMap, DataSourceMetadataService service) {
-        ConcretePhysicalTable table = new ConcretePhysicalTable( name, grain, columns, nameMap, service)
+        ConcretePhysicalTable table = new ConcretePhysicalTable(TableName.of(name), grain, columns, nameMap, service)
         DataSourceConstraint constraint = DataSourceConstraint.unconstrained(table)
         return table.withConstraint(constraint)
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/AvailabilityTestingUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/AvailabilityTestingUtils.groovy
@@ -59,7 +59,7 @@ class AvailabilityTestingUtils extends Specification {
 
                     // set new cache
                     table.setAvailability(
-                            new ConcreteAvailability(
+                            new StrictAvailability(
                                     DataSourceName.of(table.name),
                                     new TestDataSourceMetadataService(allIntervals)
                             )

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/AvailabilityTestingUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/AvailabilityTestingUtils.groovy
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.table.availability
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
 import com.yahoo.bard.webservice.data.dimension.DimensionColumn
 import com.yahoo.bard.webservice.data.metric.MetricColumn
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
@@ -56,8 +57,13 @@ class AvailabilityTestingUtils extends Specification {
                             metricIntervals.entrySet().stream()
                     ).collect(Collectors.toMap({ it.key }, { it.value }))
 
-            // set new cache
-                    table.setAvailability(new ConcreteAvailability(table.getTableName(), new TestDataSourceMetadataService(allIntervals)))
+                    // set new cache
+                    table.setAvailability(
+                            new ConcreteAvailability(
+                                    DataSourceName.of(table.name),
+                                    new TestDataSourceMetadataService(allIntervals)
+                            )
+                    )
                 }
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/AvailabilityTestingUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/AvailabilityTestingUtils.groovy
@@ -6,8 +6,6 @@ import com.yahoo.bard.webservice.application.JerseyTestBinder
 import com.yahoo.bard.webservice.data.dimension.DimensionColumn
 import com.yahoo.bard.webservice.data.metric.MetricColumn
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
-import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary
 
 import org.joda.time.Interval
@@ -42,18 +40,16 @@ class AvailabilityTestingUtils extends Specification {
         Set<String> tableNames = namesOfTablesToPopulate ?: physicalTableDictionary.keySet()
 
         physicalTableDictionary
-                .findAll { tableName, _ -> tableName in tableNames}
-                .each { _, ConcretePhysicalTable table ->
-                    Map<Column, Set<Interval>> metricIntervals = table.getSchema().getColumns(MetricColumn.class)
-                            .collectEntries {
-                                    [(it.getName()): intervalSet]
-                            }
+                .findAll { tableName, _ -> tableName in tableNames }
+                .each { _, table ->
+                    Map<String, Set<Interval>> metricIntervals = table.schema.getColumns(MetricColumn)
+                            .collectEntries { [(it.name): intervalSet] }
 
                     // Below code assumes unique one-to-one mapping from logical to physical name in testing resource
-                    Map<String, Set<Interval>> dimensionIntervals = table.getSchema().getColumns(DimensionColumn.class)
+                    Map<String, Set<Interval>> dimensionIntervals = table.schema.getColumns(DimensionColumn)
                             .collectEntries {
-                                    [(table.getSchema().getPhysicalColumnName(it.getName())): intervalSet]
-                            }
+                        [(table.schema.getPhysicalColumnName(it.name)): intervalSet]
+                    }
 
                     Map<String, Set<Interval>> allIntervals = Stream.concat(
                             dimensionIntervals.entrySet().stream(),

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ConcreteAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ConcreteAvailabilitySpec.groovy
@@ -1,6 +1,6 @@
 package com.yahoo.bard.webservice.table.availability
 
-import com.yahoo.bard.webservice.data.config.names.TableName
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
@@ -28,7 +28,7 @@ class ConcreteAvailabilitySpec extends Specification{
         interval2 = new Interval('2010-01-01/2020-12-31')
 
         concreteAvailability = new ConcreteAvailability(
-                TableName.of('table'),
+                DataSourceName.of('table'),
                 new TestDataSourceMetadataService([
                         (columnPhysicalName1): [interval1] as Set,
                         (columnPhysicalName2): [interval2] as Set,
@@ -53,7 +53,7 @@ class ConcreteAvailabilitySpec extends Specification{
         interval2 = new Interval(secondInterval)
 
         concreteAvailability = new ConcreteAvailability(
-                TableName.of('table'),
+                DataSourceName.of('table'),
                 new TestDataSourceMetadataService([
                         (columnPhysicalName1): [interval1] as Set,
                         (columnPhysicalName2): [interval2] as Set

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ConcreteAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/ConcreteAvailabilitySpec.groovy
@@ -8,6 +8,7 @@ import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 import org.joda.time.Interval
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * Test for concrete availability behavior.
@@ -19,7 +20,6 @@ class ConcreteAvailabilitySpec extends Specification{
     Interval interval1, interval2
 
     def setup() {
-
         columnPhysicalName1 = 'column_one'
         columnPhysicalName2 = 'column_two'
         columnPhysicalName3 = 'column_three'
@@ -46,7 +46,8 @@ class ConcreteAvailabilitySpec extends Specification{
         ] as LinkedHashMap
     }
 
-    def "getAvailableIntervals returns the intersection of the requested column available intervals"() {
+    @Unroll
+    def "getAvailableIntervals returns the intersection of the requested column available intervals when there is #description"() {
         given:
         interval1 = new Interval(firstInterval)
         interval2 = new Interval(secondInterval)
@@ -60,7 +61,7 @@ class ConcreteAvailabilitySpec extends Specification{
         )
 
         PhysicalDataSourceConstraint dataSourceConstraint = Mock(PhysicalDataSourceConstraint)
-        dataSourceConstraint.getAllColumnPhysicalNames() >> [columnPhysicalName1, columnPhysicalName2]
+        dataSourceConstraint.allColumnPhysicalNames >> [columnPhysicalName1, columnPhysicalName2]
 
         expect:
         concreteAvailability.getAvailableIntervals(dataSourceConstraint) == new SimplifiedIntervalList(
@@ -82,7 +83,7 @@ class ConcreteAvailabilitySpec extends Specification{
     def "getAvailableInterval returns empty interval if given column is not in data source metadata service"() {
         given:
         PhysicalDataSourceConstraint constraint = Mock(PhysicalDataSourceConstraint)
-        constraint.getAllColumnPhysicalNames() >> ['ignored']
+        constraint.allColumnPhysicalNames >> ['ignored']
 
         expect:
         concreteAvailability.getAvailableIntervals(constraint) == new SimplifiedIntervalList()
@@ -91,7 +92,7 @@ class ConcreteAvailabilitySpec extends Specification{
     def "getAvailableInterval returns empty interval if given empty column request"() {
         given:
         PhysicalDataSourceConstraint constraint = Mock(PhysicalDataSourceConstraint)
-        constraint.getAllColumnPhysicalNames() >> []
+        constraint.allColumnPhysicalNames >> []
 
         expect:
         concreteAvailability.getAvailableIntervals(constraint) == new SimplifiedIntervalList()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
@@ -59,12 +59,8 @@ class MetricUnionAvailabilitySpec extends Specification {
 
     def "Metric columns are initialized by fetching columns from availabilities, not from physical tables"() {
         given:
-        availability1.getAllAvailableIntervals() >> [
-                (metric1): []
-        ]
-        availability2.getAllAvailableIntervals() >> [
-                (metric2): []
-        ]
+        availability1.getAllAvailableIntervals() >> [(metric1): []]
+        availability2.getAllAvailableIntervals() >> [(metric2): []]
 
         MetricColumn tableColumn1 = new MetricColumn("shouldNotBeReturned1")
         MetricColumn tableColumn2 = new MetricColumn("shouldNotBeReturned2")
@@ -92,16 +88,13 @@ class MetricUnionAvailabilitySpec extends Specification {
 
     @Unroll
     def "isMetricUnique returns true if and only if metric is unique across all data sources in the case of #caseDescription"() {
-        when:
-        boolean actual = MetricUnionAvailability.isMetricUnique(
+        expect:
+        expected == MetricUnionAvailability.isMetricUnique(
                 [
-                        (availability1): metricColumnNames1.collect{it -> it} as Set,
-                        (availability2): metricColumnNames2.collect{it -> it} as Set
+                        (availability1): metricColumnNames1 as Set,
+                        (availability2): metricColumnNames2 as Set
                 ]
         )
-
-        then:
-        actual == expected
 
         where:
         metricColumnNames1     | metricColumnNames2                | expected           | caseDescription
@@ -115,12 +108,8 @@ class MetricUnionAvailabilitySpec extends Specification {
 
     def "constructor throws IllegalArgumentException when 2 availabilities have the same metric column"() {
         given:
-        availability1.getAllAvailableIntervals() >> [
-                (metric1): []
-        ]
-        availability2.getAllAvailableIntervals() >> [
-                (metric1): []
-        ]
+        availability1.getAllAvailableIntervals() >> [(metric1): []]
+        availability2.getAllAvailableIntervals() >> [(metric1): []]
 
         when:
         metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1] as Set)
@@ -129,7 +118,6 @@ class MetricUnionAvailabilitySpec extends Specification {
         RuntimeException exception = thrown()
         exception.message.startsWith("Metric columns must be unique across the metric union data sources, but duplicate was found across the following data sources: source1, source2")
     }
-
 
     def "getDataSourceNames returns sources from availabilities not from physical tables"() {
         given:
@@ -167,14 +155,11 @@ class MetricUnionAvailabilitySpec extends Specification {
                 (metric2): [new Interval('2019-01-01/2019-02-01')],
                 'column' : [new Interval('2018-01-01/2018-02-01')]
         ]
-
     }
 
     def "constructSubConstraint correctly intersects metrics configured on the table with the metrics supported by availability's underlying datasource"() {
         given:
-        availability1.getAllAvailableIntervals() >> [
-                (metric1): []
-        ]
+        availability1.getAllAvailableIntervals() >> [(metric1): []]
         availability2.getAllAvailableIntervals() >> [
                 (metric2): [],
                 'un_requested': []
@@ -203,12 +188,8 @@ class MetricUnionAvailabilitySpec extends Specification {
     @Unroll
     def "getAvailableIntervals returns the intersection of requested columns when available intervals have #reason"() {
         given:
-        availability1.getAllAvailableIntervals() >> [
-                (metric1): []
-        ]
-        availability2.getAllAvailableIntervals() >> [
-                (metric2): []
-        ]
+        availability1.getAllAvailableIntervals() >> [(metric1): []]
+        availability2.getAllAvailableIntervals() >> [(metric2): []]
 
         availability1.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList(
                 availableIntervals1.collect{it -> new Interval(it)} as Set
@@ -253,12 +234,8 @@ class MetricUnionAvailabilitySpec extends Specification {
 
     def "getAvailableIntervals returns empty availability if requesting a column on table that is not supported by the underlying data sources"() {
         given:
-        availability1.getAllAvailableIntervals() >> [
-                (metric1): ['2018-01-01/2018-02-01']
-        ]
-        availability2.getAllAvailableIntervals() >> [
-                (metric2): ['2018-01-01/2018-02-01']
-        ]
+        availability1.getAllAvailableIntervals() >> [(metric1): ['2018-01-01/2018-02-01']]
+        availability2.getAllAvailableIntervals() >> [(metric2): ['2018-01-01/2018-02-01']]
 
         availability1.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList(
                 [new Interval('2018-01-01/2018-02-01')]

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.availability
 
-import com.yahoo.bard.webservice.data.config.names.TableName
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
 import com.yahoo.bard.webservice.data.metric.MetricColumn
 import com.yahoo.bard.webservice.table.Column
 import com.yahoo.bard.webservice.table.ConfigPhysicalTable
@@ -39,8 +39,8 @@ class MetricUnionAvailabilitySpec extends Specification {
         availability1 = Mock(Availability)
         availability2 = Mock(Availability)
 
-        availability1.getDataSourceNames() >> ([TableName.of('source1')] as Set)
-        availability2.getDataSourceNames() >> ([TableName.of('source2')] as Set)
+        availability1.dataSourceNames >> ([DataSourceName.of('source1')] as Set)
+        availability2.dataSourceNames >> ([DataSourceName.of('source2')] as Set)
 
         metric1 = 'metric1'
         metric2 = 'metric2'
@@ -134,7 +134,7 @@ class MetricUnionAvailabilitySpec extends Specification {
         )
 
         expect:
-        outerMetricUnionAvailability.getDataSourceNames() == [TableName.of('source1'), TableName.of('source2')] as Set
+        outerMetricUnionAvailability.dataSourceNames == [DataSourceName.of('source1'), DataSourceName.of('source2')] as Set
     }
 
     def "getAllAvailableIntervals returns the combined intervals of all columns of all availabilities"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
@@ -65,7 +65,7 @@ class MetricUnionAvailabilitySpec extends Specification {
         MetricColumn tableColumn1 = new MetricColumn("shouldNotBeReturned1")
         MetricColumn tableColumn2 = new MetricColumn("shouldNotBeReturned2")
 
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1, metricColumn2] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, [metricColumn1, metricColumn2] as Set)
 
         when:
         Map<Availability, Set<String>> availabilitiesToAvailableColumns = metricUnionAvailability.availabilitiesToMetricNames
@@ -112,7 +112,7 @@ class MetricUnionAvailabilitySpec extends Specification {
         availability2.getAllAvailableIntervals() >> [(metric1): []]
 
         when:
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, [metricColumn1] as Set)
 
         then:
         RuntimeException exception = thrown()
@@ -124,12 +124,12 @@ class MetricUnionAvailabilitySpec extends Specification {
         availability1.getAllAvailableIntervals() >> [:]
         availability2.getAllAvailableIntervals() >> [:]
 
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, Collections.emptySet())
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, [] as Set)
 
         ConfigPhysicalTable physicalTable3 = Mock(ConfigPhysicalTable)
         physicalTable3.getAvailability() >> metricUnionAvailability
         MetricUnionAvailability outerMetricUnionAvailability = new MetricUnionAvailability(
-                [physicalTable3] as Set,
+                [physicalTable3.availability] as Set,
                 [] as Set
         )
 
@@ -147,7 +147,7 @@ class MetricUnionAvailabilitySpec extends Specification {
                 (metric2): [new Interval('2019-01-01/2019-02-01')]
         ]
 
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, [metricColumn1] as Set)
 
         expect:
         metricUnionAvailability.getAllAvailableIntervals() == [
@@ -165,7 +165,7 @@ class MetricUnionAvailabilitySpec extends Specification {
                 'un_requested': []
         ]
 
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1, metricColumn2] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, [metricColumn1, metricColumn2] as Set)
 
         DataSourceConstraint dataSourceConstraint = new DataSourceConstraint(
                 [] as Set,
@@ -198,7 +198,7 @@ class MetricUnionAvailabilitySpec extends Specification {
                 availableIntervals2.collect{it -> new Interval(it)} as Set
         )
 
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1, metricColumn2] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, [metricColumn1, metricColumn2] as Set)
 
         DataSourceConstraint dataSourceConstraint = new DataSourceConstraint(
                 [] as Set,
@@ -244,7 +244,7 @@ class MetricUnionAvailabilitySpec extends Specification {
                 [new Interval('2018-01-01/2018-02-01')]
         )
 
-        metricUnionAvailability = new MetricUnionAvailability(physicalTables, [metricColumn1, metricColumn2] as Set)
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, [metricColumn1, metricColumn2] as Set)
 
         DataSourceConstraint dataSourceConstraint = new DataSourceConstraint(
                 [] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/PermissiveAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/PermissiveAvailabilitySpec.groovy
@@ -4,8 +4,6 @@ package com.yahoo.bard.webservice.table.availability
 
 import com.yahoo.bard.webservice.data.config.names.TableName
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
-import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
@@ -50,7 +48,7 @@ class PermissiveAvailabilitySpec extends Specification  {
         )
 
         PhysicalDataSourceConstraint dataSourceConstraint = Mock(PhysicalDataSourceConstraint)
-        dataSourceConstraint.getAllColumnPhysicalNames() >> [column1, column2]
+        dataSourceConstraint.allColumnPhysicalNames >> [column1, column2]
 
         expect:
         permissiveAvailability.getAvailableIntervals(dataSourceConstraint) == new SimplifiedIntervalList(

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/PermissiveAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/PermissiveAvailabilitySpec.groovy
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.availability
 
-import com.yahoo.bard.webservice.data.config.names.TableName
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
 import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
@@ -14,7 +14,7 @@ import spock.lang.Unroll
 
 class PermissiveAvailabilitySpec extends Specification  {
 
-    TableName tableName
+    DataSourceName dataSourceName
     String column1
     String column2
     Interval interval1
@@ -22,7 +22,7 @@ class PermissiveAvailabilitySpec extends Specification  {
     Interval interval3
 
     def setup() {
-        tableName = TableName.of('table')
+        dataSourceName = DataSourceName.of('table')
 
         column1 = 'column_one'
         column2 = 'column_two'
@@ -39,7 +39,7 @@ class PermissiveAvailabilitySpec extends Specification  {
         interval2 = new Interval(secondInterval)
 
         PermissiveAvailability permissiveAvailability = new PermissiveAvailability(
-                tableName,
+                dataSourceName,
                 new TestDataSourceMetadataService([
                         (column1): [interval1] as Set,
                         (column2): [interval2] as Set,
@@ -70,7 +70,7 @@ class PermissiveAvailabilitySpec extends Specification  {
     def "getAllAvailability returns the correct availabilities for each column in datasource metadata service"() {
         given:
         PermissiveAvailability permissiveAvailability = new PermissiveAvailability(
-                tableName,
+                dataSourceName,
                 new TestDataSourceMetadataService([
                         (column1)   : [interval1] as Set,
                         (column2)   : [interval2] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/StrictAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/StrictAvailabilitySpec.groovy
@@ -13,9 +13,9 @@ import spock.lang.Unroll
 /**
  * Test for concrete availability behavior.
  */
-class ConcreteAvailabilitySpec extends Specification{
+class StrictAvailabilitySpec extends Specification{
 
-    ConcreteAvailability concreteAvailability
+    StrictAvailability strictAvailability
     String columnPhysicalName1, columnPhysicalName2, columnPhysicalName3
     Interval interval1, interval2
 
@@ -27,7 +27,7 @@ class ConcreteAvailabilitySpec extends Specification{
         interval1 = new Interval('2000-01-01/2015-12-31')
         interval2 = new Interval('2010-01-01/2020-12-31')
 
-        concreteAvailability = new ConcreteAvailability(
+        strictAvailability = new StrictAvailability(
                 DataSourceName.of('table'),
                 new TestDataSourceMetadataService([
                         (columnPhysicalName1): [interval1] as Set,
@@ -39,7 +39,7 @@ class ConcreteAvailabilitySpec extends Specification{
 
     def "getAllAvailability returns all availabilities for all column in datasource metadata service"() {
         expect:
-        concreteAvailability.getAllAvailableIntervals() == [
+        strictAvailability.getAllAvailableIntervals() == [
                 (columnPhysicalName1): [interval1],
                 (columnPhysicalName2): [interval2],
                 'hidden_column'      : [interval1],
@@ -52,7 +52,7 @@ class ConcreteAvailabilitySpec extends Specification{
         interval1 = new Interval(firstInterval)
         interval2 = new Interval(secondInterval)
 
-        concreteAvailability = new ConcreteAvailability(
+        strictAvailability = new StrictAvailability(
                 DataSourceName.of('table'),
                 new TestDataSourceMetadataService([
                         (columnPhysicalName1): [interval1] as Set,
@@ -64,7 +64,7 @@ class ConcreteAvailabilitySpec extends Specification{
         dataSourceConstraint.allColumnPhysicalNames >> [columnPhysicalName1, columnPhysicalName2]
 
         expect:
-        concreteAvailability.getAvailableIntervals(dataSourceConstraint) == new SimplifiedIntervalList(
+        strictAvailability.getAvailableIntervals(dataSourceConstraint) == new SimplifiedIntervalList(
                 expected.collect{new Interval(it)} as Set
         )
 
@@ -86,7 +86,7 @@ class ConcreteAvailabilitySpec extends Specification{
         constraint.allColumnPhysicalNames >> ['ignored']
 
         expect:
-        concreteAvailability.getAvailableIntervals(constraint) == new SimplifiedIntervalList()
+        strictAvailability.getAvailableIntervals(constraint) == new SimplifiedIntervalList()
     }
 
     def "getAvailableInterval returns empty interval if given empty column request"() {
@@ -95,6 +95,6 @@ class ConcreteAvailabilitySpec extends Specification{
         constraint.allColumnPhysicalNames >> []
 
         expect:
-        concreteAvailability.getAvailableIntervals(constraint) == new SimplifiedIntervalList()
+        strictAvailability.getAvailableIntervals(constraint) == new SimplifiedIntervalList()
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcherSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/resolver/SchemaPhysicalTableMatcherSpec.groovy
@@ -15,7 +15,7 @@ import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
 import com.yahoo.bard.webservice.data.dimension.impl.ScanSearchProviderManager
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.web.DataApiRequest
 
@@ -65,7 +65,7 @@ class SchemaPhysicalTableMatcherSpec extends Specification {
                 ),
         ] as Set
 
-        physicalTable = new ConcretePhysicalTable(
+        physicalTable = new StrictPhysicalTable(
                 "test table",
                 DAY.buildZonedTimeGrain(UTC),
                 dimSet.collect {new DimensionColumn(it)}.toSet(),

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/ClassScannerSpec.groovy
@@ -107,7 +107,7 @@ class ClassScannerSpec extends Specification {
      */
     @IgnoreIf({ClassScannerSpec.getClassesDeclaring("equals", Object.class).empty})
     @Unroll
-    def "test equals #cls.simpleName"() {
+    def "test equals for #className"() {
         setup:
         try {
             // Allow class specs to define well formed dependencies
@@ -150,10 +150,11 @@ class ClassScannerSpec extends Specification {
 
         where:
         cls << getClassesDeclaring("equals", Object.class)
+        className = cls.simpleName
     }
 
     @Unroll
-    def "test toString #cls.simpleName runs"() {
+    def "test toString for #className runs"() {
         expect:
         Object obj
         try {
@@ -168,6 +169,7 @@ class ClassScannerSpec extends Specification {
         obj.toString() != null
 
         where:
-        cls << getClassesDeclaring("toString" )
+        cls << getClassesDeclaring("toString")
+        className = cls.simpleName
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/RequestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/RequestUtils.groovy
@@ -108,25 +108,21 @@ class RequestUtils {
         )
     }
 
-    static String defaultQueryJson(
-            String dataSourceName = "dataSource",
-            TimeGrain timeGrain = DAY
-    ) {
-        """
-        {
-            "queryType" : "groupBy",
-            "context":{},
-            "dataSource" : {
-              "name" : "${dataSourceName}",
-              "type" : "table"
+    static String defaultQueryJson(String dataSourceName = "dataSource", TimeGrain timeGrain = DAY) {
+        """{
+            "queryType": "groupBy",
+            "context": {},
+            "dataSource": {
+              "name": "$dataSourceName",
+              "type": "table"
             },
-            "dimensions" : [ ],
-            "aggregations" : [ ],
-            "postAggregations" : [ ],
-            "intervals" : [ ],
-            "granularity" : {
-              "type" : "period",
-              "period" : "${timeGrain.getPeriodString()}"
+            "dimensions": [],
+            "aggregations": [],
+            "postAggregations": [],
+            "intervals": [],
+            "granularity": {
+              "type": "period",
+              "period": "$timeGrain.periodString"
             }
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
@@ -36,7 +36,7 @@ import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationP
 import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier
 import com.yahoo.bard.webservice.druid.util.SketchFieldConverter
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.TableGroup
@@ -157,7 +157,7 @@ class SketchIntersectionReportingResources extends Specification {
 
         columns.add(lmc)
 
-        PhysicalTable physicalTable = new ConcretePhysicalTable(
+        PhysicalTable physicalTable = new StrictPhysicalTable(
                 "NETWORK",
                 DAY.buildZonedTimeGrain(UTC),
                 columns,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SlicesApiRequestSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SlicesApiRequestSpec.groovy
@@ -88,11 +88,11 @@ class SlicesApiRequestSpec extends BaseDataSourceMetadataSpec {
             new URI(uri + args[0][0])
         }
 
-        Set<Map<String, Object>> dimensionsResult = new LinkedHashSet<>()
-        Set<Map<String, Object>> metricsResult = new LinkedHashSet<>()
+        Set<Map<String, Object>> dimensionsResult = [] as LinkedHashSet
+        Set<Map<String, Object>> metricsResult = [] as LinkedHashSet
 
-        table.getAllAvailableIntervals().each {
-            Map<String, Object> row = new LinkedHashMap<>()
+        table.allAvailableIntervals.each {
+            Map<String, Object> row = [:] as LinkedHashMap
             row["intervals"] = it.value
             row["name"] = it.key.name
             if (it.key instanceof DimensionColumn) {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SlicesApiRequestSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SlicesApiRequestSpec.groovy
@@ -42,7 +42,7 @@ class SlicesApiRequestSpec extends BaseDataSourceMetadataSpec {
         builder.path(_, _) >> builder
 
         DataSourceMetadata dataSourceMetadata = new DataSourceMetadata("all_pets", [:], segments)
-        dataSourceMetadataService.update(fullDictionary.get("all_pets"), dataSourceMetadata)
+        dataSourceMetadataService.update(fullDictionary.get("all_pets").dataSourceNames[0], dataSourceMetadata)
     }
 
     def cleanup() {
@@ -102,8 +102,8 @@ class SlicesApiRequestSpec extends BaseDataSourceMetadataSpec {
                 metricsResult.add(row)
             }
         }
-        Set<SortedMap<DateTime, Map<String, SegmentInfo>>> sliceMetadata = dataSourceMetadataService.getTableSegments(
-                [table.tableName] as Set
+        Set<SortedMap<DateTime, Map<String, SegmentInfo>>> sliceMetadata = dataSourceMetadataService.getSegments(
+                table.dataSourceNames
         )
 
         Map<String, Object> expected = [

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
@@ -37,7 +37,7 @@ import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier
 import com.yahoo.bard.webservice.druid.util.ThetaSketchFieldConverter
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.ConcretePhysicalTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.TableGroup
@@ -155,7 +155,7 @@ class ThetaSketchIntersectionReportingResources extends Specification {
 
         columns.add(lmc)
 
-        PhysicalTable physicalTable = new ConcretePhysicalTable(
+        PhysicalTable physicalTable = new StrictPhysicalTable(
                 "NETWORK",
                 DAY.buildZonedTimeGrain(UTC),
                 columns,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDimensionShowClauseCsvDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDimensionShowClauseCsvDataServletSpec.groovy
@@ -14,8 +14,9 @@ abstract class BaseDimensionShowClauseCsvDataServletSpec extends BaseDimensionSh
     }
 
     @Override
-    def validateExpectedApiResponse(String expectedApiResponse) {
+    boolean validateExpectedApiResponse(String expectedApiResponse) {
         // NoOp, we don't have a way to validate CSV right now
+        true
     }
 
     @Override

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/CsvEndpointDataServletMultiDimensionsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/CsvEndpointDataServletMultiDimensionsSpec.groovy
@@ -125,7 +125,7 @@ class CsvEndpointDataServletMultiDimensionsSpec extends BaseDataServletComponent
     }
 
     @Override
-    def validateExpectedApiResponse(String expectedApiResponse) {
+    boolean validateExpectedApiResponse(String expectedApiResponse) {
         true
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/CsvEndpointDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/CsvEndpointDataServletSpec.groovy
@@ -104,7 +104,7 @@ class CsvEndpointDataServletSpec extends BaseDataServletComponentSpec {
     }
 
     @Override
-    def validateExpectedApiResponse(String expectedApiResponse) {
+    boolean validateExpectedApiResponse(String expectedApiResponse) {
         true
     }
 

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/dimension/TestLookupDimensions.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/dimension/TestLookupDimensions.java
@@ -46,7 +46,7 @@ public class TestLookupDimensions extends TestDimensions {
             case "SIZE":
                 return Arrays.asList("SPECIES", "BREED", "GENDER");
             case "SHAPE":
-                return Arrays.asList("SPECIES");
+                return Collections.singletonList("SPECIES");
             default:
                 return Collections.emptyList();
         }

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/metadata/TestDataSourceMetadataService.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/metadata/TestDataSourceMetadataService.java
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.metadata;
 
-import com.yahoo.bard.webservice.data.config.names.TableName;
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
 import org.joda.time.Interval;
@@ -38,7 +38,7 @@ public class TestDataSourceMetadataService extends DataSourceMetadataService {
     }
 
     @Override
-    public Map<String, SimplifiedIntervalList> getAvailableIntervalsByTable(TableName physicalTableName) {
+    public Map<String, SimplifiedIntervalList> getAvailableIntervalsByDataSource(DataSourceName dataSourceName) {
         return testAvailableIntervals.entrySet().stream()
                 .collect(
                         Collectors.toMap(


### PR DESCRIPTION
Fixes a confusion where `TableName` was serving multi-duty as both a config concept, as well as an additional name for a `PhysicalTable` and the name referring to a Data Source in Druid. This also should allow having a `PhysicalTable` with an `Availability` that uses a different `DataSourceName` (ie. more than 1 physical table pointing at the same data source)

This PR also includes a fair amount of cleanup, both to Java code as well as the Test code. (Below is the compile commit messages for the commits included in this PR)

As part of some of this, a new `BaseMetadataAvailability` parent class to mirror the `BaseCompositeAvailability` and simplify the inheritance.

This PR also includes a fix for #246, making the log message more useful and helpful. The actual changes are in the Java cleanup I believe.

The commits are generally broken up fairly well, so it may be useful to review them 1 commit at a time. There is only a very small amount of overlap between the commits.

Commit messages:

```
Cleanup:
- Remove superfluous type indicator
- Add / Clean up / Clarify / Correct JavaDoc
- Use `Collectors.collectingAndThen` to convert to an unmodifiable collection instead of wrapping
- Unpack a lambda to get a stream into a map and then a flatMap
- Rearrange member variables to keep private static finals on top
- Make `BasePhysicalTable` take a more extension-friendly set of `PhysicalTable`s
- Clean up whitespace and variable specification in lambdas
- Remove unneeded blank lines
- Correct / Clean up line wrapping
- Small import cleanup
- Small inlining where needed
- Tidy up method ordering


Make Groovy code groovier:
- Use property access instead of getters in lots of places
- Use more list and map literals
- Use spread collections in many places instead of collects
- Compact code using ternary instead of simple conditionals and statements where readability is improved
- Removal of superfluous semicolons

Clean up tests a bit:
- Added `@Unroll` where missing
- Switch to `expect` instead of `when/then` where appropriate

Clean up `BaseDataSourceComponentSpec`
- Drop a log from `error` to `trace`
- Make JSON validation helpers return `boolean`
- Comment methods, etc.


Refactor `SegmentIntervalsHashIdGenerator`
- Make mapper map name clearer
- Tighten main processing stream and helper. Should be a little faster


-Update name of `TableName` comparator


-Force `ConcretePhysicalTable` only take a `ConcreteAvailability`


Split `DataSourceName` concept from `TableName`
- Add `DataSourceName` interface
- Make relevant places use `DataSourceName`
	- `DataSource` & children
	- `DataSourceMetadataService` & `DataSourceMetadataLoader`
	- `SegmentIntervalsHashIdGenerator`
	- `PhysicalTable` & children
	- `Availability` & children
	- `ErrorMessageFormat`
	- `SlicesApiRequest`

Add a `BaseMetadataAvailability` as a parallel to `BaseCompositeAvailability`
- `ConcreteAvailability` extends this
- `PermissiveAvailability` extends this


Remove `PhysicalTableDictionary` dependency from `SegmentIntervalsHashIdGenerator`


Make `MetricUnionAvailability` take a set of `Availability` instead of `PhysicalTable`


Remove `PhysicalTable::getTableName` to use `getName` instead
```