### PR TITLE
Fix wikipedia-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Current
 
 
 ### Changed:
+
 - [Change id field in DefaultDimensionField to lower case for Navi compatibility.](https://github.com/yahoo/fili/pull/423)
     * Navi's default setting only recongizes lower case 'id' key name.
 
@@ -45,6 +46,9 @@ Current
 - [Fix availability testing utils to be compatible with composite tables](https://github.com/yahoo/fili/pull/419)
     * Fix availability testing utils `populatePhysicalTableCacheIntervals` to assign a `TestAvailability` that will serialize correctly instead of always `StrictAvailability`
     * Fix internal representation of `VolatileIntervalsFunction` in `DefaultingVolatileIntervalsService` from `Map<PhysicalTable, VolatileIntervalsFunction>` to `Map<String, VolatileIntervalsFunction>`
+
+- [Fix metric and dimension names for wikipedia-example](https://github.com/yahoo/fili/pull/415)
+    * The metrics and dimensions configured in the `fili-wikipedia-example` were different from those in Druid and as a result the queries sent to Druid were incorrect
 
 
 ### Known Issues:

--- a/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/names/WikiApiDimensionConfigInfo.java
+++ b/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/names/WikiApiDimensionConfigInfo.java
@@ -16,7 +16,7 @@ public enum WikiApiDimensionConfigInfo implements DimensionName {
     PAGE("Page is a document that is suitable for World Wide Web and web browsers", "wiki page"),
     USER("User is a person who generally use or own wiki services", "wiki user"),
     IS_UNPATROLLED("Unpatrolled are class of pages that are not been patrolled", "wiki isUnpatrolled"),
-    IS_NEW("New Page is the first page that is created in wiki ", "wiki newPage"),
+    IS_NEW("New Page is the first page that is created in wiki ", "wiki isNew"),
     IS_ROBOT("Robot is an tool that carries out repetitive and mundane tasks", "wiki isRobot"),
     IS_ANONYMOUS("Anonymous are individual or entity whose identity is unknown", "wiki isAnonymous"),
     IS_MINOR("Minor is a person who is legally considered a minor", "wiki isMinor"),
@@ -25,8 +25,7 @@ public enum WikiApiDimensionConfigInfo implements DimensionName {
     COUNTRY_NAME("Name of the Country to which the wiki page belongs", "wiki countryName"),
     REGION_NAME("Name of the Region to which the wiki page belongs", "wiki regionName"),
     METRO_CODE("Metro Code to which the wiki page belongs", "wiki metroCode"),
-    CITY_NAME("Name of the City to which the wiki page belongs", "wiki cityName")
-    ;
+    CITY_NAME("Name of the City to which the wiki page belongs", "wiki cityName");
 
     private final String camelName;
     private final String description;

--- a/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/names/WikiApiDimensionConfigInfo.java
+++ b/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/names/WikiApiDimensionConfigInfo.java
@@ -10,18 +10,22 @@ import com.yahoo.bard.webservice.util.EnumUtils;
  * Hold all the Wikipedia API dimension names.
  */
 public enum WikiApiDimensionConfigInfo implements DimensionName {
+    COMMENT("Comment for the edit to the wiki page", "wiki comment"),
+    COUNTRY_ISO_CODE("Iso Code of the country to which the wiki page belongs ", "wiki countryIsoCode"),
+    REGION_ISO_CODE("Iso Code of the region to which the wiki page belongs ", "wiki regionIsoCode"),
     PAGE("Page is a document that is suitable for World Wide Web and web browsers", "wiki page"),
-    LANGUAGE("Language used to write the wiki page", "wiki language"),
     USER("User is a person who generally use or own wiki services", "wiki user"),
-    UNPATROLLED("Unpatrolled are class of pages that are not been patrolled", "wiki unpatrolled"),
-    NEW_PAGE("New Page is the first page that is created in wiki ", "wiki newPage"),
-    ROBOT("Robot is an tool that carries out repetitive and mundane tasks", "wiki robot"),
-    ANONYMOUS("Anonymous are individual or entity whose identity is unknown", "wiki anonymous"),
+    IS_UNPATROLLED("Unpatrolled are class of pages that are not been patrolled", "wiki isUnpatrolled"),
+    IS_NEW("New Page is the first page that is created in wiki ", "wiki newPage"),
+    IS_ROBOT("Robot is an tool that carries out repetitive and mundane tasks", "wiki isRobot"),
+    IS_ANONYMOUS("Anonymous are individual or entity whose identity is unknown", "wiki isAnonymous"),
+    IS_MINOR("Minor is a person who is legally considered a minor", "wiki isMinor"),
     NAMESPACE("Namespace is a set of wiki pages that begins with a reserved word", "wiki namespace"),
-    CONTINENT("Name of the Continent to which the wiki page belongs ", "wiki continent"),
-    COUNTRY("Name of the Country to which the wiki page belongs", "wiki country"),
-    REGION("Name of the Region to which the wiki page belongs", "wiki region"),
-    CITY("Name of the City to which the wiki page belongs", "wiki city")
+    CHANNEL("Channel is a set of wiki pages on a certain channel", "wiki channel"),
+    COUNTRY_NAME("Name of the Country to which the wiki page belongs", "wiki countryName"),
+    REGION_NAME("Name of the Region to which the wiki page belongs", "wiki regionName"),
+    METRO_CODE("Metro Code to which the wiki page belongs", "wiki metroCode"),
+    CITY_NAME("Name of the City to which the wiki page belongs", "wiki cityName")
     ;
 
     private final String camelName;

--- a/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
+++ b/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
@@ -111,8 +111,8 @@ class SlicesServletSpec extends Specification {
         where:
         sliceName = WIKITICKER.asName().toLowerCase()
         granularity = "hour"
-        dimensionNames = ("page, language, user, unpatrolled, newPage, robot, anonymous, namespace, continent, " +
-                                  "country, region, city").split(',').collect { it.trim()}
+        dimensionNames = ("comment, countryIsoCode, regionIsoCode, page, user, isUnpatrolled, isNew, isRobot, isAnonymous," +
+                " isMinor, namespace, channel, countryName, regionName, metroCode, cityName").split(',').collect { it.trim()}
         metricNames = "count, added, delta, deleted".split(',').collect {it.trim()}
     }
 

--- a/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
+++ b/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
@@ -101,8 +101,8 @@ class TablesServletSpec extends Specification {
     @Unroll
     def "Querying for table #tableName at granularity #granularity returns that table's information"() {
         setup:
-        List<String> dimensionNames = ("page, language, user, unpatrolled, newPage, robot, anonymous, namespace, " +
-                "continent, country, region, city").split(',').collect { it.trim()}
+        List<String> dimensionNames = ("comment, countryIsoCode, regionIsoCode, page, user, isUnpatrolled, isNew, isRobot, isAnonymous," +
+                " isMinor, namespace, channel, countryName, regionName, metroCode, cityName").split(',').collect { it.trim()}
 
         List<String> metricNames = "count, added, delta, deleted".split(',').collect{ it.trim()}
         String expectedResponse = """{


### PR DESCRIPTION
Rename wikipedia data dimensions to match druid names
- The api names for accessing the druid dimensions are now all named correctly
to match the physical dimensions in Druid.
- Manually tested to make sure names are correct (can't make a test without integration testing)

Also fixed #346 