### PR TITLE
duplicate dependency declaration is removed in order to eliminate maven build warnings

### DIFF
--- a/fili-security/pom.xml
+++ b/fili-security/pom.xml
@@ -42,9 +42,5 @@
             <artifactId>fili-core</artifactId>
             <type>test-jar</type>
         </dependency>
-        <dependency>
-            <groupId>com.yahoo.fili</groupId>
-            <artifactId>fili-core</artifactId>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
_**Related ticket**_: #456

_**Status:**_ `Reviewable`
