### PR TITLE
Fix DruidNavigator loading multiple tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -500,6 +500,10 @@ Removals:
 
 ### Fixed:
 
+- [Fix the generic example for loading multiple tables](https://github.com/yahoo/fili/pull/309)
+    * Loading multiple tables caused it to hang and eventually time out.
+    * Also fixed issue causing all tables to show the same set of dimensions.
+
 - [Support for Lucene 5 indexes restored](https://github.com/yahoo/fili/pull/265)
     * Added `lucene-backward-codecs.jar` as a dependency to restore support for indexes built on earlier instances.
 

--- a/fili-generic-example/README.md
+++ b/fili-generic-example/README.md
@@ -25,7 +25,10 @@ mvn -pl fili-generic-example exec:java
 - Note that if your setup is different you can adjust it by changing the default parameters below
 
     ```bash
-    mvn -pl fili-generic-example exec:java -Dbard__fili_port=9998 -Dbard__druid_coord=http://localhost:8081/druid/coordinator/v1
+    mvn -pl fili-generic-example exec:java -Dbard__fili_port=9998 \
+    -Dbard__druid_coord=http://localhost:8081/druid/coordinator/v1 \
+    -Dbard__non_ui_druid_broker=http://localhost:8082/druid/v2 \
+    -Dbard__ui_druid_broker=http://localhost:8082/druid/v2
     ```
 
 From another window, run a test query against the default druid data.

--- a/fili-generic-example/README.md
+++ b/fili-generic-example/README.md
@@ -1,9 +1,15 @@
 Fili Generic Loader Application
 ==================================
 
-This application will automatically configure fili to work with **any** instance of Druid and show the basic metrics and dimensions. This lets you test what it's like using Fili without putting any effort into setting it up.
+This application will automatically configure fili to work with **any** instance
+ of Druid and show the basic metrics and dimensions. This lets you test what it's
+  like using Fili without putting any effort into setting it up.
 
-In order to set up, this will connect to druid at  [http://localhost:8081/druid/coordinator/v1](http://localhost:8081/druid/coordinator/v1). If your set up is different, you'll have to change the `bard__druid_coord` url in `applicationConfig.properties`.
+In order to set up, this will connect to druid at  [http://localhost:8081/druid/coordinator/v1](http://localhost:8081/druid/coordinator/v1).
+ If your set up is different, you'll have to change the `bard__druid_coord`,
+  `bard__non_ui_druid_broker`, `bard__ui_druid_broker` url in `applicationConfig.properties`.
+  
+Note that this was last tested using [version 0.9.1](https://github.com/yahoo/fili/tree/0.9.1)
 
 ## Setup and Launching
 

--- a/fili-generic-example/README.md
+++ b/fili-generic-example/README.md
@@ -15,12 +15,11 @@ In order to set up, this will connect to druid at  [http://localhost:8081/druid/
     ```
 3. Use Maven to install and launch the Fili Generic example:
 
-
-```bash
-cd fili
-mvn install
-mvn -pl fili-generic-example exec:java
-```
+    ```bash
+    cd fili
+    mvn install
+    mvn -pl fili-generic-example exec:java
+    ```
 
 - Note that if your setup is different you can adjust it by changing the default parameters below
 
@@ -39,21 +38,21 @@ Here are some sample queries that you can run to verify your server:
 
 ### Any Server
 
-- List tables:
+- List [tables](http://localhost:9998/v1/tables):
   
       GET http://localhost:9998/v1/tables
 
-- List dimensions:  
+- List [dimensions](http://localhost:9998/v1/dimensions):  
 
       GET http://localhost:9998/v1/dimensions
 
-- List metrics:
+- List [metrics](http://localhost:9998/v1/metrics/):
   
       GET http://localhost:9998/v1/metrics/
 
 ### Specific to Wikipedia data
 
-- If everything is working, the query below
+- If everything is working, the [query below](http://localhost:9998/v1/data/wikiticker/day/?metrics=deleted&dateTime=2015-09-12/PT24H)
     ```bash
     curl "http://localhost:9998/v1/data/wikiticker/day/?metrics=deleted&dateTime=2015-09-12/PT24H" -H "Content-Type: application/json" | python -m json.tool
     ```
@@ -70,7 +69,9 @@ Here are some sample queries that you can run to verify your server:
 - Count of edits by hour for the last 72 hours:  
   
       GET http://localhost:9998/v1/data/wikiticker/day/?metrics=count&dateTime=PT72H/current
-    Note: this will should be something like the response below unless you have streaming data.
+    
+    Note: this will should be something like the response below since the 
+    wikiticker table doesn't have data for the past 72 hours from now.
     ```json
     {
         "rows": [],
@@ -80,7 +81,8 @@ Here are some sample queries that you can run to verify your server:
     }
     ```  
 
-- Show debug info, including the query sent to Druid:  
+- Show [debug info](http://localhost:9998/v1/data/wikiticker/day/?format=debug&metrics=count&dateTime=PT72H/current),
+ including the query sent to Druid:  
 
       GET http://localhost:9998/v1/data/wikiticker/day/?format=debug&metrics=count&dateTime=PT72H/current
 
@@ -93,4 +95,6 @@ Here are some sample queries that you can run to verify your server:
 
 1. In IntelliJ, go to `File -> Open`
 2. Select the `pom.xml` file at the root of the project
-3. Run `GenericMain` which can be found in `fili-generic-example` (e.g. right click and choose run)
+3. Under `src/main/resources/applicationConfig.properties`, change `bard__non_ui_druid_broker`, 
+`bard__ui_druid_broker`, `bard__druid_coord`, and other properties as needed.
+4. Run `GenericMain` which can be found in `fili-generic-example` (e.g. right click and choose run)

--- a/fili-generic-example/README.md
+++ b/fili-generic-example/README.md
@@ -94,7 +94,12 @@ Here are some sample queries that you can run to verify your server:
 ## Importing and Running in IntelliJ
 
 1. In IntelliJ, go to `File -> Open`
+
 2. Select the `pom.xml` file at the root of the project
+    
+    **NOTE:** if you're running this locally and haven't changed any settings (like the Wikipedia example) 
+    you can **skip step 3**.
 3. Under `src/main/resources/applicationConfig.properties`, change `bard__non_ui_druid_broker`, 
-`bard__ui_druid_broker`, `bard__druid_coord`, and other properties as needed.
+`bard__ui_druid_broker`, `bard__druid_coord`, and other properties.
+    
 4. Run `GenericMain` which can be found in `fili-generic-example` (e.g. right click and choose run)

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
@@ -81,7 +81,7 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
 
         try {
             //calling get so we wait until responses are loaded before returning and processing continues
-            responseFuture.get(60, TimeUnit.SECONDS);
+            responseFuture.get(30, TimeUnit.SECONDS);
         } catch (TimeoutException | InterruptedException | ExecutionException e) {
             LOG.error("Interrupted while waiting for a response from druid", e);
             throw new RuntimeException("Unable to automatically configure correctly, no response from druid.", e);
@@ -200,6 +200,8 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
      *
      * @param successCallback  The callback to be done if the query succeeds.
      * @param url  The url to send the query to.
+     *
+     * @return future response for the druid query
      */
     private Future<Response> queryDruid(SuccessCallback successCallback, String url) {
         LOG.debug("Fetching " + url);

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
@@ -2,12 +2,14 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.wiki.webservice.data.config.auto;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain;
 import com.yahoo.bard.webservice.data.time.TimeGrain;
 import com.yahoo.bard.webservice.druid.client.DruidWebService;
 import com.yahoo.bard.webservice.druid.client.SuccessCallback;
 import com.yahoo.bard.webservice.util.IntervalUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
 import org.asynchttpclient.Response;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -67,7 +69,7 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
      * ["wikiticker"]
      */
     private void loadAllDatasources() {
-        final List<Future<Response>> fullTableResponses = new ArrayList<>();
+        List<Future<Response>> fullTableResponses = new ArrayList<>();
         Future<Response> responseFuture = queryDruid(rootNode -> {
             if (rootNode.isArray()) {
                 rootNode.forEach(jsonNode -> {

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
@@ -90,10 +90,10 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
         // force each individual table to finish loading (i.e. loadTable(t1) and loadTable(t2) have finished)
         fullTableResponses.forEach(future -> {
             try {
-                future.get(30,TimeUnit.SECONDS);
+                future.get(30, TimeUnit.SECONDS);
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 LOG.error("Interrupted while building tables", e);
-                throw new RuntimeException("Unable to automatically configure correctly, couldn't fetch table data.", e);
+                throw new RuntimeException("Unable to configure, couldn't fetch table data.", e);
             }
         });
     }
@@ -117,6 +117,8 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
      * }
      *
      * @param table The TableConfig to be loaded with queries against druid.
+     *
+     * @return future response for the query loading the table
      */
     private Future<Response> loadTable(TableConfig table) {
         String url = COORDINATOR_TABLES_PATH + table.getName() + "/?full";

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/GenericDimensionConfigs.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/GenericDimensionConfigs.java
@@ -34,6 +34,7 @@ public class GenericDimensionConfigs {
     public GenericDimensionConfigs(Supplier<List<? extends DataSourceConfiguration>> configLoader) {
         dimensionConfigs = configLoader.get().stream()
                 .flatMap(tableName -> tableName.getDimensions().stream())
+                .distinct()
                 .map(dimensionName -> new DefaultKeyValueStoreDimensionConfig(
                         () -> dimensionName,
                         dimensionName,

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/GenericDimensionConfigs.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/GenericDimensionConfigs.java
@@ -73,7 +73,7 @@ public class GenericDimensionConfigs {
     /**
      * Get all the dimension configurations associated with this datasource.
      *
-     * @param dataSourceConfiguration the datasource configuration's dimensions to load
+     * @param dataSourceConfiguration  The datasource configuration's dimensions to load
      *
      * @return the dimension configurations for this datasource
      */
@@ -84,7 +84,7 @@ public class GenericDimensionConfigs {
     /**
      * Lazily provide a KeyValueStore for this store name.
      *
-     * @param storeName  the name for the key value store
+     * @param storeName  The name for the key value store
      *
      * @return A KeyValueStore instance
      */

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/GenericDimensionConfigs.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/GenericDimensionConfigs.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
  * Hold all the dimension configurations for a generic druid configuration.
  */
 public class GenericDimensionConfigs {
-    private final Map<String, Set<DimensionConfig>> dimensionConfigs;
+    private final Map<String, Set<DimensionConfig>> dataSourceToDimensionConfigs;
 
     /**
      * Construct the dimension configurations.
@@ -34,7 +34,7 @@ public class GenericDimensionConfigs {
      * @param configLoader  Supplies DataSourceConfigurations to build the dimensions from.
      */
     public GenericDimensionConfigs(Supplier<List<? extends DataSourceConfiguration>> configLoader) {
-        dimensionConfigs = new HashMap<>();
+        dataSourceToDimensionConfigs = new HashMap<>();
         configLoader.get()
                 .forEach(dataSourceConfiguration -> {
                     Set<DimensionConfig> tableDimensionConfigs = dataSourceConfiguration.getDimensions().stream()
@@ -54,9 +54,8 @@ public class GenericDimensionConfigs {
                                             Collections::unmodifiableSet
                                     ));
 
-                    dimensionConfigs.put(dataSourceConfiguration.getName(), tableDimensionConfigs);
+                    dataSourceToDimensionConfigs.put(dataSourceConfiguration.getName(), tableDimensionConfigs);
                 });
-        ;
     }
 
     /**
@@ -65,7 +64,7 @@ public class GenericDimensionConfigs {
      * @return set of dimension configurations
      */
     public Set<DimensionConfig> getAllDimensionConfigurations() {
-        return dimensionConfigs.values().stream()
+        return dataSourceToDimensionConfigs.values().stream()
                 .flatMap(Set::stream)
                 .distinct()
                 .collect(Collectors.toSet());
@@ -79,7 +78,7 @@ public class GenericDimensionConfigs {
      * @return the dimension configurations for this datasource
      */
     public Set<DimensionConfig> getDimensionConfigs(DataSourceConfiguration dataSourceConfiguration) {
-        return dimensionConfigs.getOrDefault(dataSourceConfiguration.getName(), Collections.emptySet());
+        return dataSourceToDimensionConfigs.getOrDefault(dataSourceConfiguration.getName(), Collections.emptySet());
     }
 
     /**

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/metric/GenericMetricLoader.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/metric/GenericMetricLoader.java
@@ -40,7 +40,7 @@ public class GenericMetricLoader implements MetricLoader {
     }
 
     /**
-     * (Re)Initialize the metric makers with the given metric dictionary.
+     * Initialize the metric makers with the given metric dictionary.
      *
      * @param metricDictionary  Metric dictionary to use for generating the metric makers.
      */

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/GenericTableLoader.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/GenericTableLoader.java
@@ -32,12 +32,12 @@ import java.util.stream.Collectors;
  * Load the table configuration for any druid setup.
  */
 public class GenericTableLoader extends BaseTableLoader {
-    private Map<String, Set<Granularity>> validGrains = new HashMap<>();
+    private final Map<String, Set<Granularity>> validGrains = new HashMap<>();
     // Set up the metrics
-    private Map<String, Set<FieldName>> druidMetricNames = new HashMap<>();
-    private Map<String, Set<ApiMetricName>> apiMetricNames = new HashMap<>();
+    private final Map<String, Set<FieldName>> druidMetricNames = new HashMap<>();
+    private final Map<String, Set<ApiMetricName>> apiMetricNames = new HashMap<>();
     // Set up the table definitions
-    private Map<String, Set<PhysicalTableDefinition>> tableDefinitions = new HashMap<>();
+    private final Map<String, Set<PhysicalTableDefinition>> tableDefinitions = new HashMap<>();
     private final Supplier<List<? extends DataSourceConfiguration>> configLoader;
 
     /**
@@ -69,13 +69,14 @@ public class GenericTableLoader extends BaseTableLoader {
                     dataSourceConfiguration.getMetrics()
                     .stream()
                     .map(DruidMetricName::new)
-                    .collect(Collectors.toSet()));
+                    .collect(Collectors.toSet())
+            );
 
             tableDefinitions.put(dataSourceConfiguration.getName(),
                     getPhysicalTableDefinitions(
                             dataSourceConfiguration,
                             dataSourceConfiguration.getValidTimeGrain(),
-                            genericDimensionConfigs.getAllDimensionConfigurations()
+                            genericDimensionConfigs.getDimensionConfigs(dataSourceConfiguration)
                     )
             );
 

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/GenericTableLoader.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/GenericTableLoader.java
@@ -32,10 +32,10 @@ import java.util.stream.Collectors;
  * Load the table configuration for any druid setup.
  */
 public class GenericTableLoader extends BaseTableLoader {
-    private Map<String,Set<Granularity>> validGrains = new HashMap<>();
+    private Map<String, Set<Granularity>> validGrains = new HashMap<>();
     // Set up the metrics
-    private Map<String,Set<FieldName>> druidMetricNames = new HashMap<>();
-    private Map<String,Set<ApiMetricName>> apiMetricNames = new HashMap<>();
+    private Map<String, Set<FieldName>> druidMetricNames = new HashMap<>();
+    private Map<String, Set<ApiMetricName>> apiMetricNames = new HashMap<>();
     // Set up the table definitions
     private Map<String, Set<PhysicalTableDefinition>> tableDefinitions = new HashMap<>();
     private final Supplier<List<? extends DataSourceConfiguration>> configLoader;
@@ -65,7 +65,7 @@ public class GenericTableLoader extends BaseTableLoader {
     private void configureTables(GenericDimensionConfigs genericDimensionConfigs) {
         configLoader.get().forEach(dataSourceConfiguration -> {
 
-            druidMetricNames.put( dataSourceConfiguration.getName(),
+            druidMetricNames.put(dataSourceConfiguration.getName(),
                     dataSourceConfiguration.getMetrics()
                     .stream()
                     .map(DruidMetricName::new)

--- a/fili-generic-example/src/main/resources/applicationConfig.properties
+++ b/fili-generic-example/src/main/resources/applicationConfig.properties
@@ -13,6 +13,7 @@ bard__non_ui_druid_broker=http://localhost:8082/druid/v2
 bard__ui_druid_broker=http://localhost:8082/druid/v2
 bard__druid_coord=http://localhost:8081/druid/coordinator/v1
 bard__fili_port=9998
+bard__druid_dimensions_loader_enabled = true
 
 # Use memory for the default dimension backing store
 bard__dimension_backend=memory

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/application/ConfigurationLoaderSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/application/ConfigurationLoaderSpec.groovy
@@ -36,7 +36,7 @@ class ConfigurationLoaderSpec extends Specification {
         StaticWikiConfigLoader wikiConfigLoader = new StaticWikiConfigLoader();
         GenericDimensionConfigs genericDimensions = new GenericDimensionConfigs(wikiConfigLoader);
         LinkedHashSet<DimensionConfig> dimensions = genericDimensions.
-                getAllDimensionConfigurations(dataSourceConfiguration.getName());
+                getAllDimensionConfigurations();
         loader = new ConfigurationLoader(
                 new KeyValueStoreDimensionLoader(dimensions),
                 new GenericMetricLoader(wikiConfigLoader),

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/application/ConfigurationLoaderSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/application/ConfigurationLoaderSpec.groovy
@@ -36,7 +36,7 @@ class ConfigurationLoaderSpec extends Specification {
         StaticWikiConfigLoader wikiConfigLoader = new StaticWikiConfigLoader();
         GenericDimensionConfigs genericDimensions = new GenericDimensionConfigs(wikiConfigLoader);
         LinkedHashSet<DimensionConfig> dimensions = genericDimensions.
-                getAllDimensionConfigurations();
+                getAllDimensionConfigurations(dataSourceConfiguration.getName());
         loader = new ConfigurationLoader(
                 new KeyValueStoreDimensionLoader(dimensions),
                 new GenericMetricLoader(wikiConfigLoader),

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/AutomaticDruidConfigLoaderSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/AutomaticDruidConfigLoaderSpec.groovy
@@ -52,7 +52,6 @@ public class AutomaticDruidConfigLoaderSpec extends Specification {
             } else if (druidWebService.lastUrl == '/datasources/' + datasource + "/?full") {
                 return expectedMetricsAndDimensions
             }
-            println "No response for " + druidWebService.lastUrl
         }
     }
 

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/AutomaticDruidConfigLoaderSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/AutomaticDruidConfigLoaderSpec.groovy
@@ -5,7 +5,6 @@ import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
 import com.yahoo.wiki.webservice.data.config.auto.DataSourceConfiguration
 import com.yahoo.wiki.webservice.data.config.auto.DruidNavigator
 import com.yahoo.wiki.webservice.data.config.auto.TableConfig
-
 import spock.lang.Specification
 
 public class AutomaticDruidConfigLoaderSpec extends Specification {
@@ -53,7 +52,7 @@ public class AutomaticDruidConfigLoaderSpec extends Specification {
             } else if (druidWebService.lastUrl == '/datasources/' + datasource + "/?full") {
                 return expectedMetricsAndDimensions
             }
-            return "Unexpected URL"
+            println "No response for " + druidWebService.lastUrl
         }
     }
 

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/MultipleDatasourceDruidConfigLoaderSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/MultipleDatasourceDruidConfigLoaderSpec.groovy
@@ -25,7 +25,6 @@ class MultipleDatasourceDruidConfigLoaderSpec extends Specification {
             } else if (druidWebService.lastUrl.equals("/datasources/table2/?full")) {
                 return getFullTable(datasources[1], table2_metrics, table2_dimensions)
             }
-            println "No response for " + druidWebService.lastUrl
         }
     }
 
@@ -50,31 +49,30 @@ class MultipleDatasourceDruidConfigLoaderSpec extends Specification {
 
     private static String getFullTable(String name, String[] metrics, String[] dimensions) {
         return """{
-    "name": "${name}",
-    "properties": {},
-    "segments": [
-        {
-            "dataSource": "${name}",
-            "interval": "2015-09-12T00:00:00.000Z/2015-09-13T00:00:00.000Z",
-            "version": "2017-02-27T03:06:09.422Z",
-            "loadSpec": 
-                {
-                    "type": "local",
-                    "path": "2015-09-12T00:00:00.000Z_2015-09-13T00:00:00.000Z/2017-02-27T03:06:09.422Z/0/index.zip"
-                },
-            "dimensions": "${dimensions.join(",")}",
-            "metrics":  "${metrics.join(",")}",
-            "shardSpec": 
-                {
-                    "type": "none"
-                },
-            "binaryVersion": 9,
-            "size": 5537610,
-            "identifier": "${name}_2015-09-12T00:00:00.000Z_2015-09-13T00:00:00.000Z_2017-02-27T03:06:09.422Z"
-        }
-    ]
-}
-
-"""
+                    "name": "${name}",
+                    "properties": {},
+                    "segments": [
+                        {
+                            "dataSource": "${name}",
+                            "interval": "2015-09-12T00:00:00.000Z/2015-09-13T00:00:00.000Z",
+                            "version": "2017-02-27T03:06:09.422Z",
+                            "loadSpec": 
+                                {
+                                    "type": "local",
+                                    "path": "2015-09-12T00:00:00.000Z_2015-09-13T00:00:00.000Z/2017-02-27T03:06:09.422Z/0/index.zip"
+                                },
+                            "dimensions": "${dimensions.join(",")}",
+                            "metrics":  "${metrics.join(",")}",
+                            "shardSpec": 
+                                {
+                                    "type": "none"
+                                },
+                            "binaryVersion": 9,
+                            "size": 5537610,
+                            "identifier": "${name}_2015-09-12T00:00:00.000Z_2015-09-13T00:00:00.000Z_2017-02-27T03:06:09.422Z"
+                        }
+                    ]
+                }
+                """
     }
 }

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/MultipleDatasourceDruidConfigLoaderSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/MultipleDatasourceDruidConfigLoaderSpec.groovy
@@ -1,0 +1,80 @@
+package com.yahoo.wiki.webservice.web.endpoints
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
+import com.yahoo.wiki.webservice.data.config.auto.DataSourceConfiguration
+import com.yahoo.wiki.webservice.data.config.auto.DruidNavigator
+import spock.lang.Specification
+
+class MultipleDatasourceDruidConfigLoaderSpec extends Specification {
+    private String[] datasources = ["table1", "table2"]
+    private String[] table1_metrics = ["1_metric1", "1_metric2"]
+    private String[] table1_dimensions = ["1_dim1", "1_dim2"]
+    private String[] table2_metrics = ["2_metric1", "2_metric2"]
+    private String[] table2_dimensions = ["2_dim1", "2_dim2"]
+
+    private TestDruidWebService druidWebService
+
+    def setup() {
+        druidWebService = new TestDruidWebService("testInstance")
+        druidWebService.jsonResponse = {
+            if (druidWebService.lastUrl.equals("/datasources/")) {
+                return new ObjectMapper().writeValueAsString(datasources)
+            } else if (druidWebService.lastUrl.equals("/datasources/table1/?full")) {
+                return getFullTable(datasources[0], table1_metrics, table1_dimensions)
+            } else if (druidWebService.lastUrl.equals("/datasources/table2/?full")) {
+                return getFullTable(datasources[1], table2_metrics, table2_dimensions)
+            }
+            println "No response for " + druidWebService.lastUrl
+        }
+    }
+
+    def "Load Multiple datasources"() {
+        when: "We query druid"
+        DruidNavigator druidNavigator = new DruidNavigator(druidWebService)
+
+        then: "What we expect"
+        List<DataSourceConfiguration> tables = druidNavigator.get();
+        tables.size() == 2
+        DataSourceConfiguration table1 = tables.get(0)
+        table1.tableName.asName() == datasources[0]
+        table1.metrics.containsAll(table1_metrics.toList())
+        table1.dimensions.containsAll(table1_dimensions.toList())
+
+        DataSourceConfiguration table2 = tables.get(1)
+        table2.tableName.asName() == datasources[1]
+        table2.metrics.containsAll(table2_metrics.toList())
+        table2.dimensions.containsAll(table2_dimensions.toList())
+    }
+
+
+    private static String getFullTable(String name, String[] metrics, String[] dimensions) {
+        return """{
+    "name": "${name}",
+    "properties": {},
+    "segments": [
+        {
+            "dataSource": "${name}",
+            "interval": "2015-09-12T00:00:00.000Z/2015-09-13T00:00:00.000Z",
+            "version": "2017-02-27T03:06:09.422Z",
+            "loadSpec": 
+                {
+                    "type": "local",
+                    "path": "2015-09-12T00:00:00.000Z_2015-09-13T00:00:00.000Z/2017-02-27T03:06:09.422Z/0/index.zip"
+                },
+            "dimensions": "${dimensions.join(",")}",
+            "metrics":  "${metrics.join(",")}",
+            "shardSpec": 
+                {
+                    "type": "none"
+                },
+            "binaryVersion": 9,
+            "size": 5537610,
+            "identifier": "${name}_2015-09-12T00:00:00.000Z_2015-09-13T00:00:00.000Z_2017-02-27T03:06:09.422Z"
+        }
+    ]
+}
+
+"""
+    }
+}


### PR DESCRIPTION
It appears the locking mechanism was forced to time out while loading
multiple tables because the lock for getting all the tables was still active.

Now only the lock for getting all the tables (`loadAllDatasources()`) is used.