### PR TITLE
Fix incorrect custom header provider conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,7 +288,10 @@ Current
 - [Specify the character encoding to support unicode characters](https://github.com/yahoo/fili/pull/221)
     * Default character set used by the back end was mangling Unicode characters.
 
-- [Default the AsyncDruidWebServiceImpl to follow redirects](https://github.com/yahoo/fili/pull/214)
+- [Correct empty-string behavior for druid header supplier class config](https://github.com/yahoo/fili/pull/214)
+    * Empty string would have tried to build a custom supplier. Now it doesn't.
+
+- [Default the AsyncDruidWebServiceImpl to follow redirects](https://github.com/yahoo/fili/pull/271)
     * It defaulted to not following redirects, and now it doesn't
 
 - [Reenable custom query types in TestDruidWebService]()
@@ -301,11 +304,11 @@ Current
     * Ordering of fields on serialization could be inconsistent if intermediate stages used `HashSet` or `HashMap`.
     * Several constructors switched to accept `Iterable` and return `LinkedHashSet` to emphasize importance of ordering/prevent `HashSet` intermediates which disrupt ordering.
 
-
 -[Fix Lookup Dimension Serialization](https://github.com/yahoo/fili/pull/187)
     * Fix a bug where lookup dimension is serialized as dimension spec in both outer and inner query
 
 - Correcting error message logged when no table schema match is found
+
 - Setting readTimeout on DefaultAsyncHttpClientConfig when building AsyncDruidWebServiceImpl
 
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -948,7 +948,7 @@ public abstract class AbstractBinderFactory implements BinderFactory {
     protected Supplier<Map<String, String>> buildDruidWebServiceHeaderSupplier() {
         Supplier<Map<String, String>> supplier = HashMap::new;
         String customSupplierClassString = SYSTEM_CONFIG.getStringProperty(DRUID_HEADER_SUPPLIER_CLASS, null);
-        if (customSupplierClassString != null && customSupplierClassString.equals("")) {
+        if (customSupplierClassString != null && !customSupplierClassString.equals("")) {
             try {
                 Class<?> c = Class.forName(customSupplierClassString);
                 Constructor<?> constructor = c.getConstructor();


### PR DESCRIPTION
Behavior before would do the wrong thing if, somehow, the param was set to empty string because it would try to build a custom provider using empty string as the class name. Now it will not try to build a custom provider if the param is empty string.