### PR TITLE
Use all available segment metadata for fili-generic-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Current
 
 ### Changed:
 
+- [Use all available segment metadata in fili-generic-example](https://github.com/yahoo/fili/pull/445)
+    * The fili-generic-example now uses all segment metadata given by Druid instead of just the first one and also provides it to the metadata service.
+
 - [Refactor Response class and implement new serialization logics](https://github.com/yahoo/fili/pull/455)
     * Define interface `ResponseWriter` and its default implementation
     * Refactor `Response` class, splitting into `ResponseData` and three implementations of `ResponseWriter`

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/application/GenericBinderFactory.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/application/GenericBinderFactory.java
@@ -34,7 +34,7 @@ public class GenericBinderFactory extends AbstractBinderFactory {
      */
     public GenericBinderFactory() {
         DruidWebService druidWebService = buildMetadataDruidWebService(getMappers().getMapper());
-        configLoader = new DruidNavigator(druidWebService);
+        configLoader = new DruidNavigator(druidWebService, getMapper());
         genericDimensionConfigs = new GenericDimensionConfigs(configLoader);
     }
 

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DataSourceConfiguration.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DataSourceConfiguration.java
@@ -35,14 +35,14 @@ public interface DataSourceConfiguration {
     /**
      * Gets the names of all the metrics for the current datasource.
      *
-     * @return a list of names of metrics for the current datasource.
+     * @return a set of names of metrics for the current datasource.
      */
     Set<String> getMetrics();
 
     /**
      * Gets the names of all the dimensions for the current datasource.
      *
-     * @return a list of names of dimensions for the current datasource.
+     * @return a set of names of dimensions for the current datasource.
      */
     Set<String> getDimensions();
 

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DataSourceConfiguration.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DataSourceConfiguration.java
@@ -5,7 +5,10 @@ package com.yahoo.wiki.webservice.data.config.auto;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.TimeGrain;
 
+import io.druid.timeline.DataSegment;
+
 import java.util.List;
+import java.util.Set;
 
 /**
  * Holds the minimum necessary configuration necessary to set up fili to
@@ -34,14 +37,14 @@ public interface DataSourceConfiguration {
      *
      * @return a list of names of metrics for the current datasource.
      */
-    List<String> getMetrics();
+    Set<String> getMetrics();
 
     /**
      * Gets the names of all the dimensions for the current datasource.
      *
      * @return a list of names of dimensions for the current datasource.
      */
-    List<String> getDimensions();
+    Set<String> getDimensions();
 
     /**
      * Gets the {@link TimeGrain} which is valid for use in queries.
@@ -51,4 +54,11 @@ public interface DataSourceConfiguration {
      * @return a {@link TimeGrain} for the current table.
      */
     TimeGrain getValidTimeGrain();
+
+    /**
+     * Gets a list of segment metadata for a datasource in Druid.
+     *
+     * @return the list of datasegments reported by druid.
+     */
+    List<DataSegment> getDataSegmentMetadata();
 }

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/TableConfig.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/TableConfig.java
@@ -5,17 +5,22 @@ package com.yahoo.wiki.webservice.data.config.auto;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.TimeGrain;
 
+import io.druid.timeline.DataSegment;
+
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * TableConfig to hold all metrics, dimensions, timegrains, and the name of a datasource.
  */
 public class TableConfig implements DataSourceConfiguration {
     private final String tableName;
-    private final List<String> metrics;
-    private final List<String> dimensions;
+    private final Set<String> metrics;
+    private final Set<String> dimensions;
+    private final List<DataSegment> dataSegments;
     private TimeGrain timeGrain;
 
     /**
@@ -25,8 +30,9 @@ public class TableConfig implements DataSourceConfiguration {
      */
     public TableConfig(String name) {
         tableName = name;
-        metrics = new ArrayList<>();
-        dimensions = new ArrayList<>();
+        metrics = new HashSet<>();
+        dimensions = new HashSet<>();
+        dataSegments = new ArrayList<>();
     }
 
     /**
@@ -57,6 +63,15 @@ public class TableConfig implements DataSourceConfiguration {
     }
 
     /**
+     * Add a {@link DataSegment} to the existing known datasegments for this table.
+     *
+     * @param dataSegment  The {@link DataSegment} metadata given by Druid.
+     */
+    public void addDataSegment(DataSegment dataSegment) {
+        dataSegments.add(dataSegment);
+    }
+
+    /**
      * Gets the name of the table.
      *
      * @return the name of the table.
@@ -82,8 +97,8 @@ public class TableConfig implements DataSourceConfiguration {
      * @return the names of metrics stored in TableConfig.
      */
     @Override
-    public List<String> getMetrics() {
-        return Collections.unmodifiableList(metrics);
+    public Set<String> getMetrics() {
+        return Collections.unmodifiableSet(metrics);
     }
 
     /**
@@ -92,8 +107,8 @@ public class TableConfig implements DataSourceConfiguration {
      * @return the names of the dimensions stored in the TableConfig.
      */
     @Override
-    public List<String> getDimensions() {
-        return Collections.unmodifiableList(dimensions);
+    public Set<String> getDimensions() {
+        return Collections.unmodifiableSet(dimensions);
     }
 
     /**
@@ -104,5 +119,10 @@ public class TableConfig implements DataSourceConfiguration {
     @Override
     public TimeGrain getValidTimeGrain() {
         return timeGrain;
+    }
+
+    @Override
+    public List<DataSegment> getDataSegmentMetadata() {
+        return dataSegments;
     }
 }

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/GenericTableLoader.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/GenericTableLoader.java
@@ -83,7 +83,7 @@ public class GenericTableLoader extends BaseTableLoader {
                     new DataSourceMetadata(
                             dataSourceConfiguration.getName(),
                             Collections.emptyMap(),
-                            Collections.emptyList()
+                            dataSourceConfiguration.getDataSegmentMetadata()
                     )
             );
 

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/AutomaticDruidConfigLoaderSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/AutomaticDruidConfigLoaderSpec.groovy
@@ -5,6 +5,9 @@ import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
 import com.yahoo.wiki.webservice.data.config.auto.DataSourceConfiguration
 import com.yahoo.wiki.webservice.data.config.auto.DruidNavigator
 import com.yahoo.wiki.webservice.data.config.auto.TableConfig
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
 import spock.lang.Specification
 
 public class AutomaticDruidConfigLoaderSpec extends Specification {
@@ -45,7 +48,7 @@ public class AutomaticDruidConfigLoaderSpec extends Specification {
 
     def setup() {
         druidWebService = new TestDruidWebService("testInstance")
-        druidNavigator = new DruidNavigator(druidWebService)
+        druidNavigator = new DruidNavigator(druidWebService, new ObjectMapper())
         druidWebService.jsonResponse = {
             if (druidWebService.lastUrl == "/datasources/") {
                 return expectedDataSources
@@ -87,14 +90,10 @@ public class AutomaticDruidConfigLoaderSpec extends Specification {
 
         then: "what we expect"
         druidWebService.lastUrl == '/datasources/' + datasource + '/?full'
-        List<String> returnedMetrics = wikiticker.getMetrics()
-        for (String m : metrics) {
-            assert returnedMetrics.contains(m)
-        }
+        Set<String> returnedMetrics = wikiticker.getMetrics()
+        returnedMetrics.equals(metrics as Set)
 
-        List<String> returnedDimensions = wikiticker.getDimensions()
-        for (String d : dimensions) {
-            assert returnedDimensions.contains(d)
-        }
+        Set<String> returnedDimensions = wikiticker.getDimensions()
+        returnedDimensions.equals(dimensions as Set)
     }
 }

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/MultipleDatasourceDruidConfigLoaderSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/MultipleDatasourceDruidConfigLoaderSpec.groovy
@@ -34,7 +34,7 @@ class MultipleDatasourceDruidConfigLoaderSpec extends Specification {
 
     def "Load Multiple datasources"() {
         when: "We query druid"
-        DruidNavigator druidNavigator = new DruidNavigator(druidWebService)
+        DruidNavigator druidNavigator = new DruidNavigator(druidWebService, new ObjectMapper())
 
         then: "What we expect"
         List<DataSourceConfiguration> tables = druidNavigator.get();

--- a/fili-generic-example/src/test/java/com/yahoo/wiki/webservice/data/config/auto/StaticWikiConfigLoader.java
+++ b/fili-generic-example/src/test/java/com/yahoo/wiki/webservice/data/config/auto/StaticWikiConfigLoader.java
@@ -5,10 +5,14 @@ package com.yahoo.wiki.webservice.data.config.auto;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain;
 import com.yahoo.bard.webservice.data.time.TimeGrain;
+import com.yahoo.bard.webservice.util.Utils;
+
+import io.druid.timeline.DataSegment;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -29,8 +33,8 @@ public class StaticWikiConfigLoader implements Supplier<List<? extends DataSourc
             }
 
             @Override
-            public List<String> getMetrics() {
-                return Arrays.asList(
+            public Set<String> getMetrics() {
+                return Utils.asLinkedHashSet(
                         "count",
                         "added",
                         "deleted",
@@ -40,8 +44,13 @@ public class StaticWikiConfigLoader implements Supplier<List<? extends DataSourc
             }
 
             @Override
-            public List<String> getDimensions() {
-                return Arrays.asList(
+            public List<DataSegment> getDataSegmentMetadata() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public Set<String> getDimensions() {
+                return Utils.asLinkedHashSet(
                         "channel",
                         "cityName",
                         "comment",


### PR DESCRIPTION
- The `fili-generic-example` was previously only using the first segment in the response from Druid but it may as well use all of them
- This also provides these segments to the MetadataService

Addresses #428 