### PR TITLE
Remove globally mutable instance from SimplifiedIntervalList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ Current
 - [Remove dependency on org.json](https://github.com/yahoo/fili/pull/416)
     * Replace uses of org.json with the jackson equivalent
 
+- [Remove NO_INTERVALS from SimplifiedIntervalList](https://github.com/yahoo/fili/pull/290)
+    * This shared instance was vulnerable to being changed globally. All calls to this have been replaced with the empty constructor
+
 
 v0.8.69 - 2017/06/06
 --------------------

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/SimplifiedIntervalList.java
@@ -31,14 +31,6 @@ import javax.validation.constraints.NotNull;
 public class SimplifiedIntervalList extends LinkedList<Interval> {
 
     /**
-     * A prebuilt empty SimplifiedIntervalList.
-     *
-     * @deprecated This shared instance is vulnerable to being changed globally with side effects, use empty constructor
-     */
-    @Deprecated
-    public static final SimplifiedIntervalList NO_INTERVALS = new SimplifiedIntervalList();
-
-    /**
      * Function to iterate an iterator if it has a next element, otherwise return null.
      */
     protected Function<Iterator<Interval>, Interval> getNextIfAvailable = (it) -> it.hasNext() ? it.next() : null;

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ResponseSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ResponseSpec.groovy
@@ -4,7 +4,6 @@ package com.yahoo.bard.webservice.web
 
 import static com.yahoo.bard.webservice.config.BardFeatureFlag.PARTIAL_DATA
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
-import static com.yahoo.bard.webservice.util.SimplifiedIntervalList.NO_INTERVALS
 
 import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.config.SystemConfig
@@ -118,7 +117,7 @@ class ResponseSpec extends Specification {
     Pagination pagination
     Map<MetricColumn, Object> metricColumnsMap
     Set<MetricColumn> defaultRequestedMetrics
-    SimplifiedIntervalList volatileIntervals = NO_INTERVALS;
+    SimplifiedIntervalList volatileIntervals = new SimplifiedIntervalList();
 
     GString defaultJsonFormat = """{
                                     "rows" : [ {
@@ -187,7 +186,7 @@ class ResponseSpec extends Specification {
         response = new Response(
                 buildTestResultSet(metricColumnsMap, defaultRequestedMetrics),
                 apiRequest,
-                NO_INTERVALS,
+                new SimplifiedIntervalList(),
                 volatileIntervals,
                 [:],
                 (Pagination) null,
@@ -285,7 +284,7 @@ class ResponseSpec extends Specification {
         resultSet = new ResultSet(schema, [result1, result2])
 
         //response without pagination
-        response = new Response(resultSet, apiRequest, NO_INTERVALS, volatileIntervals,  [:], (Pagination) null, MAPPERS)
+        response = new Response(resultSet, apiRequest, new SimplifiedIntervalList(), volatileIntervals,  [:], (Pagination) null, MAPPERS)
 
         pagination = Stub(Pagination) {
             getFirstPage() >> 1
@@ -308,7 +307,7 @@ class ResponseSpec extends Specification {
         Response paginatedResponse = new Response(
                 resultSet,
                 apiRequest,
-                NO_INTERVALS,
+                new SimplifiedIntervalList(),
                 volatileIntervals,
                 bodyLinks,
                 pagination,
@@ -359,8 +358,8 @@ class ResponseSpec extends Specification {
         Response complexResponse = new Response(
                 resultSetWithComplexMetrics,
                 apiRequest,
-                NO_INTERVALS,
-                NO_INTERVALS,
+                new SimplifiedIntervalList(),
+                new SimplifiedIntervalList(),
                 [:],
                 (Pagination) null,
                 MAPPERS
@@ -393,7 +392,7 @@ class ResponseSpec extends Specification {
                         }
                     }"""
 
-        response = new Response(resultSet, apiRequest, NO_INTERVALS, volatileIntervals, bodyLinks, pagination, MAPPERS)
+        response = new Response(resultSet, apiRequest, new SimplifiedIntervalList(), volatileIntervals, bodyLinks, pagination, MAPPERS)
 
         String expectedJson = withMetaObject(defaultJsonApiFormat, metaBlock)
 
@@ -504,7 +503,7 @@ class ResponseSpec extends Specification {
         Response response = new Response(
                 resultSet,
                 apiRequest1,
-                NO_INTERVALS,
+                new SimplifiedIntervalList(),
                 volatileIntervals,
                 [:],
                 (Pagination) null,
@@ -611,7 +610,7 @@ class ResponseSpec extends Specification {
         response = new Response(
                 buildTestResultSet(metricColumnsMap, defaultRequestedMetrics),
                 apiRequest,
-                NO_INTERVALS,
+                new SimplifiedIntervalList(),
                 volatileIntervals,
                 [:],
                 (Pagination) null,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/UIJsonResponseSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/UIJsonResponseSpec.groovy
@@ -3,7 +3,6 @@
 package com.yahoo.bard.webservice.web
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
-import static com.yahoo.bard.webservice.util.SimplifiedIntervalList.NO_INTERVALS
 
 import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.Result
@@ -114,7 +113,7 @@ class UIJsonResponseSpec extends Specification {
                 apiMetricColumnNames,
                 defaultDimensionFieldsToShow,
                 ResponseFormatType.JSON,
-                NO_INTERVALS,
+                new SimplifiedIntervalList(),
                 volatileIntervals,
                 [:],
                 (Pagination) null,
@@ -175,7 +174,7 @@ class UIJsonResponseSpec extends Specification {
                 apiMetricColumnNames,
                 defaultDimensionFieldsToShow,
                 ResponseFormatType.JSON,
-                NO_INTERVALS,
+                new SimplifiedIntervalList(),
                 volatileIntervals,
                 [:],
                 (Pagination) null,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataResultSetMapperSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/PartialDataResultSetMapperSpec.groovy
@@ -25,7 +25,7 @@ import java.util.function.Supplier
 public class PartialDataResultSetMapperSpec extends Specification {
 
     PhysicalTableDictionary physicalTableDictionary = Mock(PhysicalTableDictionary)
-    SimplifiedIntervalList intervals = SimplifiedIntervalList.NO_INTERVALS
+    SimplifiedIntervalList intervals = new SimplifiedIntervalList()
     ResultSetSchema schema = Mock(ResultSetSchema)
     Result result = Mock(Result)
     PartialDataHandler handler = new PartialDataHandler()
@@ -165,7 +165,7 @@ public class PartialDataResultSetMapperSpec extends Specification {
 
     PartialDataResultSetMapper buildMapper(
             SimplifiedIntervalList intervals,
-            Supplier<SimplifiedIntervalList> provider = { -> SimplifiedIntervalList.NO_INTERVALS }
+            Supplier<SimplifiedIntervalList> provider = { -> new SimplifiedIntervalList() }
     ) {
         return new PartialDataResultSetMapper(intervals, provider)
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessorSpec.groovy
@@ -3,7 +3,6 @@
 package com.yahoo.bard.webservice.web.responseprocessors
 
 import static com.yahoo.bard.webservice.async.ResponseContextUtils.createResponseContext
-import static com.yahoo.bard.webservice.util.SimplifiedIntervalList.NO_INTERVALS
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.MISSING_INTERVALS_CONTEXT_KEY
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.VOLATILE_INTERVALS_CONTEXT_KEY
 
@@ -44,7 +43,7 @@ class CacheV2ResponseProcessorSpec extends Specification {
     DataApiRequest apiRequest = Mock(DataApiRequest)
     GroupByQuery groupByQuery = Mock(GroupByQuery)
     List<ResultSetMapper> mappers = new ArrayList<ResultSetMapper>()
-    @Shared SimplifiedIntervalList intervals = NO_INTERVALS
+    @Shared SimplifiedIntervalList intervals = new SimplifiedIntervalList()
     @Shared SimplifiedIntervalList nonEmptyIntervals = new SimplifiedIntervalList([new Interval(0, 1)])
 
     ResponseContext responseContext =  createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): intervals])
@@ -87,10 +86,10 @@ class CacheV2ResponseProcessorSpec extends Specification {
         true     | [:]
         false    | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals])
         false    | createResponseContext([(VOLATILE_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals])
-        true     | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): NO_INTERVALS])
-        true     | createResponseContext([(VOLATILE_INTERVALS_CONTEXT_KEY.name): NO_INTERVALS])
+        true     | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): new SimplifiedIntervalList()])
+        true     | createResponseContext([(VOLATILE_INTERVALS_CONTEXT_KEY.name): new SimplifiedIntervalList()])
         false    | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals, (VOLATILE_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals])
-        false    | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): NO_INTERVALS, (VOLATILE_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals])
+        false    | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): new SimplifiedIntervalList(), (VOLATILE_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals])
     }
 
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CachingResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CachingResponseProcessorSpec.groovy
@@ -3,7 +3,6 @@
 package com.yahoo.bard.webservice.web.responseprocessors
 
 import static com.yahoo.bard.webservice.async.ResponseContextUtils.createResponseContext
