### PR TITLE
Tell maven to use more memory during builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-
+dist: trusty
 language: java
 
 jdk:

--- a/travis/deploy.bash
+++ b/travis/deploy.bash
@@ -2,6 +2,8 @@
 PUBLISH_WHITELIST="master"
 RELEASE_TAG_REGEX="^[0-9]+\\.[0-9]+\\.[0-9]+"
 
+export MAVEN_OPTS="-Xmx3000m"
+
 # Deploy if this has a travis tag and is on an approved branch
 MATCHING_TAG=$(echo $TRAVIS_TAG | egrep ${RELEASE_TAG_REGEX})
 if [[ ${MATCHING_TAG} != "" ]]; then


### PR DESCRIPTION
Maven builds running on trusty were failing because they killed maven. 
Adding more memory seems to solve this so I've also explicitly specified builds should be done on trusty.