### PR TITLE
Custom Response creation part1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ Current
 
 ### Changed:
 
+- [Make HttpResponseMaker injectable and change functions signature related to custom response creation](https://github.com/yahoo/fili/pull/447)
+    * Make `HttpResponseMaker` injectable. `DataServlet` and `JobsServlet` takes `HttpResponseMaker` as input parameter now
+    * Add `ApiRequest` to `BuildResponse`, `HttpReponseChannel` and `createResponseBuilder` to enable passing information needed by customizable serialization
+    * Remove duplicate parameter such as `UriInfo` that can be derived from `ApiRequest`
+
 - [Change id field in DefaultDimensionField to lower case for Navi compatibility.](https://github.com/yahoo/fili/pull/423)
     * Navi's default setting only recongizes lower case 'id' key name.
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -35,6 +35,7 @@ import com.yahoo.bard.webservice.config.SystemConfig;
 import com.yahoo.bard.webservice.config.SystemConfigProvider;
 import com.yahoo.bard.webservice.data.DruidQueryBuilder;
 import com.yahoo.bard.webservice.data.DruidResponseParser;
+import com.yahoo.bard.webservice.data.HttpResponseMaker;
 import com.yahoo.bard.webservice.data.PartialDataHandler;
 import com.yahoo.bard.webservice.data.PreResponseDeserializer;
 import com.yahoo.bard.webservice.data.cache.DataCache;
@@ -301,6 +302,8 @@ public abstract class AbstractBinderFactory implements BinderFactory {
                 bind(getAsynchronousProcessBuilder()).to(AsynchronousWorkflowsBuilder.class);
 
                 bind(getClock()).to(Clock.class);
+
+                bind(getHttpResponseMaker()).to(HttpResponseMaker.class);
 
                 if (DRUID_DIMENSIONS_LOADER.isOn()) {
                     DruidDimensionsLoader druidDimensionsLoader = buildDruidDimensionsLoader(
@@ -904,6 +907,15 @@ public abstract class AbstractBinderFactory implements BinderFactory {
      */
     protected JobPayloadBuilder buildJobPayloadBuilder() {
         return new DefaultJobPayloadBuilder();
+    }
+
+    /**
+     * Initializes the factory that builds HttpResponseMaker.
+     *
+     * @return an instance of the {@link HttpResponseMaker}
+     */
+    protected Class<? extends HttpResponseMaker> getHttpResponseMaker() {
+        return HttpResponseMaker.class;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseChannel.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseChannel.java
@@ -6,9 +6,8 @@ import static com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow.RESP
 
 import com.yahoo.bard.webservice.async.ResponseException;
 import com.yahoo.bard.webservice.logging.RequestLog;
-import com.yahoo.bard.webservice.web.DataApiRequest;
+import com.yahoo.bard.webservice.web.ApiRequest;
 import com.yahoo.bard.webservice.web.PreResponse;
-import com.yahoo.bard.webservice.web.ResponseFormatType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +16,6 @@ import rx.Observer;
 
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * Converts preResponse/errorResponse into HTTP Responses, and ships them immediately to the client.
@@ -28,28 +26,7 @@ public class HttpResponseChannel implements Observer<PreResponse> {
 
     private final AsyncResponse asyncResponse;
     private final HttpResponseMaker httpResponseMaker;
-    private final ResponseFormatType responseFormatType;
-    private final UriInfo uriInfo;
-
-    /**
-     * Constructor.
-     *
-     * @param asyncResponse  An async response that we can use to respond asynchronously
-     * @param httpResponseMaker  Helper class instance to prepare the response object
-     * @param responseFormatType  The format of the response returned to the user
-     * @param uriInfo  UriInfo of the request
-     */
-    public HttpResponseChannel(
-            AsyncResponse asyncResponse,
-            HttpResponseMaker httpResponseMaker,
-            ResponseFormatType responseFormatType,
-            UriInfo uriInfo
-    ) {
-        this.asyncResponse = asyncResponse;
-        this.httpResponseMaker = httpResponseMaker;
-        this.responseFormatType = responseFormatType;
-        this.uriInfo = uriInfo;
-    }
+    private final ApiRequest apiRequest;
 
     /**
      * Constructor.
@@ -58,16 +35,15 @@ public class HttpResponseChannel implements Observer<PreResponse> {
      * @param apiRequest  Api request object with all the associated info with it
      * @param httpResponseMaker  Helper class instance to prepare the response object
      *
-     * @deprecated  The ResponseFormatType and UriInfo should be passed explicitly, rather than implicitly via the
-     * DataApiRequest.
      */
-    @Deprecated
     public HttpResponseChannel(
             AsyncResponse asyncResponse,
-            DataApiRequest apiRequest,
+            ApiRequest apiRequest,
             HttpResponseMaker httpResponseMaker
     ) {
-        this(asyncResponse, httpResponseMaker, apiRequest.getFormat(), apiRequest.getUriInfo());
+        this.asyncResponse = asyncResponse;
+        this.httpResponseMaker = httpResponseMaker;
+        this.apiRequest = apiRequest;
     }
 
     @Override
@@ -104,7 +80,7 @@ public class HttpResponseChannel implements Observer<PreResponse> {
 
     @Override
     public void onNext(PreResponse preResponse) {
-        publishResponse(httpResponseMaker.buildResponse(preResponse, responseFormatType, uriInfo));
+        publishResponse(httpResponseMaker.buildResponse(preResponse, apiRequest));
     }
 
     /**

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/HttpResponseMakerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/HttpResponseMakerSpec.groovy
@@ -106,7 +106,7 @@ class HttpResponseMakerSpec extends Specification {
         PreResponse preResponse = new PreResponse(resultSet, responseContext)
 
         when:
-        Response actual = httpResponseMaker.buildResponse(preResponse, apiRequest.format, apiRequest.uriInfo)
+        Response actual = httpResponseMaker.buildResponse(preResponse, apiRequest)
 
         then:
         actual.getStatus() == 200
@@ -121,7 +121,7 @@ class HttpResponseMakerSpec extends Specification {
         PreResponse preResponse = new PreResponse(resultSet, responseContext)
 
         when: "The Response is built"
-        Response actual = httpResponseMaker.buildResponse(preResponse, apiRequest.format, apiRequest.uriInfo)
+        Response actual = httpResponseMaker.buildResponse(preResponse, apiRequest)
 
         then: "The header is set correctly"
         actual.getHeaderString(HttpHeaders.CONTENT_TYPE) == "text/csv; charset=utf-8"
@@ -135,7 +135,7 @@ class HttpResponseMakerSpec extends Specification {
 
         when:
         Response.ResponseBuilder responseBuilder
-        responseBuilder = httpResponseMaker.createResponseBuilder(resultSet, responseContext, apiRequest.format, apiRequest.uriInfo)
+        responseBuilder = httpResponseMaker.createResponseBuilder(resultSet, responseContext, apiRequest)
 
         then:
         responseBuilder != null

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/JobsServletReactiveChainforResultsEndpointSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/JobsServletReactiveChainforResultsEndpointSpec.groovy
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.web.endpoints
 
 import com.yahoo.bard.webservice.application.ObjectMappersSuite
+import com.yahoo.bard.webservice.data.HttpResponseMaker
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.async.jobs.stores.ApiJobStore
 import com.yahoo.bard.webservice.async.broadcastchannels.BroadcastChannel
@@ -25,7 +26,6 @@ import spock.lang.Specification
 import spock.lang.Timeout
 
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 import javax.ws.rs.core.UriInfo
 
@@ -45,6 +45,7 @@ class JobsServletReactiveChainforResultsEndpointSpec extends Specification {
     RequestMapper requestMapper
     PreResponseStore mockPreResponseStore
     JobsServlet mockJobServlet
+    HttpResponseMaker httpResponseMaker
 
     def setup() {
         objectMappersSuite = Mock(ObjectMappersSuite)
@@ -61,6 +62,7 @@ class JobsServletReactiveChainforResultsEndpointSpec extends Specification {
 
         preResponseStore = new HashPreResponseStore()
         broadcastChannel = new SimpleBroadcastChannel<>(PublishSubject.create())
+        httpResponseMaker = new HttpResponseMaker(objectMappersSuite, dimensionDictionary)
 
         jobsServlet = new JobsServlet(
                 objectMappersSuite,
@@ -68,8 +70,8 @@ class JobsServletReactiveChainforResultsEndpointSpec extends Specification {
                 jobPayloadBuilder,
                 preResponseStore,
                 broadcastChannel,
-                dimensionDictionary,
-                requestMapper
+                requestMapper,
+                httpResponseMaker
         )
 
         //Mocked objects for interaction testing
@@ -81,8 +83,8 @@ class JobsServletReactiveChainforResultsEndpointSpec extends Specification {
                 jobPayloadBuilder,
                 mockPreResponseStore,
                 broadcastChannel,
-                dimensionDictionary,
-                requestMapper
+                requestMapper,
+                httpResponseMaker
         )
     }
 


### PR DESCRIPTION
This PR implements step 6,7 in [RFC for custom response creation](https://github.com/yahoo/fili/pull/442)

- Make `httpResponseMaker` injectable.
- Change signature of `httpResponseChannel` constructor to take `ApiRequest`. 