### PR TITLE
Reduce level of asynchronous workflow error log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,11 @@ Current
 
 ### Changed:
 
+- [Reduce log level of failure to store a result in the asynchronous job store](https://github.com/yahoo/fili/pull/266)
+    * Customers who aren't using the asynchronous infrastructure shouldn't be seeing spurious warnings about a failure
+        to execute one step (which is a no-op for them) in a complex system they aren't using. Until we can revisit how
+        we log report asynchronous errors, we reduce the log level to `DEBUG` to reduce noise.
+
 - [Update availabilities for PartitionAvailability](https://github.com/yahoo/fili/pull/244)
     * Created `BaseCompositeAvailability` for common features
     * Refactored `DataSourceMetadataService` methods to use SimplifiedIntervaList to standardize intersections

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/async/workflows/DefaultAsynchronousWorkflowsBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/async/workflows/DefaultAsynchronousWorkflowsBuilder.java
@@ -146,7 +146,7 @@ public class DefaultAsynchronousWorkflowsBuilder implements AsynchronousWorkflow
         return asynchronousPayload
                 .flatMap(apiJobStore::save)
                 .onErrorReturn(error -> {
-                    LOG.warn(ErrorMessageFormat.FAILED_TO_SAVE_JOB_ROW.format(jobRow), error);
+                    LOG.debug(ErrorMessageFormat.FAILED_TO_SAVE_JOB_ROW.format(jobRow), error);
                     return jobRow;
                 });
     }


### PR DESCRIPTION
--Currently, whenever an error is encountered in Fili during response
processing, we log it in two places:
   1. Where the error occurred as an `ERROR` level message.
   2. When the Observable stream that saves the job to the ApiJobStore
      encounters the error, even if "saving" is a no-op because there
      isn't a job store set up (the current case for everyone using Fili).

While it may be useful to know that a value has not been stored in
the job store once a customer starts using asynchronous queries, for now
it clutters up people's logs with red herrings.

The long term solution is to rethink how we handle errors during
asynchronous processing so that the logging can be as transparent as the
processing. But since nobody has the bandwidth to tackle that right now,
instead we lower the log level to debug. That way we aren't just
silently swallowing the error, but neither do we clutter up logs set at
the standard `INFO` level.