-import static com.yahoo.bard.webservice.util.SimplifiedIntervalList.NO_INTERVALS
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.MISSING_INTERVALS_CONTEXT_KEY
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.VOLATILE_INTERVALS_CONTEXT_KEY
 
@@ -42,7 +41,7 @@ class CachingResponseProcessorSpec extends Specification {
     DataApiRequest apiRequest = Mock(DataApiRequest)
     GroupByQuery groupByQuery = Mock(GroupByQuery)
     List<ResultSetMapper> mappers = new ArrayList<ResultSetMapper>()
-    @Shared SimplifiedIntervalList intervals = NO_INTERVALS
+    @Shared SimplifiedIntervalList intervals = new SimplifiedIntervalList()
     @Shared SimplifiedIntervalList nonEmptyIntervals = new SimplifiedIntervalList([new Interval(0, 1)])
 
     ResponseContext responseContext = createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name) : intervals])
@@ -78,10 +77,10 @@ class CachingResponseProcessorSpec extends Specification {
         true     | [:]
         false    | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name) : nonEmptyIntervals])
         false    | createResponseContext([(VOLATILE_INTERVALS_CONTEXT_KEY.name) : nonEmptyIntervals])
-        true     | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name) : NO_INTERVALS])
-        true     | createResponseContext([(VOLATILE_INTERVALS_CONTEXT_KEY.name) : NO_INTERVALS])
+        true     | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name) : new SimplifiedIntervalList()])
+        true     | createResponseContext([(VOLATILE_INTERVALS_CONTEXT_KEY.name) : new SimplifiedIntervalList()])
         false    | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals, (VOLATILE_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals])
-        false    | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): NO_INTERVALS, (VOLATILE_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals])
+        false    | createResponseContext([(MISSING_INTERVALS_CONTEXT_KEY.name): new SimplifiedIntervalList(), (VOLATILE_INTERVALS_CONTEXT_KEY.name): nonEmptyIntervals])
     }
 
     def "Process response stored and continues without partial and good cache key"() {


### PR DESCRIPTION
The static instance was mutable and has been removed to prevent leaking the state throughout the application (#237)