### PR TITLE
Better programmatic generation of metadata json in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,10 @@ Current
 
 ### Changed:
 
+- [Better programmatic generation of metadata json in tests](https://github.com/yahoo/fili/pull/412)
+    * Rework metadata tests to be more generated from strings and more pluggable to support heavier and more expressive
+      testing. This allows for more consistency, as well as make it easier to test more cases.
+
 - [Expose `RequestLog` `LogInfo` objects](https://github.com/yahoo/fili/pull/574)
     * Exposes the `LogInfo` objects stored in the `RequestLog`, via `RequestLog::retrieveAll` making it easier
         for customers to implement their own scheme for logging the `RequestLog`.

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/broadcastchannels/RedisBroadcastChannelSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/broadcastchannels/RedisBroadcastChannelSpec.groovy
@@ -13,31 +13,30 @@ import org.redisson.config.Config
 
 class RedisBroadcastChannelSpec extends BroadcastChannelSpec {
 
-
     private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.instance
 
     boolean USE_REAL_REDIS_CLIENT = SYSTEM_CONFIG.getBooleanProperty(
             SYSTEM_CONFIG.getPackageVariableName("use_real_redis_client"),
             false
-    );
+    )
 
     String REDIS_CHANNEL = SYSTEM_CONFIG.getStringProperty(
             SYSTEM_CONFIG.getPackageVariableName("redisbroadcastchannel_name"),
             "preResponse_notification_channel"
-    );
+    )
 
     List<RedissonClient> redissonClients = new ArrayList<>()
 
     List<MessageListener<String>> topicListeners = new ArrayList<>()
 
     @Override
-    public BroadcastChannel<String> getBroadcastChannel() {
+    BroadcastChannel<String> getBroadcastChannel() {
         RedissonClient redissonClient = USE_REAL_REDIS_CLIENT ? Redisson.create(createConfig()) : mockRedissonClient()
         redissonClients << redissonClient
         return new RedisBroadcastChannel<String>(redissonClient)
     }
 
-    public RedissonClient mockRedissonClient() {
+    RedissonClient mockRedissonClient() {
         RedissonClient redissonClient = Mock(RedissonClient)
         RTopic<String> topic = Mock(RTopic)
 
@@ -55,7 +54,7 @@ class RedisBroadcastChannelSpec extends BroadcastChannelSpec {
         return redissonClient
     }
 
-    public static Config createConfig() {
+    static Config createConfig() {
         // Redis server details
         String redisHost = SYSTEM_CONFIG.getStringProperty(
                 SYSTEM_CONFIG.getPackageVariableName("redis_host"),

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
@@ -256,8 +256,8 @@ abstract class BaseDataSourceMetadataSpec extends Specification {
                         intervals.interval1,
                         versions.version1,
                         null,
-                        dimensions.keySet().toList(),
-                        metrics.keySet().toList(),
+                        dimensions.keySet() as List,
+                        metrics.keySet() as List,
                         partition1,
                         binaryVersions.binaryVersion1,
                         sizes.size1
@@ -267,8 +267,8 @@ abstract class BaseDataSourceMetadataSpec extends Specification {
                         intervals.interval1,
                         versions.version2,
                         null,
-                        dimensions.keySet().toList(),
-                        metrics.keySet().toList(),
+                        dimensions.keySet() as List,
+                        metrics.keySet() as List,
                         partition2,
                         binaryVersions.binaryVersion1,
                         sizes.size2
@@ -278,8 +278,8 @@ abstract class BaseDataSourceMetadataSpec extends Specification {
                         intervals.interval2,
                         versions.version1,
                         null,
-                        dimensions.keySet().toList(),
-                        metrics.keySet().toList(),
+                        dimensions.keySet() as List,
+                        metrics.keySet() as List,
                         partition1,
                         binaryVersions.binaryVersion1,
                         sizes.size1
@@ -289,8 +289,8 @@ abstract class BaseDataSourceMetadataSpec extends Specification {
                         intervals.interval2,
                         versions.version2,
                         null,
-                        dimensions.keySet().toList(),
-                        metrics.keySet().toList(),
+                        dimensions.keySet() as List,
+                        metrics.keySet() as List,
                         partition2,
                         binaryVersions.binaryVersion1,
                         sizes.size2

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
@@ -29,7 +29,7 @@ import spock.lang.Specification
  * Take "intervals" as an example
  * <ul>
  *     <li>
- *         you don't need any of the resources(including "intervals") defined in metadata tests, you do nothing and
+ *         you don't need any of the resources(including "intervals") defined in this Spec, you do nothing and
  *         leave childSetupSpec() empty as it is in this Spec
  *     </li>
  *     <li>

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
@@ -20,82 +20,129 @@ import io.druid.timeline.DataSegment
 import spock.lang.Shared
 import spock.lang.Specification
 
-class BaseDataSourceMetadataSpec extends Specification {
-    @Shared
-    String tableName = TestDruidTableName.ALL_PETS.asName()
-
-    @Shared
-    String intervalString1
-    @Shared
-    String intervalString2
-    @Shared
-    String intervalString12
-
-    @Shared
-    Interval interval1
-    @Shared
-    Interval interval2
-    @Shared
-    Interval interval12
-
-    @Shared
-    RangeSet<DateTime> rangeSet12
-
-    @Shared
-    String version1
-    @Shared
-    String version2
-
-    @Shared
-    DataSegment segment1
-
-    @Shared
-    DataSegment segment2
-
-    @Shared
-    DataSegment segment3
-
-    @Shared
-    DataSegment segment4
-
-    @Shared
-    List<DataSegment> segments
-
+/**
+ * Base specification of all metadata tests.
+ * <p>
+ * Any metadata Specs should extend this Spec, override childSetupSpec(), and call/override generate*() methods to
+ * initiate metadata related resources.
+ * <p>
+ * Take "intervals" as an example
+ * <ul>
+ *     <li>
+ *         you don't need any of the resources(including "intervals") defined in metadata tests, you do nothing and
+ *         leave childSetupSpec() empty as it is in this Spec
+ *     </li>
+ *     <li>
+ *         you need "intervals" in your test, you override childSetupSpec() and call its generation method in your Spec
+ *         as follows
+ *         <pre>
+ *             {@code
+ *             @Override
+ *             def childSetupSpec() {
+ *                 intervals = generateIntervals()
+ *             }
+ *             }
+ *         </pre>
+ *     </li>
+ *     <li>
+ *         you need "intervals" in your test, but you need a different set of intervals:
+ *         <pre>
+ *             {@code
+ *             @Override
+ *             def childSetupSpec() {
+ *                 intervals = generateIntervals()
+ *             }
+ *
+ *             @Override
+ *             Map<String, Interval> generateIntervals() {
+ *                 [
+ *                     "interval1": Interval.parse("2015-01-01T00:00:00.000Z/2015-01-02T00:00:00.000Z"),
+ *                     "interval2": Interval.parse("2015-01-02T00:00:00.000Z/2015-01-03T00:00:00.000Z"),
+ *                     "interval3": Interval.parse("2015-01-03T00:00:00.000Z/2015-01-04T00:00:00.000Z"),
+ *                     "interval123": Interval.parse("2015-01-01T00:00:00.000Z/2015-01-04T00:00:00.000Z")
+ *                 ]
+ *             }
+ *             }
+ *         </pre>
+ *     </li>
+ * </ul>
+ */
+abstract class BaseDataSourceMetadataSpec extends Specification {
     @Shared
     DateTimeZone currentTZ
 
     @Shared
-    List<String> dimensions123
-
+    String tableName
     @Shared
-    List<String> metrics123
+    Map<String, Interval> intervals
+    @Shared
+    RangeSet<DateTime> rangeSet
+    @Shared
+    List<TestApiDimensionName> dimensions
+    @Shared
+    List<TestApiMetricName> metrics
+    @Shared
+    Integer binversion1
+    @Shared
+    long size1
+    @Shared
+    long size2
+    @Shared
+    List<String> versions
+    @Shared
+    List<DataSegment> segments
 
     def setupSpec() {
         currentTZ = DateTimeZone.getDefault()
         DateTimeZone.setDefault(DateTimeZone.UTC)
+        binversion1 = 9
+        size1 = 1024
+        size2 = 512
 
-        intervalString1 = "2015-01-01T00:00:00.000Z/2015-01-02T00:00:00.000Z"
-        intervalString2 = "2015-01-02T00:00:00.000Z/2015-01-03T00:00:00.000Z"
-        intervalString12 = "2015-01-01T00:00:00.000Z/2015-01-03T00:00:00.000Z"
-        interval1 = Interval.parse(intervalString1)
-        interval2 = Interval.parse(intervalString2)
-        interval12 = Interval.parse(intervalString12)
-        rangeSet12 = TreeRangeSet.create()
-        rangeSet12.add(Range.closedOpen(interval12.getStart(), interval12.getEnd()))
-        version1 = DateTimeFormat.fullDateTime().print(DateTime.now().minusDays(1))
-        version2 = DateTimeFormat.fullDateTime().print(DateTime.now())
+        childSetupSpec()
+    }
 
-        TestApiDimensionName dim1 = TestApiDimensionName.BREED
-        TestApiDimensionName dim2 = TestApiDimensionName.SPECIES
-        TestApiDimensionName dim3 = TestApiDimensionName.SEX
+    def childSetupSpec() {}
 
-        dimensions123 = [dim1, dim2, dim3]*.asName()
+    def shutdownSpec() {
+        DateTimeZone.setDefault(currentTZ)
+    }
 
-        TestApiMetricName met1 = TestApiMetricName.A_ROW_NUM
-        TestApiMetricName met2 = TestApiMetricName.A_LIMBS
-        TestApiMetricName met3 = TestApiMetricName.A_DAY_AVG_LIMBS
+    String generateTableName() {
+        TestDruidTableName.ALL_PETS.asName()
+    }
 
-        metrics123 = [met1, met2, met3]*.asName()
+    Map<String, Interval> generateIntervals() {
+        [
+                "interval1": Interval.parse("2015-01-01T00:00:00.000Z/2015-01-02T00:00:00.000Z"),
+                "interval2": Interval.parse("2015-01-02T00:00:00.000Z/2015-01-03T00:00:00.000Z"),
+                "interval12": Interval.parse("2015-01-01T00:00:00.000Z/2015-01-03T00:00:00.000Z")
+        ]
+    }
+
+    RangeSet<DateTime> generateRangeSet() {
+        rangeSet = TreeRangeSet.create()
+        rangeSet.add(Range.closedOpen(intervals["interval12"].getStart(), intervals["interval12"].getEnd()))
+        rangeSet
+    }
+
+    List<TestApiDimensionName> generateDimensions() {
+        [TestApiDimensionName.BREED, TestApiDimensionName.SPECIES, TestApiDimensionName.SEX]
+    }
+
+    List<TestApiMetricName> generateMetrics() {
+        [TestApiMetricName.A_ROW_NUM, TestApiMetricName.A_LIMBS, TestApiMetricName.A_DAY_AVG_LIMBS]
+    }
+
+    List<String> generateVersions() {
+        [
+                DateTimeFormat.fullDateTime().print(DateTime.now().minusDays(1)),
+                DateTimeFormat.fullDateTime().print(DateTime.now())
+        ]
+    }
+
+    List<DataSegment> generateSegments() {
+        versions = generateVersions()
 
         NumberedShardSpec partition1 = Stub(NumberedShardSpec) {
             getPartitionNum() >> 0
@@ -105,63 +152,51 @@ class BaseDataSourceMetadataSpec extends Specification {
             getPartitionNum() >> 1
         }
 
-        Integer binversion1 = 9
-        long size1 = 1024
-        long size2 = 512
-
-        segment1 = new DataSegment(
-                tableName,
-                interval1,
-                version1,
-                null,
-                dimensions123,
-                metrics123,
-                partition1,
-                binversion1,
-                size1
-        )
-
-        segment2 = new DataSegment(
-                tableName,
-                interval1,
-                version2,
-                null,
-                dimensions123,
-                metrics123,
-                partition2,
-                binversion1,
-                size2
-        )
-
-        segment3 = new DataSegment(
-                tableName,
-                interval2,
-                version1,
-                null,
-                dimensions123,
-                metrics123,
-                partition1,
-                binversion1,
-                size1
-        )
-
-        segment4 = new DataSegment(
-                tableName,
-                interval2,
-                version2,
-                null,
-                dimensions123,
-                metrics123,
-                partition2,
-                binversion1,
-                size2
-        )
-
-        segments = [segment1, segment2, segment3, segment4]
-
-    }
-
-    def shutdownSpec() {
-        DateTimeZone.setDefault(currentTZ)
+        [
+                new DataSegment(
+                        tableName,
+                        intervals["interval1"],
+                        versions[0],
+                        null,
+                        dimensions*.asName(),
+                        metrics*.asName(),
+                        partition1,
+                        binversion1,
+                        size1
+                ),
+                new DataSegment(
+                        tableName,
+                        intervals["interval1"],
+                        versions[1],
+                        null,
+                        dimensions*.asName(),
+                        metrics*.asName(),
+                        partition2,
+                        binversion1,
+                        size2
+                ),
+                new DataSegment(
+                        tableName,
+                        intervals["interval2"],
+                        versions[0],
+                        null,
+                        dimensions*.asName(),
+                        metrics*.asName(),
+                        partition1,
+                        binversion1,
+                        size1
+                ),
+                new DataSegment(
+                        tableName,
+                        intervals["interval2"],
+                        versions[1],
+                        null,
+                        dimensions*.asName(),
+                        metrics*.asName(),
+                        partition2,
+                        binversion1,
+                        size2
+                )
+        ]
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
@@ -7,10 +7,6 @@ import com.yahoo.bard.webservice.data.config.names.TestApiMetricName
 import com.yahoo.bard.webservice.data.config.names.TestDruidTableName
 import com.yahoo.bard.webservice.druid.model.metadata.NumberedShardSpec
 
-import com.google.common.collect.Range
-import com.google.common.collect.RangeSet
-import com.google.common.collect.TreeRangeSet
-
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
@@ -72,76 +68,179 @@ abstract class BaseDataSourceMetadataSpec extends Specification {
 
     @Shared
     String tableName
+
+    /**
+     * A map of interval name(String) to an Interval object.
+     * <p>
+     * With a map, you can use {@code intervals.interval1} rather than {@code intervals[0]}. This allows you writing
+     * specs to give your intervals meaningful names and then use them.
+     */
     @Shared
     Map<String, Interval> intervals
+
+    /**
+     * A map of dimension name(String) to a TestApiDimensionName object.
+     * <p>
+     * With a map, you can use {@code dimensions.dim3.asName()} rather than {@code dimensions[2].asName()}. This allows
+     * you writing specs to give your dimensions meaningful names and then use them.
+     */
     @Shared
-    RangeSet<DateTime> rangeSet
+    Map<String, TestApiDimensionName> dimensions
+
+    /**
+     * A map of metric name(String) to a TestApiMetricName object.
+     * <p>
+     * With a map, you can use {@code metrics.metric3.asName()} rather than {@code metrics[2].asName()}. This allows you
+     * writing specs to give your metrics meaningful names and then use them.
+     */
     @Shared
-    List<TestApiDimensionName> dimensions
+    Map<String, TestApiMetricName> metrics
+
+    /**
+     * A map of segment name(String) to a DataSegment object.
+     * <p>
+     * With a map, you can use {@code segments.identifier3} rather than {@code segments[2]}. This allows you writing
+     * specs to give your segments meaningful names and then use them.
+     */
     @Shared
-    List<TestApiMetricName> metrics
+    Map<String, DataSegment> segments
+
+    /**
+     * A map of version name to a version object.
+     * <p>
+     * With a map, you can use {@code versions.version3} rather than {@code version[2]}. This allows you writing specs
+     * to give your versions meaningful names and then use them.
+     */
     @Shared
-    Integer binversion1
+    Map<String, String> versions
+
+    /**
+     * A map of size identifier to the actual size.
+     * <p>
+     * With a map, you can use {@code sizes.identifier3} rather than {@code sizes[2]}. This allows you writing specs
+     * to give your sizes meaningful names and them use them.
+     */
     @Shared
-    long size1
+    Map<String, Long> sizes
+
+    /**
+     * A map of binary version name to its actual binary version.
+     * <p>
+     * A binary version is used as a required argument to construct a DataSegment.
+     * <p>
+     * With a map, you can use {@code binaryVersions.version3} rather than {@code binaryVersions[2]}. This allows you
+     * writing specs to give your sizes meaningful names and then use them.
+     */
     @Shared
-    long size2
-    @Shared
-    List<String> versions
-    @Shared
-    List<DataSegment> segments
+    Map<String, Integer> binaryVersions
 
     def setupSpec() {
         currentTZ = DateTimeZone.getDefault()
         DateTimeZone.setDefault(DateTimeZone.UTC)
-        binversion1 = 9
-        size1 = 1024
-        size2 = 512
 
         childSetupSpec()
     }
 
     def childSetupSpec() {}
 
-    def shutdownSpec() {
+    def cleanupSpec() {
         DateTimeZone.setDefault(currentTZ)
     }
 
+    def childCleanupSpec() {}
+
     String generateTableName() {
-        TestDruidTableName.ALL_PETS.asName()
+        return TestDruidTableName.ALL_PETS.asName()
     }
 
+    /**
+     * Returns a map of interval name(String) to an Interval object.
+     *
+     * @return a map of interval name to an Interval object.
+     */
     Map<String, Interval> generateIntervals() {
-        [
-                "interval1": Interval.parse("2015-01-01T00:00:00.000Z/2015-01-02T00:00:00.000Z"),
-                "interval2": Interval.parse("2015-01-02T00:00:00.000Z/2015-01-03T00:00:00.000Z"),
-                "interval12": Interval.parse("2015-01-01T00:00:00.000Z/2015-01-03T00:00:00.000Z")
+        return [
+                interval1: Interval.parse("2015-01-01T00:00:00.000Z/2015-01-02T00:00:00.000Z"),
+                interval2: Interval.parse("2015-01-02T00:00:00.000Z/2015-01-03T00:00:00.000Z"),
+                interval12: Interval.parse("2015-01-01T00:00:00.000Z/2015-01-03T00:00:00.000Z")
         ]
     }
 
-    RangeSet<DateTime> generateRangeSet() {
-        rangeSet = TreeRangeSet.create()
-        rangeSet.add(Range.closedOpen(intervals["interval12"].getStart(), intervals["interval12"].getEnd()))
-        rangeSet
-    }
-
-    List<TestApiDimensionName> generateDimensions() {
-        [TestApiDimensionName.BREED, TestApiDimensionName.SPECIES, TestApiDimensionName.SEX]
-    }
-
-    List<TestApiMetricName> generateMetrics() {
-        [TestApiMetricName.A_ROW_NUM, TestApiMetricName.A_LIMBS, TestApiMetricName.A_DAY_AVG_LIMBS]
-    }
-
-    List<String> generateVersions() {
-        [
-                DateTimeFormat.fullDateTime().print(DateTime.now().minusDays(1)),
-                DateTimeFormat.fullDateTime().print(DateTime.now())
+    /**
+     * Returns a map of dimension name(String) to a TestApiDimensionName object.
+     *
+     * @return a map of dimension name to a TestApiDimensionName object
+     */
+    Map<String, TestApiDimensionName> generateDimensions() {
+        return [
+                (TestApiDimensionName.BREED.asName()): TestApiDimensionName.BREED,
+                (TestApiDimensionName.SPECIES.asName()): TestApiDimensionName.SPECIES,
+                (TestApiDimensionName.SEX.asName()): TestApiDimensionName.SEX
         ]
     }
 
-    List<DataSegment> generateSegments() {
+    /**
+     * Returns a map of metric name(String) to a TestApiMetricName object.
+     *
+     * @return a map of metric name to a TestApiMetricName object
+     */
+    Map<String, TestApiMetricName> generateMetrics() {
+        return [
+                (TestApiMetricName.A_ROW_NUM.asName()): TestApiMetricName.A_ROW_NUM,
+                (TestApiMetricName.A_LIMBS.asName()): TestApiMetricName.A_LIMBS,
+                (TestApiMetricName.A_DAY_AVG_LIMBS.asName()): TestApiMetricName.A_DAY_AVG_LIMBS
+        ]
+    }
+
+    /**
+     * Returns a map of version name to a version object.
+     *
+     * @return map of version name to a version object
+     */
+    Map<String, String> generateVersions() {
+        return [
+                version1: DateTimeFormat.fullDateTime().print(DateTime.now().minusDays(1)),
+                version2: DateTimeFormat.fullDateTime().print(DateTime.now())
+        ]
+    }
+
+    /**
+     * Returns a map of size identifier to its actual size.
+     *
+     * @return a map of size identifier to its actual size
+     */
+    Map<String, Long> generateSizes() {
+        return [
+                size1: 1024,
+                size2: 512
+        ]
+    }
+
+    /**
+     * Returns a map of binary version name to its actual version.
+     *
+     * @return a map of binary version name to its actual version
+     */
+    Map<String, Integer> generateBinaryVersions() {
+        return [binaryversion1: 9]
+    }
+
+    /**
+     * Returns a map of segment name(String) to a DataSegment object.
+     * <p>
+     * This method also generates {@code tableName}, {@code intervals}, {@code dimensions}, {@code metrics},
+     * {@code versions}, {@code sizes}, and {@code binaryVersions}
+     *
+     * @return a map of segment name to a DataSegment object
+     */
+    Map<String, DataSegment> generateSegments() {
+        tableName = generateTableName()
+        intervals = generateIntervals()
+        dimensions = generateDimensions()
+        metrics = generateMetrics()
         versions = generateVersions()
+        sizes = generateSizes()
+        binaryVersions = generateBinaryVersions()
 
         NumberedShardSpec partition1 = Stub(NumberedShardSpec) {
             getPartitionNum() >> 0
@@ -151,50 +250,50 @@ abstract class BaseDataSourceMetadataSpec extends Specification {
             getPartitionNum() >> 1
         }
 
-        [
-                new DataSegment(
+        return [
+                segment1: new DataSegment(
                         tableName,
-                        intervals["interval1"],
-                        versions[0],
+                        intervals.interval1,
+                        versions.version1,
                         null,
-                        dimensions*.asName(),
-                        metrics*.asName(),
+                        dimensions.keySet().toList(),
+                        metrics.keySet().toList(),
                         partition1,
-                        binversion1,
-                        size1
+                        binaryVersions.binaryVersion1,
+                        sizes.size1
                 ),
-                new DataSegment(
+                segment2: new DataSegment(
                         tableName,
-                        intervals["interval1"],
-                        versions[1],
+                        intervals.interval1,
+                        versions.version2,
                         null,
-                        dimensions*.asName(),
-                        metrics*.asName(),
+                        dimensions.keySet().toList(),
+                        metrics.keySet().toList(),
                         partition2,
-                        binversion1,
-                        size2
+                        binaryVersions.binaryVersion1,
+                        sizes.size2
                 ),
-                new DataSegment(
+                segment3: new DataSegment(
                         tableName,
-                        intervals["interval2"],
-                        versions[0],
+                        intervals.interval2,
+                        versions.version1,
                         null,
-                        dimensions*.asName(),
-                        metrics*.asName(),
+                        dimensions.keySet().toList(),
+                        metrics.keySet().toList(),
                         partition1,
-                        binversion1,
-                        size1
+                        binaryVersions.binaryVersion1,
+                        sizes.size1
                 ),
-                new DataSegment(
+                segment4: new DataSegment(
                         tableName,
-                        intervals["interval2"],
-                        versions[1],
+                        intervals.interval2,
+                        versions.version2,
                         null,
-                        dimensions*.asName(),
-                        metrics*.asName(),
+                        dimensions.keySet().toList(),
+                        metrics.keySet().toList(),
                         partition2,
-                        binversion1,
-                        size2
+                        binaryVersions.binaryVersion1,
+                        sizes.size2
                 )
         ]
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/BaseDataSourceMetadataSpec.groovy
@@ -29,8 +29,7 @@ import spock.lang.Specification
  * Take "intervals" as an example
  * <ul>
  *     <li>
- *         you don't need any of the resources(including "intervals") defined in this Spec, you do nothing and
- *         leave childSetupSpec() empty as it is in this Spec
+ *         you don't need any of the resources(including "intervals") defined in this Spec, you do nothing
  *     </li>
  *     <li>
  *         you need "intervals" in your test, you override childSetupSpec() and call its generation method in your Spec

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoadTaskSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoadTaskSpec.groovy
@@ -8,7 +8,8 @@ import static com.yahoo.bard.webservice.data.Columns.METRICS
 import com.yahoo.bard.webservice.application.JerseyTestBinder
 import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.config.names.DataSourceName
-import com.yahoo.bard.webservice.data.dimension.DimensionColumn
+import com.yahoo.bard.webservice.data.config.names.TestApiDimensionName
+import com.yahoo.bard.webservice.data.config.names.TestApiMetricName
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.data.metric.MetricColumn
 import com.yahoo.bard.webservice.druid.client.DruidWebService
@@ -27,6 +28,27 @@ class DataSourceMetadataLoadTaskSpec extends BaseDataSourceMetadataSpec {
 
     private static final ObjectMappersSuite MAPPERS = new ObjectMappersSuite()
 
+    Interval interval1
+    Interval interval2
+    Interval interval3
+
+    List<String> dimensions13
+    List<String> quotedDimensions
+    List<String> metrics123
+    List<String> metrics13
+
+    String fullDataSourceMetadataJson
+    String gappyDataSourceMetadataJson
+
+    JerseyTestBinder jtb
+
+    PhysicalTableDictionary tableDict
+    DataSourceMetadataService metadataService
+    SegmentIntervalsHashIdGenerator segmentSetIdGenerator
+    DimensionDictionary dimensionDict
+    TestDruidWebService druidWS = new TestDruidWebService()
+    Map<Column, Set<Interval>> expectedIntervalsMap
+
     @Override
     def childSetupSpec() {
         tableName = generateTableName()
@@ -34,6 +56,8 @@ class DataSourceMetadataLoadTaskSpec extends BaseDataSourceMetadataSpec {
         dimensions = generateDimensions()
         metrics = generateMetrics()
         versions = generateVersions()
+        sizes = generateSizes()
+        binaryVersions = generateBinaryVersions()
     }
 
     @Override
@@ -46,11 +70,154 @@ class DataSourceMetadataLoadTaskSpec extends BaseDataSourceMetadataSpec {
         ]
     }
 
-    List<String> dimensions13 = [dimensions[0], dimensions[2]]*.asName()
-    List<String> quotedDimensions = dimensions13.collect() { '"' + it + '"'}
+    def setup() {
+        dimensions13 = [
+                dimensions.(TestApiDimensionName.BREED.asName()).asName(),
+                dimensions.(TestApiDimensionName.SEX.asName()).asName()
+        ]
+        quotedDimensions = dimensions13.collect() { '"' + it + '"'}
 
-    List<String> metrics123 = [metrics[0], metrics[1], metrics[2]]*.asName()
-    List<String> metrics13 = [metrics[0], metrics[2]]*.asName()
+        metrics123 = [
+                metrics.(TestApiMetricName.A_ROW_NUM.asName()).asName(),
+                metrics.(TestApiMetricName.A_LIMBS.asName()).asName(),
+                metrics.(TestApiMetricName.A_DAY_AVG_LIMBS.asName()).asName()
+        ]
+        metrics13 = [TestApiMetricName.A_ROW_NUM.asName(), TestApiMetricName.A_DAY_AVG_LIMBS.asName()]
+
+        interval1 = intervals.interval1
+        interval2 = intervals.interval2
+        interval3 = intervals.interval3
+
+        fullDataSourceMetadataJson =
+                """{
+                       "name": "$tableName",
+                       "properties": {},
+                       "segments": [
+                           ${[
+                               generateSegment(tableName, interval1, versions.version1, dimensions.keySet().join(','), metrics123.join(','), 0, 2, binaryVersions.binaryVersion1, sizes.size1),
+                               generateSegment(tableName, interval1, versions.version2, dimensions.keySet().join(','), metrics123.join(','), 1, 2, binaryVersions.binaryVersion1, sizes.size2),
+                               generateSegment(tableName, interval1, versions.version1, dimensions.keySet().join(','), metrics123.join(','), 0, 2, binaryVersions.binaryVersion1, sizes.size1),
+                               generateSegment(tableName, interval2, versions.version2, dimensions.keySet().join(','), metrics123.join(','), 1, 2, binaryVersions.binaryVersion1, sizes.size2),
+                               generateSegment(tableName, interval3, versions.version1, dimensions.keySet().join(','), metrics123.join(','), 0, 2, binaryVersions.binaryVersion1, sizes.size1),
+                               generateSegment(tableName, interval3, versions.version2, dimensions.keySet().join(','), metrics123.join(','), 1, 2, binaryVersions.binaryVersion1, sizes.size2),
+                               generateSegment_9_1(tableName, interval3, versions.version2, dimensions.keySet().join(','), metrics123.join(','), 0, 2, [], binaryVersions.binaryVersion1, sizes.size2),
+                               generateSegment_9_1(tableName, interval3, versions.version2, dimensions.keySet().join(','), metrics123.join(','), 1, 2, quotedDimensions, binaryVersions.binaryVersion1, sizes.size2)
+                           ].join(',')}
+                       ]
+                }"""
+
+        gappyDataSourceMetadataJson =
+                """{
+                      "name": "$tableName",
+                      "properties": {},
+                      "segments": [
+                          ${[
+                              generateSegment(tableName, interval1, versions.version1, dimensions.keySet().join(','), metrics123.join(','), 0, 2, binaryVersions.binaryVersion1, sizes.size1),
+                              generateSegment(tableName, interval1, versions.version2, dimensions.keySet().join(','), metrics123.join(','), 1, 2, binaryVersions.binaryVersion1, sizes.size2),
+                              generateSegment(tableName, interval2, versions.version1, dimensions13.join(','), metrics13.join(','), 0, 2, binaryVersions.binaryVersion1, sizes.size1),
+                              generateSegment(tableName, interval2, versions.version2, dimensions13.join(','), metrics13.join(','), 1, 2, binaryVersions.binaryVersion1, sizes.size2),
+                              generateSegment(tableName, interval3, versions.version1, dimensions.keySet().join(','), metrics123.join(','), 0, 2, binaryVersions.binaryVersion1, sizes.size1),
+                              generateSegment(tableName, interval3, versions.version2, dimensions.keySet().join(','), metrics123.join(','), 1, 2, binaryVersions.binaryVersion1, sizes.size2),
+                              generateSegment_9_1(tableName, interval3, versions.version1, dimensions.keySet().join(','), metrics123.join(','), 0, 2, [], binaryVersions.binaryVersion1, sizes.size1),
+                              generateSegment_9_1(tableName, interval3, versions.version2, dimensions.keySet().join(','), metrics123.join(','), 1, 2, quotedDimensions, binaryVersions.binaryVersion1, sizes.size2)
+                          ].join(',')}
+                      ]
+                }"""
+
+        jtb = new JerseyTestBinder()
+        segmentSetIdGenerator = jtb.testBinderFactory.querySigningService
+        metadataService = jtb.testBinderFactory.getDataSourceMetadataService()
+        dimensionDict = jtb.configurationLoader.dimensionDictionary
+        tableDict = jtb.configurationLoader.physicalTableDictionary
+        druidWS.jsonResponse = {fullDataSourceMetadataJson}
+
+        Interval interval123 = intervals.interval123
+
+        expectedIntervalsMap = dimensions
+                .collect {dimensionDict.findByApiName(it.key)}
+                .collectEntries{[(it): [interval123] as Set]}
+        metrics123.collect {new MetricColumn(it)}.each {expectedIntervalsMap[it] = [interval123] as Set}
+    }
+
+    def cleanup() {
+        jtb.tearDown()
+    }
+
+    def "test whether DataSourceMetadataLoader loads any metadata segments"() {
+        setup: "run the loader"
+        DataSourceMetadataLoadTask loader = new DataSourceMetadataLoadTask(
+                tableDict,
+                metadataService,
+                druidWS,
+                MAPPERS.mapper
+        )
+        DataSource dataSource = Mock(DataSource)
+        dataSource.physicalTable >> Mock(ConstrainedTable) {
+            getDataSourceNames() >> ([DataSourceName.of(tableName)] as Set)
+        }
+
+        DruidAggregationQuery<?> query = Mock(DruidAggregationQuery)
+        query.intervals >> [interval1, interval2]
+        query.innermostQuery >> query
+        query.dataSource >> dataSource
+
+        loader.run()
+
+        expect: "cache gets loaded as expected"
+        segmentSetIdGenerator.getSegmentSetId(query) != OptionalInt.empty()
+    }
+
+    def "Test datasource metadata can deserialize JSON correctly"() {
+        setup: "instantiate the loader"
+        DataSourceMetadataService localMetadataService = Mock(DataSourceMetadataService)
+        DataSourceMetadataLoadTask loader = new DataSourceMetadataLoadTask(
+                tableDict,
+                localMetadataService,
+                druidWS,
+                MAPPERS.mapper
+        )
+        druidWS.jsonResponse = {gappyDataSourceMetadataJson}
+        StrictPhysicalTable table = Mock(StrictPhysicalTable)
+        table.dataSourceName >> DataSourceName.of("test")
+        DataSourceMetadata capture
+
+        when: "JSON metadata return successfully"
+        SuccessCallback success = loader.buildDataSourceMetadataSuccessCallback(table.dataSourceName)
+        success.invoke(MAPPERS.mapper.readTree(gappyDataSourceMetadataJson))
+
+        then: "the segment metadata are loaded to the metadata service as expected"
+        1 * localMetadataService.update(table.dataSourceName, _ as DataSourceMetadata) >> { physicalTable, dataSourceMetadata ->
+            capture = dataSourceMetadata
+        }
+        def intervalLists = DataSourceMetadata.getIntervalLists(capture)
+        intervalLists.get(DIMENSIONS).containsKey(dimensions.(TestApiDimensionName.SEX.asName()).asName())
+        intervalLists.get(DIMENSIONS).get(dimensions.(TestApiDimensionName.SEX.asName()).asName()).size() == 1
+        intervalLists.get(METRICS).get(metrics.(TestApiMetricName.A_LIMBS.asName()).asName()).size() == 2
+        capture.name == tableName
+        capture.properties == [:]
+        capture.segments[0].dimensions.toSet().sort() == dimensions.keySet().sort()
+        capture.segments[1].size == sizes.size2
+        capture.segments[1].shardSpec.partitionNum == 1
+    }
+
+    def "Test queryDataSourceMetadata builds callbacks and sends query"() {
+        setup: "instantiate the loader"
+        DruidWebService testWs = Mock(DruidWebService)
+        DataSourceMetadataLoadTask loader = new DataSourceMetadataLoadTask(
+                tableDict,
+                metadataService,
+                testWs,
+                MAPPERS.mapper
+        )
+        StrictPhysicalTable table = Mock(StrictPhysicalTable)
+        table.dataSourceName >> DataSourceName.of("test")
+
+        when: "loader issues a metadata query"
+        loader.queryDataSourceMetadata(table.dataSourceName)
+
+        then: "the query is issued to the webservice that was specified to query the druid metadata endpoint"
+        1 * testWs.getJsonObject(_, _, _, _)
+    }
 
     def generateSegment(tableName, interval, version, dimensions, metrics, partitionNum, partitions, binVersion, size) {
         return """{
@@ -89,145 +256,5 @@ class DataSourceMetadataLoadTaskSpec extends BaseDataSourceMetadataSpec {
                         "size": $size,
                         "identifier": ""
         }"""
-    }
-
-    String fullDataSourceMetadataJson =
-           """{
-            "name": "$tableName",
-            "properties": {},
-            "segments": [
-                    ${[
-                            generateSegment(tableName, intervals["interval1"], versions[0], dimensions.join(','), metrics123.join(','), 0, 2, binversion1, size1),
-                            generateSegment(tableName, intervals["interval1"], versions[1], dimensions.join(','), metrics123.join(','), 1, 2, binversion1, size2),
-                            generateSegment(tableName, intervals["interval2"], versions[0], dimensions.join(','), metrics123.join(','), 0, 2, binversion1, size1),
-                            generateSegment(tableName, intervals["interval2"], versions[1], dimensions.join(','), metrics123.join(','), 1, 2, binversion1, size2),
-                            generateSegment(tableName, intervals["interval3"], versions[0], dimensions.join(','), metrics123.join(','), 0, 2, binversion1, size1),
-                            generateSegment(tableName, intervals["interval3"], versions[1], dimensions.join(','), metrics123.join(','), 1, 2, binversion1, size2),
-                            generateSegment_9_1(tableName, intervals["interval3"], versions[1], dimensions.join(','), metrics123.join(','), 0, 2, [], binversion1, size2),
-                            generateSegment_9_1(tableName, intervals["interval3"], versions[1], dimensions.join(','), metrics123.join(','), 1, 2, quotedDimensions, binversion1, size2)
-                    ].join(',')}
-                ]
-            }"""
-
-    String gappyDataSourceMetadataJson =
-           """{
-            "name": "$tableName",
-            "properties": {},
-            "segments": [
-                   ${[
-                            generateSegment(tableName, intervals["interval1"], versions[0], dimensions.join(','), metrics123.join(','), 0, 2, binversion1, size1),
-                            generateSegment(tableName, intervals["interval1"], versions[1], dimensions.join(','), metrics123.join(','), 1, 2, binversion1, size2),
-                            generateSegment(tableName, intervals["interval2"], versions[0], dimensions13.join(','), metrics13.join(','), 0, 2, binversion1, size1),
-                            generateSegment(tableName, intervals["interval2"], versions[1], dimensions13.join(','), metrics13.join(','), 1, 2, binversion1, size2),
-                            generateSegment(tableName, intervals["interval3"], versions[0], dimensions.join(','), metrics123.join(','), 0, 2, binversion1, size1),
-                            generateSegment(tableName, intervals["interval3"], versions[1], dimensions.join(','), metrics123.join(','), 1, 2, binversion1, size2),
-                            generateSegment_9_1(tableName, intervals["interval3"], versions[0], dimensions.join(','), metrics123.join(','), 0, 2, [], binversion1, size1),
-                            generateSegment_9_1(tableName, intervals["interval3"], versions[1], dimensions.join(','), metrics123.join(','), 1, 2, quotedDimensions, binversion1, size2)
-                   ].join(',')}
-                ]
-            }"""
-
-    JerseyTestBinder jtb
-
-    PhysicalTableDictionary tableDict
-    DataSourceMetadataService metadataService
-    SegmentIntervalsHashIdGenerator segmentSetIdGenerator
-    DimensionDictionary dimensionDict
-    TestDruidWebService druidWS = new TestDruidWebService()
-    Map<Column, Set<Interval>> expectedIntervalsMap
-
-    def setup() {
-        jtb = new JerseyTestBinder()
-        segmentSetIdGenerator = jtb.testBinderFactory.querySigningService
-        metadataService = jtb.testBinderFactory.getDataSourceMetadataService()
-        dimensionDict = jtb.configurationLoader.dimensionDictionary
-        tableDict = jtb.configurationLoader.physicalTableDictionary
-        druidWS.jsonResponse = {fullDataSourceMetadataJson}
-
-        expectedIntervalsMap = [:]
-        dimensions.each {
-            expectedIntervalsMap.put(new DimensionColumn(dimensionDict.findByApiName(it.asName())), [intervals["interval123"]] as Set)
-        }
-        metrics123.each { expectedIntervalsMap.put(new MetricColumn(it), [intervals["interval123"]] as Set) }
-    }
-
-    def cleanup() {
-        jtb.tearDown()
-    }
-
-    def "test whether DataSourceMetadataLoader loads any metadata segments"() {
-        setup: "run the loader"
-        DataSourceMetadataLoadTask loader = new DataSourceMetadataLoadTask(
-                tableDict,
-                metadataService,
-                druidWS,
-                MAPPERS.mapper
-        )
-        DataSource dataSource = Mock(DataSource)
-        dataSource.physicalTable >> Mock(ConstrainedTable) {
-            getDataSourceNames() >> ([DataSourceName.of(tableName)] as Set)
-        }
-
-        DruidAggregationQuery<?> query = Mock(DruidAggregationQuery)
-        query.intervals >> [intervals["interval1"], intervals["interval2"]]
-        query.innermostQuery >> query
-        query.dataSource >> dataSource
-
-        loader.run()
-
-        expect: "cache gets loaded as expected"
-        segmentSetIdGenerator.getSegmentSetId(query) != OptionalInt.empty()
-    }
-
-    def "Test datasource metadata can deserialize JSON correctly"() {
-        setup: "instantiate the loader"
-        DataSourceMetadataService localMetadataService = Mock(DataSourceMetadataService)
-        DataSourceMetadataLoadTask loader = new DataSourceMetadataLoadTask(
-                tableDict,
-                localMetadataService,
-                druidWS,
-                MAPPERS.mapper
-        )
-        druidWS.jsonResponse = {gappyDataSourceMetadataJson}
-        StrictPhysicalTable table = Mock(StrictPhysicalTable)
-        table.dataSourceName >> DataSourceName.of("test")
-        DataSourceMetadata capture
-
-        when: "JSON metadata return successfully"
-        SuccessCallback success = loader.buildDataSourceMetadataSuccessCallback(table.dataSourceName)
-        success.invoke(MAPPERS.mapper.readTree(gappyDataSourceMetadataJson))
-
-        then: "the segment metadata are loaded to the metadata service as expected"
-        1 * localMetadataService.update(table.dataSourceName, _ as DataSourceMetadata) >> { physicalTable, dataSourceMetadata ->
-            capture = dataSourceMetadata
-        }
-        def intervalLists = DataSourceMetadata.getIntervalLists(capture)
-        intervalLists.get(DIMENSIONS).containsKey(dimensions[2].asName())
-        intervalLists.get(DIMENSIONS).get(dimensions[2].asName()).size() == 1
-        intervalLists.get(METRICS).get(metrics[1].asName()).size() == 2
-        capture.name == tableName
-        capture.properties == [:]
-        capture.segments[0].dimensions == dimensions*.name()
-        capture.segments[1].size == size2
-        capture.segments[1].shardSpec.partitionNum == 1
-    }
-
-    def "Test queryDataSourceMetadata builds callbacks and sends query"() {
-        setup: "instantiate the loader"
-        DruidWebService testWs = Mock(DruidWebService)
-        DataSourceMetadataLoadTask loader = new DataSourceMetadataLoadTask(
-                tableDict,
-                metadataService,
-                testWs,
-                MAPPERS.mapper
-        )
-        StrictPhysicalTable table = Mock(StrictPhysicalTable)
-        table.dataSourceName >> DataSourceName.of("test")
-
-        when: "loader issues a metadata query"
-        loader.queryDataSourceMetadata(table.dataSourceName)
-
-        then: "the query is issued to the webservice that was specified to query the druid metadata endpoint"
-        1 * testWs.getJsonObject(_, _, _, _)
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoadTaskSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoadTaskSpec.groovy
@@ -75,7 +75,7 @@ class DataSourceMetadataLoadTaskSpec extends BaseDataSourceMetadataSpec {
                 dimensions.(TestApiDimensionName.BREED.asName()).asName(),
                 dimensions.(TestApiDimensionName.SEX.asName()).asName()
         ]
-        quotedDimensions = dimensions13.collect() { '"' + it + '"'}
+        quotedDimensions = dimensions13.collect() { /"$it"/ }
 
         metrics123 = [
                 metrics.(TestApiMetricName.A_ROW_NUM.asName()).asName(),

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataServiceSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataServiceSpec.groovy
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.metadata
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
 import com.yahoo.bard.webservice.data.config.names.DataSourceName
+import com.yahoo.bard.webservice.data.config.names.TestApiDimensionName
 
 import org.joda.time.DateTime
 import org.joda.time.Interval
@@ -26,7 +27,7 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
     }
 
     def setup() {
-        metadata = new DataSourceMetadata(tableName, [:], segments)
+        metadata = new DataSourceMetadata(tableName, [:], segments.values().toList())
     }
 
     def "test metadata service updates segment availability for physical tables and access methods behave correctly"() {
@@ -50,8 +51,8 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
                 .map({it.values()})
                 .map({it.collect {it.identifier}})
                 .collect(Collectors.toList())  == [
-                        [segments[0].identifier, segments[1].identifier],
-                        [segments[2].identifier, segments[3].identifier]
+                        [segments.segment1.identifier, segments.segment2.identifier],
+                        [segments.segment3.identifier, segments.segment4.identifier]
                 ]
 
         and: "all the intervals by column in metadata service are simplified to interval12"
@@ -70,7 +71,7 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
 
         expect:
         segmentByTime.keySet() == [dateTime1, dateTime2] as Set
-        segmentByTime.get(new DateTime(intervals["interval2"].start)).keySet() == [segments[2].identifier, segments[3].identifier] as Set
+        segmentByTime.get(new DateTime(intervals["interval2"].start)).keySet() == [segments.segment3.identifier, segments.segment4.identifier] as Set
     }
 
     def "grouping intervals by column behave as expected"() {
@@ -78,8 +79,8 @@ class DataSourceMetadataServiceSpec extends BaseDataSourceMetadataSpec {
         Map<String, List<Interval>> intervalByColumn = DataSourceMetadataService.groupIntervalByColumn(metadata)
 
         expect:
-        intervalByColumn.keySet() == (dimensions*.asName() + metrics*.asName()) as Set
-        intervalByColumn.get(dimensions.get(0).asName()) == [intervals["interval12"]]
+        intervalByColumn.keySet() == dimensions.keySet() + metrics.keySet()
+        intervalByColumn.get(dimensions.(TestApiDimensionName.BREED.asName()).asName()) == [intervals["interval12"]]
     }
 
     def "accessing availability by column throws exception if the table does not exist in datasource metadata service"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataSpec.groovy
@@ -13,6 +13,16 @@ import com.google.common.collect.RangeSet
 import org.joda.time.DateTime
 
 class DataSourceMetadataSpec extends BaseDataSourceMetadataSpec {
+    @Override
+    def childSetupSpec() {
+        tableName = generateTableName()
+        intervals = generateIntervals()
+        rangeSet = generateRangeSet()
+        dimensions = generateDimensions()
+        metrics = generateMetrics()
+        segments = generateSegments()
+    }
+
     def "test construct healthy datasource metadata (interval version)"() {
         setup:
         DataSourceMetadata metadata = new DataSourceMetadata(tableName, [:], segments)
@@ -23,17 +33,17 @@ class DataSourceMetadataSpec extends BaseDataSourceMetadataSpec {
         metadata.getProperties() == [:]
         metadata.getSegments() == segments
         intervalLists.size() == 2
-        intervalLists.get(DIMENSIONS).keySet().sort() == dimensions123.sort()
+        intervalLists.get(DIMENSIONS).keySet().sort() == dimensions*.asName().sort()
         intervalLists.get(DIMENSIONS).values() as List == [
-                [interval12] as SimplifiedIntervalList,
-                [interval12] as SimplifiedIntervalList,
-                [interval12] as SimplifiedIntervalList
+                [intervals["interval12"]] as SimplifiedIntervalList,
+                [intervals["interval12"]] as SimplifiedIntervalList,
+                [intervals["interval12"]] as SimplifiedIntervalList
         ]
-        intervalLists.get(METRICS).keySet().sort() == metrics123.sort()
+        intervalLists.get(METRICS).keySet().sort() == metrics*.asName().sort()
         intervalLists.get(METRICS).values() as List == [
-                [interval12] as SimplifiedIntervalList,
-                [interval12] as SimplifiedIntervalList,
-                [interval12] as SimplifiedIntervalList
+                [intervals["interval12"]] as SimplifiedIntervalList,
+                [intervals["interval12"]] as SimplifiedIntervalList,
+                [intervals["interval12"]] as SimplifiedIntervalList
         ]
     }
 
@@ -47,17 +57,17 @@ class DataSourceMetadataSpec extends BaseDataSourceMetadataSpec {
         metadata.getProperties() == [:]
         metadata.getSegments() == segments
         rangeLists.size() == 2
-        rangeLists.get(DIMENSIONS).keySet().sort() == dimensions123.sort()
+        rangeLists.get(DIMENSIONS).keySet().sort() == dimensions*.asName().sort()
         rangeLists.get(DIMENSIONS).values() as List == [
-                rangeSet12,
-                rangeSet12,
-                rangeSet12
+                rangeSet,
+                rangeSet,
+                rangeSet
         ]
-        rangeLists.get(METRICS).keySet().sort() == metrics123.sort()
+        rangeLists.get(METRICS).keySet().sort() == metrics*.asName().sort()
         rangeLists.get(METRICS).values() as List == [
-                rangeSet12,
-                rangeSet12,
-                rangeSet12
+                rangeSet,
+                rangeSet,
+                rangeSet
         ]
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/DataSourceMetadataSpec.groovy
@@ -8,66 +8,73 @@ import static com.yahoo.bard.webservice.data.Columns.METRICS
 import com.yahoo.bard.webservice.data.Columns
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
+import com.google.common.collect.Range
 import com.google.common.collect.RangeSet
+import com.google.common.collect.TreeRangeSet
 
 import org.joda.time.DateTime
+import org.joda.time.Interval
+
+import io.druid.timeline.DataSegment
 
 class DataSourceMetadataSpec extends BaseDataSourceMetadataSpec {
+    DataSourceMetadata metadata
+    List<DataSegment> allSegments
+    Interval interval12
+
     @Override
     def childSetupSpec() {
         tableName = generateTableName()
         intervals = generateIntervals()
-        rangeSet = generateRangeSet()
         dimensions = generateDimensions()
         metrics = generateMetrics()
         segments = generateSegments()
     }
 
+    def setup() {
+        allSegments = segments.values().toList()
+        metadata = new DataSourceMetadata(tableName, [:], allSegments)
+        interval12 = intervals.interval12
+    }
+
     def "test construct healthy datasource metadata (interval version)"() {
         setup:
-        DataSourceMetadata metadata = new DataSourceMetadata(tableName, [:], segments)
         Map<Columns, Map<String, SimplifiedIntervalList>> intervalLists = DataSourceMetadata.getIntervalLists(metadata)
 
         expect:
         metadata.getName() == tableName
         metadata.getProperties() == [:]
-        metadata.getSegments() == segments
+        metadata.getSegments() == allSegments
         intervalLists.size() == 2
-        intervalLists.get(DIMENSIONS).keySet().sort() == dimensions*.asName().sort()
+        intervalLists.get(DIMENSIONS).keySet().sort() == dimensions.keySet().sort()
         intervalLists.get(DIMENSIONS).values() as List == [
-                [intervals["interval12"]] as SimplifiedIntervalList,
-                [intervals["interval12"]] as SimplifiedIntervalList,
-                [intervals["interval12"]] as SimplifiedIntervalList
+                [interval12] as SimplifiedIntervalList,
+                [interval12] as SimplifiedIntervalList,
+                [interval12] as SimplifiedIntervalList
         ]
-        intervalLists.get(METRICS).keySet().sort() == metrics*.asName().sort()
+        intervalLists.get(METRICS).keySet().sort() == metrics.keySet().sort()
         intervalLists.get(METRICS).values() as List == [
-                [intervals["interval12"]] as SimplifiedIntervalList,
-                [intervals["interval12"]] as SimplifiedIntervalList,
-                [intervals["interval12"]] as SimplifiedIntervalList
+                [interval12] as SimplifiedIntervalList,
+                [interval12] as SimplifiedIntervalList,
+                [interval12] as SimplifiedIntervalList
         ]
     }
 
     def "test construct healthy datasource metadata (rangeSet version)"() {
         setup:
-        DataSourceMetadata metadata = new DataSourceMetadata(tableName, [:], segments)
         Map<Columns, Map<String, RangeSet<DateTime>>> rangeLists = DataSourceMetadata.getRangeLists(metadata)
+
+        RangeSet<DateTime> rangeSet = TreeRangeSet.create()
+        rangeSet.add(Range.closedOpen(interval12.getStart(), interval12.getEnd()))
 
         expect:
         metadata.getName() == tableName
         metadata.getProperties() == [:]
-        metadata.getSegments() == segments
+        metadata.getSegments() == allSegments
         rangeLists.size() == 2
-        rangeLists.get(DIMENSIONS).keySet().sort() == dimensions*.asName().sort()
-        rangeLists.get(DIMENSIONS).values() as List == [
-                rangeSet,
-                rangeSet,
-                rangeSet
-        ]
-        rangeLists.get(METRICS).keySet().sort() == metrics*.asName().sort()
-        rangeLists.get(METRICS).values() as List == [
-                rangeSet,
-                rangeSet,
-                rangeSet
-        ]
+        rangeLists.get(DIMENSIONS).keySet().sort() == dimensions.keySet().sort()
+        rangeLists.get(DIMENSIONS).values() as List == [rangeSet, rangeSet, rangeSet]
+        rangeLists.get(METRICS).keySet().sort() == metrics.keySet().sort()
+        rangeLists.get(METRICS).values() as List == [rangeSet, rangeSet, rangeSet]
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/SegmentIntervalsHashIdGeneratorSpec.groovy
@@ -56,15 +56,22 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
     @Shared
     LookbackQuery lookbackQuery
 
+    @Override
+    def childSetupSpec() {
+        tableName = generateTableName()
+        intervals = generateIntervals()
+        segments = generateSegments()
+    }
+
     def setupSpec() {
         segmentInfoMap1 = [:] as LinkedHashMap
         segmentInfoMap2 = [:] as LinkedHashMap
         segmentInfoMap3 = [:] as LinkedHashMap
 
-        segmentInfoMap1[segment1.identifier] = new SegmentInfo(segment1)
-        segmentInfoMap1[segment2.identifier] = new SegmentInfo(segment2)
+        segmentInfoMap1[segments[0].identifier] = new SegmentInfo(segments[0])
+        segmentInfoMap1[segments[1].identifier] = new SegmentInfo(segments[1])
 
-        segmentInfoMap2[segment3.identifier] = new SegmentInfo(segment3)
+        segmentInfoMap2[segments[2].identifier] = new SegmentInfo(segments[2])
 
         jtb = new JerseyTestBinder()
         tableDict = jtb.configurationLoader.physicalTableDictionary
@@ -80,11 +87,11 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
         customSegmentSetIdGenerator = new SegmentIntervalsHashIdGenerator(metadataService, signingFunctions)
 
         availabilityList1 = [
-                (interval1.start): segmentInfoMap1,
-                (interval2.start): segmentInfoMap2
+                (intervals["interval1"].start): segmentInfoMap1,
+                (intervals["interval2"].start): segmentInfoMap2
         ] as ConcurrentSkipListMap
 
-        availabilityList2 = [(interval2.start): segmentInfoMap2] as ConcurrentSkipListMap
+        availabilityList2 = [(intervals["interval2"].start): segmentInfoMap2] as ConcurrentSkipListMap
 
         AtomicReference<ConcurrentSkipListMap<DateTime, Map<String, SegmentInfo>>> atomicRef = new AtomicReference<>()
         atomicRef.set(availabilityList1)
@@ -95,7 +102,7 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
         )
 
         timeSeriesQuery = new TimeSeriesQuerySpec().defaultQuery(
-                intervals: [interval2],
+                intervals: [intervals["interval2"]],
                 dataSource: new TableDataSource(
                         TableTestUtils.buildTable(
                                 tableName,
@@ -125,7 +132,7 @@ class SegmentIntervalsHashIdGeneratorSpec extends BaseDataSourceMetadataSpec {
         }
 
         DruidAggregationQuery<?> query = Mock(DruidAggregationQuery)
-        query.intervals >> [interval1, interval2]
+        query.intervals >> [intervals["interval1"], intervals["interval2"]]
         query.innermostQuery >> query
         query.dataSource >> dataSource
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImplSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImplSpec.groovy
@@ -36,6 +36,13 @@ class SlicesApiRequestImplSpec extends BaseDataSourceMetadataSpec {
     @Shared
     PhysicalTableDictionary emptyDictionary = new PhysicalTableDictionary()
 
+    @Override
+    def childSetupSpec() {
+        tableName = generateTableName()
+        intervals = generateIntervals()
+        segments = generateSegments()
+    }
+
     def setup() {
         jtb = new JerseyTestBinder(SlicesServlet.class)
         fullDictionary = jtb.configurationLoader.physicalTableDictionary

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImplSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImplSpec.groovy
@@ -24,34 +24,39 @@ import javax.ws.rs.core.UriInfo
 
 class SlicesApiRequestImplSpec extends BaseDataSourceMetadataSpec {
 
-    JerseyTestBinder jtb
-    UriInfo uriInfo = Mock(UriInfo)
-    UriBuilder builder = Mock(UriBuilder)
-    String baseUri = "http://localhost:9998/v1/slices/"
-    DataSourceMetadataService dataSourceMetadataService = new DataSourceMetadataService()
-
     @Shared
     PhysicalTableDictionary fullDictionary
-
     @Shared
-    PhysicalTableDictionary emptyDictionary = new PhysicalTableDictionary()
+    PhysicalTableDictionary emptyDictionary
+
+    JerseyTestBinder jtb
+    UriInfo uriInfo
+    UriBuilder builder
+    String baseUri
+    DataSourceMetadataService dataSourceMetadataService
 
     @Override
     def childSetupSpec() {
         tableName = generateTableName()
-        intervals = generateIntervals()
         segments = generateSegments()
+
+        emptyDictionary = new PhysicalTableDictionary()
     }
 
     def setup() {
+        uriInfo = Mock(UriInfo)
+        builder = Mock(UriBuilder)
+        baseUri = "http://localhost:9998/v1/slices/"
+        dataSourceMetadataService = new DataSourceMetadataService()
+
         jtb = new JerseyTestBinder(SlicesServlet.class)
         fullDictionary = jtb.configurationLoader.physicalTableDictionary
         uriInfo.getBaseUriBuilder() >> builder
         builder.path(_) >> builder
         builder.path(_, _) >> builder
 
-        DataSourceMetadata dataSourceMetadata = new DataSourceMetadata("all_pets", [:], segments)
-        dataSourceMetadataService.update(fullDictionary.get("all_pets").dataSourceNames[0], dataSourceMetadata)
+        DataSourceMetadata dataSourceMetadata = new DataSourceMetadata(tableName, [:], segments.values().toList())
+        dataSourceMetadataService.update(fullDictionary.get(tableName).dataSourceNames[0], dataSourceMetadata)
     }
 
     def cleanup() {


### PR DESCRIPTION
Address issue https://github.com/yahoo/fili/issues/392

The strategy is to have all metadata specs under `com.yahoo.bard.webservice.metadata` to extend `BaseDataSourceMetadataSpec`, which is a base specification of all metadata tests. All metadata Specs override `childSetupSpec()`, and call/override` generate*()` methods to initiate metadata related resources.

Take "intervals" as an example:

1. you don't need any of the resources(including "intervals") defined in base Spec, you do nothing
2. you need "intervals" in your test, you override `childSetupSpec()` and call its generation method in your Spec as follows

```java
@Override
def childSetupSpec() {
    intervals = generateIntervals()
}
```
3. you need "intervals" in your test, but you need a different set of intervals:

```java
@Override
def childSetupSpec() {
    intervals = generateIntervals()
}

@Override
Map<String, Interval> generateIntervals() {
    [
        "interval1": Interval.parse("2015-01-01T00:00:00.000Z/2015-01-02T00:00:00.000Z"),
        "interval2": Interval.parse("2015-01-02T00:00:00.000Z/2015-01-03T00:00:00.000Z"),
        "interval3": Interval.parse("2015-01-03T00:00:00.000Z/2015-01-04T00:00:00.000Z"),
        "interval123": Interval.parse("2015-01-01T00:00:00.000Z/2015-01-04T00:00:00.000Z")
    ]
}
```