### PR TITLE
Use dynamic ports in JerseyTestBinder for tests

### DIFF
--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncDruidSendsErrorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncDruidSendsErrorSpec.groovy
@@ -6,8 +6,6 @@ import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobStatus.PEND
 import com.yahoo.bard.webservice.async.workflows.TestAsynchronousWorkflowsBuilder
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
-import rx.Observer
-
 import java.util.concurrent.CountDownLatch
 
 /**
@@ -66,8 +64,10 @@ class AsyncDruidSendsErrorSpec extends AsyncFunctionalSpec {
                 }
     */
 
-    static final String QUERY =
-            "http://localhost:9998/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=always"
+
+    String getQuery() {
+        return "http://localhost:${jtb.getHarness().getPort()}/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=always"
+    }
 
     static final String ERROR_MESSAGE = """{
                         "status" : 500,
@@ -113,7 +113,7 @@ class AsyncDruidSendsErrorSpec extends AsyncFunctionalSpec {
         [
                 data: {
                     assert it.status == 202
-                    AsyncTestUtils.validateJobPayload(it.readEntity(String), QUERY, PENDING.name)
+                    AsyncTestUtils.validateJobPayload(jtb, it.readEntity(String), getQuery(), PENDING.name)
                 },
                 syncResults: {
                     // However, there was a problem in the backend, and the job failed. So when we go to get the
@@ -130,7 +130,7 @@ class AsyncDruidSendsErrorSpec extends AsyncFunctionalSpec {
                 },
                 jobs: { response ->
                     assert response.status == 200
-                    AsyncTestUtils.validateJobPayload(response.readEntity(String), QUERY, FAILURE.name)
+                    AsyncTestUtils.validateJobPayload(jtb, response.readEntity(String), getQuery(), FAILURE.name)
                 }
         ]
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncResultsNotReadySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncResultsNotReadySpec.groovy
@@ -6,7 +6,6 @@ import com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobStatus
 import spock.lang.Timeout
 
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 import javax.ws.rs.core.Response
 
@@ -43,8 +42,9 @@ class AsyncResultsNotReadySpec extends AsyncFunctionalSpec {
 
     final CountDownLatch validationFinished = new CountDownLatch(3)
 
-    static final String QUERY =
-            "http://localhost:9998/data/shapes/day/color?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=always"
+    String getQuery() {
+        return "http://localhost:${jtb.getHarness().getPort()}/data/shapes/day/color?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=always"
+    }
 
     @Override
     Map<String, Closure<String>> getResultsToTargetFunctions() {
@@ -65,8 +65,9 @@ class AsyncResultsNotReadySpec extends AsyncFunctionalSpec {
                     try {
                         assert response.status == 202
                         AsyncTestUtils.validateJobPayload(
+                                jtb,
                                 response.readEntity(String),
-                                QUERY,
+                                getQuery(),
                                 DefaultJobStatus.PENDING.name
                         )
                     } finally {
@@ -78,8 +79,9 @@ class AsyncResultsNotReadySpec extends AsyncFunctionalSpec {
                         assert response.status == 200
                         //The jobs endpoint returns job metadata containing the same expected value as the data endpoint
                         AsyncTestUtils.validateJobPayload(
+                                jtb,
                                 response.readEntity(String),
-                                QUERY,
+                                getQuery(),
                                 DefaultJobStatus.PENDING.name
                         )
                     } finally {
@@ -92,8 +94,9 @@ class AsyncResultsNotReadySpec extends AsyncFunctionalSpec {
                         //The results endpoint returns job metadata containing the same expected value as the data
                         // endpoint
                         AsyncTestUtils.validateJobPayload(
+                                jtb,
                                 response.readEntity(String),
-                                QUERY,
+                                getQuery(),
                                 DefaultJobStatus.PENDING.name
                         )
                     } finally {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncResultsReadySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncResultsReadySpec.groovy
@@ -4,8 +4,6 @@ import com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobStatus
 import com.yahoo.bard.webservice.async.workflows.TestAsynchronousWorkflowsBuilder
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
-import rx.Observer
-
 import java.util.concurrent.CountDownLatch
 
 /**
@@ -65,8 +63,9 @@ class AsyncResultsReadySpec extends AsyncFunctionalSpec {
                 }
     */
 
-    static final String QUERY =
-            "http://localhost:9998/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=always"
+    String getQuery() {
+        return "http://localhost:${jtb.getHarness().getPort()}/data/shapes/day?dateTime=2016-08-30%2F2016-08-31&metrics=height&asyncAfter=always"
+    }
 
     final CountDownLatch jobMetadataReady = new CountDownLatch(1)
 
@@ -105,7 +104,7 @@ class AsyncResultsReadySpec extends AsyncFunctionalSpec {
         [
                 data: {
                     assert it.status == 202
-                    AsyncTestUtils.validateJobPayload(it.readEntity(String), QUERY, DefaultJobStatus.PENDING.name)
+                    AsyncTestUtils.validateJobPayload(jtb, it.readEntity(String), getQuery(), DefaultJobStatus.PENDING.name)
                 },
                 syncResults: {
                     assert it.status == 200
@@ -118,8 +117,9 @@ class AsyncResultsReadySpec extends AsyncFunctionalSpec {
                 jobs: { response ->
                         assert response.status == 200
                         AsyncTestUtils.validateJobPayload(
+                                jtb,
                                 response.readEntity(String),
-                                QUERY,
+                                getQuery(),
                                 DefaultJobStatus.SUCCESS.name
                         )
                 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncTestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncTestUtils.groovy
@@ -7,13 +7,11 @@ import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.QUERY
 import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.STATUS
 import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.USER_ID
 
-import com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField
+import com.yahoo.bard.webservice.application.JerseyTestBinder
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 import com.yahoo.bard.webservice.util.JsonSlurper
 
 import org.joda.time.DateTime
-
-import javax.ws.rs.core.UriBuilder
 
 /**
  * Contains a collection of functions to aid in testing asynchronous
@@ -57,7 +55,7 @@ class AsyncTestUtils {
     * @param query  The query that triggered the job
     * @param status  The job's expected status
     */
-   static void validateJobPayload(String asynchronousPayload, String query, String status) {
+   static void validateJobPayload(JerseyTestBinder jtb, String asynchronousPayload, String query, String status) {
       Map payloadJson = JSON_PARSER.parseText(asynchronousPayload)
       //The test payload builder always sets the user id to greg in TestBinderFactory::buildJobRowBuilder.
       assert payloadJson[USER_ID.name] == "greg"
@@ -66,11 +64,11 @@ class AsyncTestUtils {
       assert GroovyTestUtils.compareURL(payloadJson[QUERY.name] as String, query)
       assert GroovyTestUtils.compareURL(
               payloadJson["results"],
-              "http://localhost:9998/jobs/${payloadJson[JOB_TICKET.name]}/results"
+              "http://localhost:${jtb.getHarness().getPort()}/jobs/${payloadJson[JOB_TICKET.name]}/results"
       )
       assert GroovyTestUtils.compareURL(
               payloadJson["syncResults"],
-              "http://localhost:9998/jobs/${payloadJson[JOB_TICKET.name]}/results&asyncAfter=never"
+              "http://localhost:${jtb.getHarness().getPort()}/jobs/${payloadJson[JOB_TICKET.name]}/results&asyncAfter=never"
       );
       //Validate that the dates are valid dates
       DateTime.parse(payloadJson[DATE_CREATED.name])

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DataPaginationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DataPaginationSpec.groovy
@@ -324,7 +324,7 @@ class DataPaginationSpec extends BaseDataServletComponentSpec {
      * @return A String representation of a link to the desired page
      */
     String buildPageLink(int perPage, int page){
-        "http://localhost:9998/$target?metrics=height&dateTime=2014-09-01%2F2014-09-13&perPage=$perPage&page=$page"
+        "http://localhost:${jtb.getHarness().getPort()}/$target?metrics=height&dateTime=2014-09-01%2F2014-09-13&perPage=$perPage&page=$page"
     }
 
     /**

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DimensionsServletComponentSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DimensionsServletComponentSpec.groovy
@@ -80,14 +80,14 @@ class DimensionsServletComponentSpec extends Specification {
         String expectedResponse = """{
                                         "dimensions":
                                         [
-                                            {"category": "General", "name": "color", "longName": "color", "uri": "http://localhost:9998/dimensions/color", "cardinality": 0},
-                                            {"category": "General", "name": "shape", "longName": "shape", "uri": "http://localhost:9998/dimensions/shape", "cardinality": 38},
-                                            {"category": "General", "name": "size", "longName": "size", "uri": "http://localhost:9998/dimensions/size", "cardinality": 0},
-                                            {"category": "General", "name": "model", "longName": "model", "uri": "http://localhost:9998/dimensions/model", "cardinality": 21},
-                                            {"category": "General", "name": "other", "longName": "other", "uri": "http://localhost:9998/dimensions/other", "cardinality": 100000},
-                                            {"category": "General", "name": "sex", "longName": "sex", "uri": "http://localhost:9998/dimensions/sex", "cardinality": 0},
-                                            {"category": "General", "name": "species", "longName": "species", "uri": "http://localhost:9998/dimensions/species", "cardinality": 0},
-                                            {"category": "General", "name": "breed", "longName": "breed", "uri": "http://localhost:9998/dimensions/breed", "cardinality": 0}
+                                            {"category": "General", "name": "color", "longName": "color", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color", "cardinality": 0},
+                                            {"category": "General", "name": "shape", "longName": "shape", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape", "cardinality": 38},
+                                            {"category": "General", "name": "size", "longName": "size", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size", "cardinality": 0},
+                                            {"category": "General", "name": "model", "longName": "model", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model", "cardinality": 21},
+                                            {"category": "General", "name": "other", "longName": "other", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other", "cardinality": 100000},
+                                            {"category": "General", "name": "sex", "longName": "sex", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/sex", "cardinality": 0},
+                                            {"category": "General", "name": "species", "longName": "species", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/species", "cardinality": 0},
+                                            {"category": "General", "name": "breed", "longName": "breed", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/breed", "cardinality": 0}
                                         ]
                                     }"""
 
@@ -121,112 +121,112 @@ class DimensionsServletComponentSpec extends Specification {
                                                 "longName": "shapes",
                                                 "name": "shapes",
                                                 "granularity": "day",
-                                                "uri": "http://localhost:9998/tables/shapes/day"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/day"
                                             }, {
                                                 "category": "General",
                                                 "longName": "shapes",
                                                 "name": "shapes",
                                                 "granularity": "all",
-                                                "uri": "http://localhost:9998/tables/shapes/all"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/all"
                                             }, {
                                                 "category": "General",
                                                 "longName": "shapes",
                                                 "name": "shapes",
                                                 "granularity": "week",
-                                                "uri": "http://localhost:9998/tables/shapes/week"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/week"
                                             }, {
                                                 "category": "General",
                                                 "longName": "shapes",
                                                 "name": "shapes",
                                                 "granularity": "month",
-                                                "uri": "http://localhost:9998/tables/shapes/month"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/month"
                                             }, {
                                                 "category": "General",
                                                 "longName": "monthly",
                                                 "name": "monthly",
                                                 "granularity": "day",
-                                                "uri": "http://localhost:9998/tables/monthly/day"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/monthly/day"
                                             }, {
                                                 "category": "General",
                                                 "longName": "monthly",
                                                 "name": "monthly",
                                                 "granularity": "all",
-                                                "uri": "http://localhost:9998/tables/monthly/all"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/monthly/all"
                                             }, {
                                                 "category": "General",
                                                 "longName": "monthly",
                                                 "name": "monthly",
                                                 "granularity": "week",
-                                                "uri": "http://localhost:9998/tables/monthly/week"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/monthly/week"
                                             }, {
                                                 "category": "General",
                                                 "longName": "monthly",
                                                 "name": "monthly",
                                                 "granularity": "month",
-                                                "uri": "http://localhost:9998/tables/monthly/month"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/monthly/month"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly",
                                                 "name": "hourly",
                                                 "granularity": "hour",
-                                                "uri": "http://localhost:9998/tables/hourly/hour"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/hour"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly",
                                                 "name": "hourly",
                                                 "granularity": "all",
-                                                "uri": "http://localhost:9998/tables/hourly/all"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/all"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly",
                                                 "name": "hourly",
                                                 "granularity": "day",
-                                                "uri": "http://localhost:9998/tables/hourly/day"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/day"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly",
                                                 "name": "hourly",
                                                 "granularity": "week",
-                                                "uri": "http://localhost:9998/tables/hourly/week"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/week"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly",
                                                 "name": "hourly",
                                                 "granularity": "month",
-                                                "uri": "http://localhost:9998/tables/hourly/month"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/month"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly_monthly",
                                                 "name": "hourly_monthly",
                                                 "granularity": "hour",
-                                                "uri": "http://localhost:9998/tables/hourly_monthly/hour"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/hour"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly_monthly",
                                                 "name": "hourly_monthly",
                                                 "granularity": "all",
-                                                "uri": "http://localhost:9998/tables/hourly_monthly/all"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/all"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly_monthly",
                                                 "name": "hourly_monthly",
                                                 "granularity": "day",
-                                                "uri": "http://localhost:9998/tables/hourly_monthly/day"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/day"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly_monthly",
                                                 "name": "hourly_monthly",
                                                 "granularity": "week",
-                                                "uri": "http://localhost:9998/tables/hourly_monthly/week"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/week"
                                             }, {
                                                 "category": "General",
                                                 "longName": "hourly_monthly",
                                                 "name": "hourly_monthly",
                                                 "granularity": "month",
-                                                "uri": "http://localhost:9998/tables/hourly_monthly/month"
+                                                "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/month"
                                             }
                                         ],
-                                        "values": "http://localhost:9998/dimensions/other/values"
+                                        "values": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other/values"
                                     }"""
         when: "We send a request"
         String result = makeRequest("/dimensions/other", null).get(String.class)
@@ -258,8 +258,8 @@ class DimensionsServletComponentSpec extends Specification {
                                                 "numberOfResults": 38,
                                                 "rowsPerPage": 3,
                                                 "paginationLinks": {
-                                                    "next": "http://localhost:9998/dimensions/shape/values?perPage=3&page=2",
-                                                    "last": "http://localhost:9998/dimensions/shape/values?perPage=3&page=13"
+                                                    "next": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape/values?perPage=3&page=2",
+                                                    "last": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape/values?perPage=3&page=13"
                                                 }
                                             }
                                          }
@@ -311,8 +311,8 @@ class DimensionsServletComponentSpec extends Specification {
                                      """.replaceAll("\\r?\\n?\\s","")
 
         Map<String, String> expectedLinks = [
-                ('"last"'): """<http://localhost:9998/dimensions/shape/values?perPage=3&format=CSV&page=13>""",
-                ('"next"'): """<http://localhost:9998/dimensions/shape/values?perPage=3&format=CSV&page=2>"""
+                ('"last"'): """<http://localhost:${jtb.getHarness().getPort()}/dimensions/shape/values?perPage=3&format=CSV&page=13>""",
+                ('"next"'): """<http://localhost:${jtb.getHarness().getPort()}/dimensions/shape/values?perPage=3&format=CSV&page=2>"""
         ]
 
         when: "We send a request"

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTableColumnsEndpointSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTableColumnsEndpointSpec.groovy
@@ -37,31 +37,31 @@ class ExpectedTableColumnsEndpointSpec extends BaseTableServletComponentSpec {
                   "category": "General",
                   "name": "color",
                   "longName": "color",
-                  "uri": "http://localhost:9998/dimensions/color"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color"
                 }, {
                   "cardinality": "0",
                   "category": "General",
                   "name": "shape",
                   "longName": "shape",
-                  "uri": "http://localhost:9998/dimensions/shape"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape"
                 }, {
                   "cardinality": "0",
                   "category": "General",
                   "name": "size",
                   "longName": "size",
-                  "uri": "http://localhost:9998/dimensions/size"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size"
                 }, {
                   "cardinality": "38",
                   "category": "General",
                   "name": "model",
                   "longName": "model",
-                  "uri": "http://localhost:9998/dimensions/model"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model"
                 }, {
                   "cardinality": "100000",
                   "category": "General",
                   "name": "other",
                   "longName": "other",
-                  "uri": "http://localhost:9998/dimensions/other"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                 }
               ],
               "metrics": [
@@ -69,42 +69,42 @@ class ExpectedTableColumnsEndpointSpec extends BaseTableServletComponentSpec {
                   "category": "General",
                   "name":"rowNum",
                   "longName": "rowNum",
-                  "uri": "http://localhost:9998/metrics/rowNum"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/rowNum"
                 }, {
                   "category": "General",
                   "name": "height",
                   "longName": "height",
-                  "uri": "http://localhost:9998/metrics/height"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/height"
                 }, {
                   "category": "General",
                   "name": "width",
                   "longName": "width",
-                  "uri": "http://localhost:9998/metrics/width"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/width"
                 }, {
                   "category": "General",
                   "name": "depth",
                   "longName": "depth",
-                  "uri": "http://localhost:9998/metrics/depth"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/depth"
                 }, {
                   "category": "General",
                   "name": "area",
                   "longName": "area",
-                  "uri": "http://localhost:9998/metrics/area"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/area"
                 }, {
                   "category": "General",
                   "name": "volume",
                   "longName": "volume",
-                  "uri": "http://localhost:9998/metrics/volume"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/volume"
                 }, {
                   "category": "General",
                   "name": "otherUsers",
                   "longName": "otherUsers",
-                  "uri": "http://localhost:9998/metrics/otherUsers"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/otherUsers"
                 }, {
                   "category": "General",
                   "name": "users",
                   "longName": "users",
-                  "uri": "http://localhost:9998/metrics/users"
+                  "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/users"
                 }
               ]
             }"""

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTableEndpointSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTableEndpointSpec.groovy
@@ -29,25 +29,25 @@ class ExpectedTableEndpointSpec extends BaseTableServletComponentSpec {
                           "name": "shapes",
                           "longName": "shapes",
                           "granularity": "all",
-                          "uri": "http://localhost:9998/tables/shapes/all"
+                          "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/all"
                     },{
                           "category": "General",
                           "longName": "shapes",
                           "name": "shapes",
                           "granularity": "day",
-                          "uri": "http://localhost:9998/tables/shapes/day"
+                          "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/day"
                     },{
                           "category": "General",
                           "name": "shapes",
                           "longName": "shapes",
                           "granularity": "week",
-                          "uri": "http://localhost:9998/tables/shapes/week"
+                          "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/week"
                     },{
                           "category": "General",
                           "name": "shapes",
                           "longName": "shapes",
                           "granularity": "month",
-                          "uri": "http://localhost:9998/tables/shapes/month"
+                          "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/month"
                     }
                  ]
            }"""

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTablesEndpointSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTablesEndpointSpec.groovy
@@ -29,133 +29,133 @@ class ExpectedTablesEndpointSpec extends BaseTableServletComponentSpec {
                     "longName": "hourly",
                     "name": "hourly",
                     "granularity": "all",
-                    "uri": "http://localhost:9998/tables/hourly/all"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/all"
                 }, {
                     "category": "General",
                     "longName": "hourly",
                     "name": "hourly",
                     "granularity": "day",
-                    "uri": "http://localhost:9998/tables/hourly/day"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/day"
                 }, {
                     "category": "General",
                     "longName": "hourly",
                     "name": "hourly",
                     "granularity": "hour",
-                    "uri": "http://localhost:9998/tables/hourly/hour"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/hour"
                 }, {
                     "category": "General",
                     "longName": "hourly",
                     "name": "hourly",
                     "granularity": "month",
-                    "uri": "http://localhost:9998/tables/hourly/month"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/month"
                 }, {
                     "category": "General",
                     "longName": "hourly",
                     "name": "hourly",
                     "granularity": "week",
-                    "uri": "http://localhost:9998/tables/hourly/week"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly/week"
                 }, {
                     "category": "General",
                     "longName": "hourly_monthly",
                     "name": "hourly_monthly",
                     "granularity": "all",
-                    "uri": "http://localhost:9998/tables/hourly_monthly/all"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/all"
                 }, {
                     "category": "General",
                     "longName": "hourly_monthly",
                     "name": "hourly_monthly",
                     "granularity": "day",
-                    "uri": "http://localhost:9998/tables/hourly_monthly/day"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/day"
                 }, {
                     "category": "General",
                     "longName": "hourly_monthly",
                     "name": "hourly_monthly",
                     "granularity": "hour",
-                    "uri": "http://localhost:9998/tables/hourly_monthly/hour"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/hour"
                 }, {
                     "category": "General",
                     "longName": "hourly_monthly",
                     "name": "hourly_monthly",
                     "granularity": "month",
-                    "uri": "http://localhost:9998/tables/hourly_monthly/month"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/month"
                 }, {
                     "category": "General",
                     "longName": "hourly_monthly",
                     "name": "hourly_monthly",
                     "granularity": "week",
-                    "uri": "http://localhost:9998/tables/hourly_monthly/week"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/hourly_monthly/week"
                 }, {
                     "category": "General",
                     "longName": "monthly",
                     "name": "monthly",
                     "granularity": "all",
-                    "uri": "http://localhost:9998/tables/monthly/all"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/monthly/all"
                 }, {
                     "category": "General",
                     "longName": "monthly",
                     "name": "monthly",
                     "granularity": "day",
-                    "uri": "http://localhost:9998/tables/monthly/day"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/monthly/day"
                 }, {
                     "category": "General",
                     "longName": "monthly",
                     "name": "monthly",
                     "granularity": "month",
-                    "uri": "http://localhost:9998/tables/monthly/month"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/monthly/month"
                 }, {
                     "category": "General",
                     "longName": "monthly",
                     "name": "monthly",
                     "granularity": "week",
-                    "uri": "http://localhost:9998/tables/monthly/week"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/monthly/week"
                 }, {
                     "category": "General",
                     "longName": "pets",
                     "name": "pets",
                     "granularity": "all",
-                    "uri": "http://localhost:9998/tables/pets/all"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/pets/all"
                 }, {
                     "category": "General",
                     "longName": "pets",
                     "name": "pets",
                     "granularity": "day",
-                    "uri": "http://localhost:9998/tables/pets/day"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/pets/day"
                 }, {
                     "category": "General",
                     "longName": "pets",
                     "name": "pets",
                     "granularity": "month",
-                    "uri": "http://localhost:9998/tables/pets/month"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/pets/month"
                 }, {
                     "category": "General",
                     "longName": "pets",
                     "name": "pets",
                     "granularity": "week",
-                    "uri": "http://localhost:9998/tables/pets/week"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/pets/week"
                 }, {
                     "category": "General",
                     "longName": "shapes",
                     "name": "shapes",
                     "granularity": "all",
-                    "uri": "http://localhost:9998/tables/shapes/all"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/all"
                 }, {
                     "category": "General",
                     "longName": "shapes",
                     "name": "shapes",
                     "granularity": "day",
-                    "uri": "http://localhost:9998/tables/shapes/day"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/day"
                 }, {
                     "category": "General",
                     "longName": "shapes",
                     "name": "shapes",
                     "granularity": "month",
-                    "uri": "http://localhost:9998/tables/shapes/month"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/month"
                 }, {
                     "category": "General",
                     "longName": "shapes",
                     "name": "shapes",
                     "granularity": "week",
-                    "uri": "http://localhost:9998/tables/shapes/week"
+                    "uri": "http://localhost:${jtb.getHarness().getPort()}/tables/shapes/week"
                 }
             ]
         }"""

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTablesFullViewEndpointSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTablesFullViewEndpointSpec.groovy
@@ -84,7 +84,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "All",
@@ -93,7 +93,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "all",
@@ -116,7 +116,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Day",
@@ -125,7 +125,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "day",
@@ -148,7 +148,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Hour",
@@ -157,7 +157,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "hour",
@@ -180,7 +180,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Month",
@@ -189,7 +189,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "month",
@@ -212,7 +212,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Week",
@@ -221,7 +221,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "week",
@@ -252,7 +252,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "All",
@@ -261,13 +261,13 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "all",
@@ -290,7 +290,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Day",
@@ -299,13 +299,13 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "day",
@@ -328,7 +328,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Hour",
@@ -337,7 +337,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "hour",
@@ -360,7 +360,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Month",
@@ -369,13 +369,13 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "month",
@@ -398,7 +398,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Week",
@@ -407,13 +407,13 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "week",
@@ -444,7 +444,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "All",
@@ -453,13 +453,13 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "all",
@@ -482,7 +482,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Day",
@@ -491,13 +491,13 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "day",
@@ -520,7 +520,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Month",
@@ -529,13 +529,13 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "month",
@@ -558,7 +558,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Week",
@@ -567,13 +567,13 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     }
                   ],
                   "name": "week",
@@ -604,7 +604,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/breed"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/breed"
                     },
                     {
                       "cardinality": 0,
@@ -620,7 +620,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/sex"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/sex"
                     },
                     {
                       "cardinality": 0,
@@ -636,7 +636,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/species"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/species"
                     }
                   ],
                   "longName": "All",
@@ -645,19 +645,19 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     },
                     {
                       "category": "General",
                       "longName": "rowNum",
                       "name": "rowNum",
-                      "uri": "http://localhost:9998/metrics/rowNum"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/rowNum"
                     }
                   ],
                   "name": "all",
@@ -680,7 +680,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/breed"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/breed"
                     },
                     {
                       "cardinality": 0,
@@ -696,7 +696,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/sex"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/sex"
                     },
                     {
                       "cardinality": 0,
@@ -712,7 +712,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/species"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/species"
                     }
                   ],
                   "longName": "Day",
@@ -721,19 +721,19 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     },
                     {
                       "category": "General",
                       "longName": "rowNum",
                       "name": "rowNum",
-                      "uri": "http://localhost:9998/metrics/rowNum"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/rowNum"
                     }
                   ],
                   "name": "day",
@@ -756,7 +756,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/breed"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/breed"
                     },
                     {
                       "cardinality": 0,
@@ -772,7 +772,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/sex"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/sex"
                     },
                     {
                       "cardinality": 0,
@@ -788,7 +788,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/species"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/species"
                     }
                   ],
                   "longName": "Month",
@@ -797,19 +797,19 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     },
                     {
                       "category": "General",
                       "longName": "rowNum",
                       "name": "rowNum",
-                      "uri": "http://localhost:9998/metrics/rowNum"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/rowNum"
                     }
                   ],
                   "name": "month",
@@ -832,7 +832,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/breed"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/breed"
                     },
                     {
                       "cardinality": 0,
@@ -848,7 +848,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/sex"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/sex"
                     },
                     {
                       "cardinality": 0,
@@ -864,7 +864,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/species"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/species"
                     }
                   ],
                   "longName": "Week",
@@ -873,19 +873,19 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "dayAvgLimbs",
                       "name": "dayAvgLimbs",
-                      "uri": "http://localhost:9998/metrics/dayAvgLimbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgLimbs"
                     },
                     {
                       "category": "General",
                       "longName": "limbs",
                       "name": "limbs",
-                      "uri": "http://localhost:9998/metrics/limbs"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/limbs"
                     },
                     {
                       "category": "General",
                       "longName": "rowNum",
                       "name": "rowNum",
-                      "uri": "http://localhost:9998/metrics/rowNum"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/rowNum"
                     }
                   ],
                   "name": "week",
@@ -925,7 +925,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"redPigment"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/color"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color"
                     },
                     {
                       "cardinality": 0,
@@ -941,7 +941,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/model"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model"
                     },
                     {
                       "cardinality": 0,
@@ -957,7 +957,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/shape"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape"
                     },
                     {
                       "cardinality": 0,
@@ -973,7 +973,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/size"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size"
                     },
                     {
                       "cardinality": 100000,
@@ -989,7 +989,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "All",
@@ -998,85 +998,85 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "area",
                       "name": "area",
-                      "uri": "http://localhost:9998/metrics/area"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/area"
                     },
                     {
                       "category": "General",
                       "longName": "booleanMetric",
                       "name": "booleanMetric",
-                      "uri": "http://localhost:9998/metrics/booleanMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/booleanMetric"
                     },
                     {
                       "category": "General",
                       "longName": "dayAvgOtherUsers",
                       "name": "dayAvgOtherUsers",
-                      "uri": "http://localhost:9998/metrics/dayAvgOtherUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgOtherUsers"
                     },
                     {
                       "category": "General",
                       "longName": "dayAvgUsers",
                       "name": "dayAvgUsers",
-                      "uri": "http://localhost:9998/metrics/dayAvgUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgUsers"
                     },
                     {
                       "category": "General",
                       "longName": "depth",
                       "name": "depth",
-                      "uri": "http://localhost:9998/metrics/depth"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/depth"
                     },
                     {
                       "category": "General",
                       "longName": "height",
                       "name": "height",
-                      "uri": "http://localhost:9998/metrics/height"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/height"
                     },
                     {
                       "category": "General",
                       "longName": "jsonNodeMetric",
                       "name": "jsonNodeMetric",
-                      "uri": "http://localhost:9998/metrics/jsonNodeMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/jsonNodeMetric"
                     },
                     {
                       "category": "General",
                       "longName": "nullMetric",
                       "name": "nullMetric",
-                      "uri": "http://localhost:9998/metrics/nullMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/nullMetric"
                     },
                     {
                       "category": "General",
                       "longName": "otherUsers",
                       "name": "otherUsers",
-                      "uri": "http://localhost:9998/metrics/otherUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/otherUsers"
                     },
                     {
                       "category": "General",
                       "longName": "rowNum",
                       "name": "rowNum",
-                      "uri": "http://localhost:9998/metrics/rowNum"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/rowNum"
                     },
                     {
                       "category": "General",
                       "longName": "stringMetric",
                       "name": "stringMetric",
-                      "uri": "http://localhost:9998/metrics/stringMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/stringMetric"
                     },
                     {
                       "category": "General",
                       "longName": "users",
                       "name": "users",
-                      "uri": "http://localhost:9998/metrics/users"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/users"
                     },
                     {
                       "category": "General",
                       "longName": "volume",
                       "name": "volume",
-                      "uri": "http://localhost:9998/metrics/volume"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/volume"
                     },
                     {
                       "category": "General",
                       "longName": "width",
                       "name": "width",
-                      "uri": "http://localhost:9998/metrics/width"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/width"
                     }
                   ],
                   "name": "all",
@@ -1108,7 +1108,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"redPigment"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/color"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color"
                     },
                     {
                       "cardinality": 0,
@@ -1124,7 +1124,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/model"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model"
                     },
                     {
                       "cardinality": 0,
@@ -1140,7 +1140,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/shape"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape"
                     },
                     {
                       "cardinality": 0,
@@ -1156,7 +1156,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/size"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size"
                     },
                     {
                       "cardinality": 100000,
@@ -1172,7 +1172,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Day",
@@ -1181,73 +1181,73 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "area",
                       "name": "area",
-                      "uri": "http://localhost:9998/metrics/area"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/area"
                     },
                     {
                       "category": "General",
                       "longName": "booleanMetric",
                       "name": "booleanMetric",
-                      "uri": "http://localhost:9998/metrics/booleanMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/booleanMetric"
                     },
                     {
                       "category": "General",
                       "longName": "depth",
                       "name": "depth",
-                      "uri": "http://localhost:9998/metrics/depth"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/depth"
                     },
                     {
                       "category": "General",
                       "longName": "height",
                       "name": "height",
-                      "uri": "http://localhost:9998/metrics/height"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/height"
                     },
                     {
                       "category": "General",
                       "longName": "jsonNodeMetric",
                       "name": "jsonNodeMetric",
-                      "uri": "http://localhost:9998/metrics/jsonNodeMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/jsonNodeMetric"
                     },
                     {
                       "category": "General",
                       "longName": "nullMetric",
                       "name": "nullMetric",
-                      "uri": "http://localhost:9998/metrics/nullMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/nullMetric"
                     },
                     {
                       "category": "General",
                       "longName": "otherUsers",
                       "name": "otherUsers",
-                      "uri": "http://localhost:9998/metrics/otherUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/otherUsers"
                     },
                     {
                       "category": "General",
                       "longName": "rowNum",
                       "name": "rowNum",
-                      "uri": "http://localhost:9998/metrics/rowNum"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/rowNum"
                     },
                     {
                       "category": "General",
                       "longName": "stringMetric",
                       "name": "stringMetric",
-                      "uri": "http://localhost:9998/metrics/stringMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/stringMetric"
                     },
                     {
                       "category": "General",
                       "longName": "users",
                       "name": "users",
-                      "uri": "http://localhost:9998/metrics/users"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/users"
                     },
                     {
                       "category": "General",
                       "longName": "volume",
                       "name": "volume",
-                      "uri": "http://localhost:9998/metrics/volume"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/volume"
                     },
                     {
                       "category": "General",
                       "longName": "width",
                       "name": "width",
-                      "uri": "http://localhost:9998/metrics/width"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/width"
                     }
                   ],
                   "name": "day",
@@ -1279,7 +1279,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"redPigment"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/color"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color"
                     },
                     {
                       "cardinality": 0,
@@ -1295,7 +1295,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/model"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model"
                     },
                     {
                       "cardinality": 0,
@@ -1311,7 +1311,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/shape"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape"
                     },
                     {
                       "cardinality": 0,
@@ -1327,7 +1327,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/size"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size"
                     },
                     {
                       "cardinality": 100000,
@@ -1343,7 +1343,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Month",
@@ -1352,85 +1352,85 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "area",
                       "name": "area",
-                      "uri": "http://localhost:9998/metrics/area"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/area"
                     },
                     {
                       "category": "General",
                       "longName": "booleanMetric",
                       "name": "booleanMetric",
-                      "uri": "http://localhost:9998/metrics/booleanMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/booleanMetric"
                     },
                     {
                       "category": "General",
                       "longName": "dayAvgOtherUsers",
                       "name": "dayAvgOtherUsers",
-                      "uri": "http://localhost:9998/metrics/dayAvgOtherUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgOtherUsers"
                     },
                     {
                       "category": "General",
                       "longName": "dayAvgUsers",
                       "name": "dayAvgUsers",
-                      "uri": "http://localhost:9998/metrics/dayAvgUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgUsers"
                     },
                     {
                       "category": "General",
                       "longName": "depth",
                       "name": "depth",
-                      "uri": "http://localhost:9998/metrics/depth"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/depth"
                     },
                     {
                       "category": "General",
                       "longName": "height",
                       "name": "height",
-                      "uri": "http://localhost:9998/metrics/height"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/height"
                     },
                     {
                       "category": "General",
                       "longName": "jsonNodeMetric",
                       "name": "jsonNodeMetric",
-                      "uri": "http://localhost:9998/metrics/jsonNodeMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/jsonNodeMetric"
                     },
                     {
                       "category": "General",
                       "longName": "nullMetric",
                       "name": "nullMetric",
-                      "uri": "http://localhost:9998/metrics/nullMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/nullMetric"
                     },
                     {
                       "category": "General",
                       "longName": "otherUsers",
                       "name": "otherUsers",
-                      "uri": "http://localhost:9998/metrics/otherUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/otherUsers"
                     },
                     {
                       "category": "General",
                       "longName": "rowNum",
                       "name": "rowNum",
-                      "uri": "http://localhost:9998/metrics/rowNum"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/rowNum"
                     },
                     {
                       "category": "General",
                       "longName": "stringMetric",
                       "name": "stringMetric",
-                      "uri": "http://localhost:9998/metrics/stringMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/stringMetric"
                     },
                     {
                       "category": "General",
                       "longName": "users",
                       "name": "users",
-                      "uri": "http://localhost:9998/metrics/users"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/users"
                     },
                     {
                       "category": "General",
                       "longName": "volume",
                       "name": "volume",
-                      "uri": "http://localhost:9998/metrics/volume"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/volume"
                     },
                     {
                       "category": "General",
                       "longName": "width",
                       "name": "width",
-                      "uri": "http://localhost:9998/metrics/width"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/width"
                     }
                   ],
                   "name": "month",
@@ -1462,7 +1462,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"redPigment"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/color"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color"
                     },
                     {
                       "cardinality": 0,
@@ -1478,7 +1478,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/model"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model"
                     },
                     {
                       "cardinality": 0,
@@ -1494,7 +1494,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/shape"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape"
                     },
                     {
                       "cardinality": 0,
@@ -1510,7 +1510,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/size"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size"
                     },
                     {
                       "cardinality": 100000,
@@ -1526,7 +1526,7 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                           "name":"id"
                         }
                       ],
-                      "uri": "http://localhost:9998/dimensions/other"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other"
                     }
                   ],
                   "longName": "Week",
@@ -1535,85 +1535,85 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "category": "General",
                       "longName": "area",
                       "name": "area",
-                      "uri": "http://localhost:9998/metrics/area"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/area"
                     },
                     {
                       "category": "General",
                       "longName": "booleanMetric",
                       "name": "booleanMetric",
-                      "uri": "http://localhost:9998/metrics/booleanMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/booleanMetric"
                     },
                     {
                       "category": "General",
                       "longName": "dayAvgOtherUsers",
                       "name": "dayAvgOtherUsers",
-                      "uri": "http://localhost:9998/metrics/dayAvgOtherUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgOtherUsers"
                     },
                     {
                       "category": "General",
                       "longName": "dayAvgUsers",
                       "name": "dayAvgUsers",
-                      "uri": "http://localhost:9998/metrics/dayAvgUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/dayAvgUsers"
                     },
                     {
                       "category": "General",
                       "longName": "depth",
                       "name": "depth",
-                      "uri": "http://localhost:9998/metrics/depth"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/depth"
                     },
                     {
                       "category": "General",
                       "longName": "height",
                       "name": "height",
-                      "uri": "http://localhost:9998/metrics/height"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/height"
                     },
                     {
                       "category": "General",
                       "longName": "jsonNodeMetric",
                       "name": "jsonNodeMetric",
-                      "uri": "http://localhost:9998/metrics/jsonNodeMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/jsonNodeMetric"
                     },
                     {
                       "category": "General",
                       "longName": "nullMetric",
                       "name": "nullMetric",
-                      "uri": "http://localhost:9998/metrics/nullMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/nullMetric"
                     },
                     {
                       "category": "General",
                       "longName": "otherUsers",
                       "name": "otherUsers",
-                      "uri": "http://localhost:9998/metrics/otherUsers"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/otherUsers"
                     },
                     {
                       "category": "General",
                       "longName": "rowNum",
                       "name": "rowNum",
-                      "uri": "http://localhost:9998/metrics/rowNum"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/rowNum"
                     },
                     {
                       "category": "General",
                       "longName": "stringMetric",
                       "name": "stringMetric",
-                      "uri": "http://localhost:9998/metrics/stringMetric"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/stringMetric"
                     },
                     {
                       "category": "General",
                       "longName": "users",
                       "name": "users",
-                      "uri": "http://localhost:9998/metrics/users"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/users"
                     },
                     {
                       "category": "General",
                       "longName": "volume",
                       "name": "volume",
-                      "uri": "http://localhost:9998/metrics/volume"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/volume"
                     },
                     {
                       "category": "General",
                       "longName": "width",
                       "name": "width",
-                      "uri": "http://localhost:9998/metrics/width"
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/width"
                     }
                   ],
                   "name": "week",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/JobsServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/JobsServletSpec.groovy
@@ -25,10 +25,10 @@ class JobsServletSpec extends Specification {
     def "jobs/ticket endpoint returns the correct response to a get request"() {
         setup:
         String expectedResponse = """{
-                "query": "https://localhost:9998/v1/data/QUERY",
-                "results": "http://localhost:9998/jobs/ticket1/results",
-                "syncResults": "http://localhost:9998/jobs/ticket1/results?asyncAfter=never",
-                "self": "http://localhost:9998/jobs/ticket1",
+                "query": "https://localhost:PORT/v1/data/QUERY",
+                "results": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1/results",
+                "syncResults": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1/results?asyncAfter=never",
+                "self": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1",
                 "status": "success",
                 "jobTicket": "ticket1",
                 "dateCreated": "2016-01-01",
@@ -52,11 +52,11 @@ class JobsServletSpec extends Specification {
                   "dateCreated": "2016-01-01",
                   "dateUpdated": "2016-01-01",
                   "jobTicket": "ticket1",
-                  "query": "https://localhost:9998/v1/data/QUERY",
-                  "results": "http://localhost:9998/jobs/ticket1/results",
-                  "self": "http://localhost:9998/jobs/ticket1",
+                  "query": "https://localhost:PORT/v1/data/QUERY",
+                  "results": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1/results",
+                  "self": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1",
                   "status": "success",
-                  "syncResults": "http://localhost:9998/jobs/ticket1/results?asyncAfter=never",
+                  "syncResults": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1/results?asyncAfter=never",
                   "userId": "momo"
                 }
               ],
@@ -65,8 +65,8 @@ class JobsServletSpec extends Specification {
                   "currentPage": 1,
                   "numberOfResults": 3,
                   "paginationLinks": {
-                    "last": "http://localhost:9998/jobs?perPage=1&page=3",
-                    "next": "http://localhost:9998/jobs?perPage=1&page=2"
+                    "last": "http://localhost:${jtb.getHarness().getPort()}/jobs?perPage=1&page=3",
+                    "next": "http://localhost:${jtb.getHarness().getPort()}/jobs?perPage=1&page=2"
                   },
                   "rowsPerPage": 1
                 }
@@ -113,10 +113,10 @@ class JobsServletSpec extends Specification {
     def "jobs/result endpoint returns the job metadata if the PreResponse is not available in the PreResponsestore in the async timeout"() {
         setup:
         String expectedResponse = """{
-                "query": "https://localhost:9998/v1/data/QUERY",
-                "results": "http://localhost:9998/jobs/ticket2/results",
-                "syncResults": "http://localhost:9998/jobs/ticket2/results?asyncAfter=never",
-                "self": "http://localhost:9998/jobs/ticket2",
+                "query": "https://localhost:PORT/v1/data/QUERY",
+                "results": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket2/results",
+                "syncResults": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket2/results?asyncAfter=never",
+                "self": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket2",
                 "status": "pending",
                 "jobTicket": "ticket2",
                 "dateCreated": "2016-01-01",
@@ -170,33 +170,33 @@ class JobsServletSpec extends Specification {
                             "dateCreated":"2016-01-01",
                             "dateUpdated":"2016-01-01",
                             "jobTicket":"ticket1",
-                            "query":"https://localhost:9998/v1/data/QUERY",
-                            "results":"http://localhost:9998/jobs/ticket1/results",
-                            "self":"http://localhost:9998/jobs/ticket1",
+                            "query":"https://localhost:PORT/v1/data/QUERY",
+                            "results":"http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1/results",
+                            "self":"http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1",
                             "status":"success",
-                            "syncResults":"http://localhost:9998/jobs/ticket1/results?asyncAfter=never",
+                            "syncResults":"http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1/results?asyncAfter=never",
                             "userId": "momo"
                         },
                         {
                             "dateCreated":"2016-01-01",
                             "dateUpdated":"2016-01-01",
                             "jobTicket":"ticket2",
-                            "query":"https://localhost:9998/v1/data/QUERY",
-                            "results":"http://localhost:9998/jobs/ticket2/results",
-                            "self":"http://localhost:9998/jobs/ticket2",
+                            "query":"https://localhost:PORT/v1/data/QUERY",
+                            "results":"http://localhost:${jtb.getHarness().getPort()}/jobs/ticket2/results",
+                            "self":"http://localhost:${jtb.getHarness().getPort()}/jobs/ticket2",
                             "status":"pending",
-                            "syncResults":"http://localhost:9998/jobs/ticket2/results?asyncAfter=never",
+                            "syncResults":"http://localhost:${jtb.getHarness().getPort()}/jobs/ticket2/results?asyncAfter=never",
                             "userId": "dodo"
                         },
                         {
                             "dateCreated": "2016-01-01",
                             "dateUpdated":"2016-01-01",
                             "jobTicket": "ticket3p",
-                            "query": "https://localhost:9998/v1/data/QUERY",
-                            "results": "http://localhost:9998/jobs/ticket3p/results",
-                            "self": "http://localhost:9998/jobs/ticket3p",
+                            "query": "https://localhost:PORT/v1/data/QUERY",
+                            "results": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results",
+                            "self": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p",
                             "status": "success",
-                            "syncResults": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=never",
+                            "syncResults": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=never",
                             "userId": "yoyo"
                         }
                       ]
@@ -217,11 +217,11 @@ class JobsServletSpec extends Specification {
                                             "dateCreated":"2016-01-01",
                                             "dateUpdated":"2016-01-01",
                                             "jobTicket":"ticket1",
-                                            "query":"https://localhost:9998/v1/data/QUERY",
-                                            "results":"http://localhost:9998/jobs/ticket1/results",
-                                            "self":"http://localhost:9998/jobs/ticket1",
+                                            "query":"https://localhost:PORT/v1/data/QUERY",
+                                            "results":"http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1/results",
+                                            "self":"http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1",
                                             "status":"success",
-                                            "syncResults":"http://localhost:9998/jobs/ticket1/results?asyncAfter=never",
+                                            "syncResults":"http://localhost:${jtb.getHarness().getPort()}/jobs/ticket1/results?asyncAfter=never",
                                             "userId": "momo"
                                         }
                                   ]}"""
@@ -295,8 +295,8 @@ class JobsServletSpec extends Specification {
               ],
               "meta": {
                 "pagination": {
-                  "last": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=3",
-                  "next": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=2",
+                  "last": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=3",
+                  "next": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=2",
                   "currentPage": 1,
                   "rowsPerPage": 1,
                   "numberOfResults": 3
@@ -312,9 +312,9 @@ class JobsServletSpec extends Specification {
               "meta": {
                 "pagination": {
                   "currentPage": 3,
-                  "first": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=1",
+                  "first": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=1",
                   "numberOfResults": 3,
-                  "previous": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=2",
+                  "previous": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=2",
                   "rowsPerPage": 1
                 }
               },
@@ -334,8 +334,8 @@ class JobsServletSpec extends Specification {
               "meta": {
                 "pagination": {
                   "currentPage": 1,
-                  "last": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=2&page=2",
-                  "next": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=2&page=2",
+                  "last": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=2&page=2",
+                  "next": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=2&page=2",
                   "numberOfResults": 3,
                   "rowsPerPage": 2
                 }
@@ -365,10 +365,10 @@ class JobsServletSpec extends Specification {
               ],
               "meta": {
                 "pagination": {
-                  "first": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=1",
-                  "last": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=3",
-                  "next": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=3",
-                  "previous": "http://localhost:9998/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=1",
+                  "first": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=1",
+                  "last": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=3",
+                  "next": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=3",
+                  "previous": "http://localhost:${jtb.getHarness().getPort()}/jobs/ticket3p/results?asyncAfter=5&perPage=1&page=1",
                   "currentPage": 2,
                   "rowsPerPage": 1,
                   "numberOfResults": 3

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/MetricsServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/MetricsServletSpec.groovy
@@ -44,9 +44,9 @@ class MetricsServletSpec extends Specification {
         String expectedResponse = """{
                                         "rows":
                                         [
-                                            {"category": "General", "name":"metricA", "longName": "metricA", "uri":"http://localhost:9998/metrics/metricA"},
-                                            {"category": "General", "name":"metricB", "longName": "metricB", "uri":"http://localhost:9998/metrics/metricB"},
-                                            {"category": "General", "name":"metricC", "longName": "metricC", "uri":"http://localhost:9998/metrics/metricC"}
+                                            {"category": "General", "name":"metricA", "longName": "metricA", "uri":"http://localhost:${jtb.getHarness().getPort()}/metrics/metricA"},
+                                            {"category": "General", "name":"metricB", "longName": "metricB", "uri":"http://localhost:${jtb.getHarness().getPort()}/metrics/metricB"},
+                                            {"category": "General", "name":"metricC", "longName": "metricC", "uri":"http://localhost:${jtb.getHarness().getPort()}/metrics/metricC"}
                                         ]
                                     }"""
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SlicesServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SlicesServletSpec.groovy
@@ -33,15 +33,15 @@ class SlicesServletSpec extends Specification {
         String expectedResponse = """{
             "rows":
             [
-                {"timeGrain":"hour", "name":"color_shapes_hourly", "uri":"http://localhost:9998/slices/color_shapes_hourly"},
-                {"timeGrain":"day", "name":"color_shapes", "uri":"http://localhost:9998/slices/color_shapes"},
-                {"timeGrain":"month", "name":"color_shapes_monthly", "uri":"http://localhost:9998/slices/color_shapes_monthly"},
-                {"timeGrain":"day", "name":"color_size_shapes", "uri":"http://localhost:9998/slices/color_size_shapes"},
-                {"timeGrain":"day", "name":"color_size_shape_shapes", "uri":"http://localhost:9998/slices/color_size_shape_shapes"},
-                {"timeGrain":"day", "name":"all_pets", "uri":"http://localhost:9998/slices/all_pets"},
-                {"timeGrain":"day", "name":"all_shapes", "uri":"http://localhost:9998/slices/all_shapes"},
-                {"timeGrain":"month", "name":"monthly", "uri":"http://localhost:9998/slices/monthly"},
-                {"timeGrain":"hour", "name":"hourly", "uri":"http://localhost:9998/slices/hourly"}
+                {"timeGrain":"hour", "name":"color_shapes_hourly", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/color_shapes_hourly"},
+                {"timeGrain":"day", "name":"color_shapes", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/color_shapes"},
+                {"timeGrain":"month", "name":"color_shapes_monthly", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/color_shapes_monthly"},
+                {"timeGrain":"day", "name":"color_size_shapes", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/color_size_shapes"},
+                {"timeGrain":"day", "name":"color_size_shape_shapes", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/color_size_shape_shapes"},
+                {"timeGrain":"day", "name":"all_pets", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/all_pets"},
+                {"timeGrain":"day", "name":"all_shapes", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/all_shapes"},
+                {"timeGrain":"month", "name":"monthly", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/monthly"},
+                {"timeGrain":"hour", "name":"hourly", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/hourly"}
             ]
         }"""
 
@@ -60,9 +60,9 @@ class SlicesServletSpec extends Specification {
             "timeZone":"UTC",
             "dimensions":
             [
-                {"name":"breed", "uri":"http://localhost:9998/dimensions/breed", "intervals":["$interval"]},
-                {"name":"sex", "uri":"http://localhost:9998/dimensions/sex", "intervals":["$interval"]},
-                {"name":"species", "uri":"http://localhost:9998/dimensions/species", "intervals":["$interval"]}
+                {"name":"breed", "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/breed", "intervals":["$interval"]},
+                {"name":"sex", "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/sex", "intervals":["$interval"]},
+                {"name":"species", "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/species", "intervals":["$interval"]}
             ],
             "segmentInfo": {},
             "metrics":
@@ -79,7 +79,7 @@ class SlicesServletSpec extends Specification {
     }
 
     String makeRequest(String target) {
-        // Set target of call
+        // Set target of call 
         def httpCall = jtb.getHarness().target(target)
 
         // Make the call

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/LogFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/LogFilterSpec.groovy
@@ -174,7 +174,7 @@ class LogFilterSpec extends Specification {
 
     def "client reset by peer still logs"() {
         when:
-        URL url = new URL("http://localhost:9998/test/fail")
+        URL url = new URL("http://localhost:${jtb.getHarness().getPort()}/test/fail")
         HttpURLConnection con = url.openConnection()
         con.setUseCaches(false)
         con.setInstanceFollowRedirects(false)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/RateLimitFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/RateLimitFilterSpec.groovy
@@ -95,7 +95,7 @@ class RateLimitFilterSpec extends Specification {
 
         void runTest() {
 
-            URL url = new URL("http://localhost:9998/test/data?"+TestRateLimitFilter.USER_PARAM+"="+this.user+"&t="+Thread.currentThread().getName())
+            URL url = new URL("http://localhost:${jtb.getHarness().getPort()}/test/data?"+TestRateLimitFilter.USER_PARAM+"="+this.user+"&t="+Thread.currentThread().getName())
 
             HttpURLConnection con = url.openConnection()
             con.setInstanceFollowRedirects(false)
@@ -208,7 +208,7 @@ class RateLimitFilterSpec extends Specification {
     def "UI header triggers UI user limit"() {
         when: "UI user opens 20 simultaneous requests"
         Map headers = [
-            referer: "http://localhost:9998/",
+            referer: "http://localhost:${jtb.getHarness().getPort()}/",
             (DataApiRequestTypeIdentifier.CLIENT_HEADER_NAME) : (DataApiRequestTypeIdentifier.CLIENT_HEADER_VALUE)
         ]
         List<Thread> threads = []

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/application/JerseyTestBinder.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/application/JerseyTestBinder.java
@@ -66,7 +66,7 @@ public class JerseyTestBinder {
     public ConfigurationLoader configurationLoader;
     public TestBinderFactory testBinderFactory;
     public boolean useTestWebService = true;
-    private static final int RANDOM_PORT = 0;
+    private static final String RANDOM_PORT = "0";
 
     private DateTimeZone previousDateTimeZone;
 
@@ -159,7 +159,7 @@ public class JerseyTestBinder {
             @Override
             protected Application configure() {
                 // Find first available port.
-                forceSet(TestProperties.CONTAINER_PORT, String.valueOf(RANDOM_PORT));
+                forceSet(TestProperties.CONTAINER_PORT, RANDOM_PORT);
 
                 return config;
             }

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/application/JerseyTestBinder.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/application/JerseyTestBinder.java
@@ -37,6 +37,7 @@ import org.glassfish.hk2.api.MultiException;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.slf4j.Logger;
@@ -55,7 +56,6 @@ import javax.ws.rs.core.Application;
  * Configures JerseyTest and also sets up DI.  This is a singleton since JerseyTest binds a network port.
  */
 public class JerseyTestBinder {
-
     private static final Logger LOG = LoggerFactory.getLogger(JerseyTestBinder.class);
 
     public ApplicationState state;
@@ -66,6 +66,7 @@ public class JerseyTestBinder {
     public ConfigurationLoader configurationLoader;
     public TestBinderFactory testBinderFactory;
     public boolean useTestWebService = true;
+    private static final int RANDOM_PORT = 0;
 
     private DateTimeZone previousDateTimeZone;
 
@@ -100,10 +101,11 @@ public class JerseyTestBinder {
      * @param resourceClasses  Resource classes for Jersey to load
      */
     public JerseyTestBinder(boolean doStart, ApplicationState state, Class<?>... resourceClasses) {
+
         this.state = state;
 
         //Initializing the Sketch field converter
-        FieldConverterSupplier.sketchConverter =  initializeSketchConverter();
+        FieldConverterSupplier.sketchConverter = initializeSketchConverter();
 
         //Initialize the metrics filter helper
         FieldConverterSupplier.metricsFilterSetBuilder = initializeMetricsFilterSetBuilder();
@@ -156,6 +158,9 @@ public class JerseyTestBinder {
         this.harness = new JerseyTest() {
             @Override
             protected Application configure() {
+                // Find first available port.
+                forceSet(TestProperties.CONTAINER_PORT, String.valueOf(RANDOM_PORT));
+
                 return config;
             }
         };
@@ -239,7 +244,7 @@ public class JerseyTestBinder {
             if (isAlive()) {
                 // Include thread stack dump
                 StringBuilder sb = new StringBuilder("Timeout starting Jersey\n");
-                for (StackTraceElement ste: this.getStackTrace()) {
+                for (StackTraceElement ste : this.getStackTrace()) {
                     sb.append("\tat ").append(ste).append('\n');
                 }
                 // try to interrupt and tear down

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/web/endpoints/JobsEndpointResources.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/web/endpoints/JobsEndpointResources.java
@@ -49,7 +49,7 @@ public class JobsEndpointResources {
         fieldValueMap1.put(DefaultJobField.JOB_TICKET, "ticket1");
         fieldValueMap1.put(DefaultJobField.DATE_CREATED, "2016-01-01");
         fieldValueMap1.put(DefaultJobField.DATE_UPDATED, "2016-01-01");
-        fieldValueMap1.put(DefaultJobField.QUERY, "https://localhost:9998/v1/data/QUERY");
+        fieldValueMap1.put(DefaultJobField.QUERY, "https://localhost:PORT/v1/data/QUERY");
         fieldValueMap1.put(DefaultJobField.STATUS, "success");
         fieldValueMap1.put(DefaultJobField.USER_ID, "momo");
 
@@ -60,7 +60,7 @@ public class JobsEndpointResources {
         fieldValueMap2.put(DefaultJobField.JOB_TICKET, "ticket2");
         fieldValueMap2.put(DefaultJobField.DATE_CREATED, "2016-01-01");
         fieldValueMap2.put(DefaultJobField.DATE_UPDATED, "2016-01-01");
-        fieldValueMap2.put(DefaultJobField.QUERY, "https://localhost:9998/v1/data/QUERY");
+        fieldValueMap2.put(DefaultJobField.QUERY, "https://localhost:PORT/v1/data/QUERY");
         fieldValueMap2.put(DefaultJobField.STATUS, "pending");
         fieldValueMap2.put(DefaultJobField.USER_ID, "dodo");
 
@@ -71,7 +71,7 @@ public class JobsEndpointResources {
         fieldValueMap3.put(DefaultJobField.JOB_TICKET, "ticket3p");
         fieldValueMap3.put(DefaultJobField.DATE_CREATED, "2016-01-01");
         fieldValueMap3.put(DefaultJobField.DATE_UPDATED, "2016-01-01");
-        fieldValueMap3.put(DefaultJobField.QUERY, "https://localhost:9998/v1/data/QUERY");
+        fieldValueMap3.put(DefaultJobField.QUERY, "https://localhost:PORT/v1/data/QUERY");
         fieldValueMap3.put(DefaultJobField.STATUS, "success");
         fieldValueMap3.put(DefaultJobField.USER_ID, "yoyo");
 

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
@@ -42,7 +42,7 @@ class SlicesServletSpec extends Specification {
         String expectedResponse = """{
             "rows":
             [
-                {"timeGrain":"hour", "name":"$sliceNameHour", "uri":"http://localhost:9998/slices/$sliceNameHour"},
+                {"timeGrain":"hour", "name":"$sliceNameHour", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/$sliceNameHour"},
             ]
         }"""
 
@@ -72,7 +72,7 @@ class SlicesServletSpec extends Specification {
                 """
                                 {
                                     "name":"$it",
-                                    "uri":"http://localhost:9998/dimensions/$it",
+                                    "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/$it",
                                     "intervals":["$interval"]
                                 }
                         """

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
@@ -46,14 +46,14 @@ class TablesServletSpec extends Specification {
                                                     "granularity":"hour",
                                                     "name":"$tableName",
                                                     "longName":"$tableName",
-                                                    "uri":"http://localhost:9998/tables/$tableName/hour"
+                                                    "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/hour"
                                             },
                                             {
                                                     "category":"General",
                                                     "granularity":"all",
                                                     "name":"$tableName",
                                                     "longName":"$tableName",
-                                                    "uri":"http://localhost:9998/tables/$tableName/all"
+                                                    "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/all"
                                             }
                                         ]
                                     }"""
@@ -72,14 +72,14 @@ class TablesServletSpec extends Specification {
                                                 "granularity":"hour",
                                                 "name":"$tableName",
                                                 "longName":"$tableName",
-                                                "uri":"http://localhost:9998/tables/$tableName/hour"
+                                                "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/hour"
                                             },
                                             {
                                                 "category":"General",
                                                 "granularity":"all",
                                                 "name":"$tableName",
                                                 "longName":"$tableName",
-                                                "uri":"http://localhost:9998/tables/$tableName/all"
+                                                "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/all"
                                             }
                                         ]
                                     }"""
@@ -114,7 +114,7 @@ class TablesServletSpec extends Specification {
                                                         "name": "$it",
                                                         "longName": "$it",
                                                         "cardinality": 0,
-                                                        "uri": "http://localhost:9998/dimensions/$it"
+                                                        "uri": "http://localhost:${jerseyTestBinder.getHarness().getPort()}/dimensions/$it"
                                                     }""" 
                                                 }
                                                 .join(',')
@@ -127,7 +127,7 @@ class TablesServletSpec extends Specification {
                                                         "category": "General",
                                                         "name": "$it",
                                                         "longName": "$it",
-                                                        "uri": "http://localhost:9998/metrics/$it"
+                                                        "uri": "http://localhost:${jerseyTestBinder.getHarness().getPort()}/metrics/$it"
                                                     }""" 
                                                 }
                                                 .join(',')

--- a/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
+++ b/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
@@ -41,7 +41,7 @@ class SlicesServletSpec extends Specification {
         String expectedResponse = """{
             "rows":
             [
-                {"timeGrain":"hour", "name":"$sliceNameHour", "uri":"http://localhost:9998/slices/$sliceNameHour"},
+                {"timeGrain":"hour", "name":"$sliceNameHour", "uri":"http://localhost:${jtb.getHarness().getPort()}/slices/$sliceNameHour"},
             ]
         }"""
 
@@ -70,7 +70,7 @@ class SlicesServletSpec extends Specification {
                         dimensionNames.collect {"""
                                 {
                                     "name":"$it",
-                                    "uri":"http://localhost:9998/dimensions/$it",
+                                    "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/$it",
                                     "intervals":["$interval"]
                                 }
                         """}

--- a/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
+++ b/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
@@ -38,21 +38,21 @@ class TablesServletSpec extends Specification {
                                                     "granularity":"hour",
                                                     "name":"$tableName",
                                                     "longName":"$tableName",
-                                                    "uri":"http://localhost:9998/tables/$tableName/hour"
+                                                    "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/hour"
                                             },
                                             {
                                                     "category":"General",
                                                     "granularity":"day",
                                                     "name":"$tableName",
                                                     "longName":"$tableName",
-                                                    "uri":"http://localhost:9998/tables/$tableName/day"
+                                                    "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/day"
                                             },
                                             {
                                                     "category":"General",
                                                     "granularity":"all",
                                                     "name":"$tableName",
                                                     "longName":"$tableName",
-                                                    "uri":"http://localhost:9998/tables/$tableName/all"
+                                                    "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/all"
                                             }
                                         ]
                                     }"""
@@ -71,21 +71,21 @@ class TablesServletSpec extends Specification {
                                                 "granularity":"hour",
                                                 "name":"$tableName",
                                                 "longName":"$tableName",
-                                                "uri":"http://localhost:9998/tables/$tableName/hour"
+                                                "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/hour"
                                             },
                                             {
                                                 "category":"General",
                                                 "granularity":"day",
                                                 "name":"$tableName",
                                                 "longName":"$tableName",
-                                                "uri":"http://localhost:9998/tables/$tableName/day"
+                                                "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/day"
                                             },
                                             {
                                                 "category":"General",
                                                 "granularity":"all",
                                                 "name":"$tableName",
                                                 "longName":"$tableName",
-                                                "uri":"http://localhost:9998/tables/$tableName/all"
+                                                "uri":"http://localhost:${jerseyTestBinder.getHarness().getPort()}/tables/$tableName/all"
                                             }
                                         ]
                                     }"""
@@ -121,7 +121,7 @@ class TablesServletSpec extends Specification {
                                                     "name": "$it",
                                                     "longName": "wiki $it",
                                                     "cardinality": 0,
-                                                    "uri": "http://localhost:9998/dimensions/$it"
+                                                    "uri": "http://localhost:${jerseyTestBinder.getHarness().getPort()}/dimensions/$it"
                                                     }"""
                                                 }
                                                 .join(',')
@@ -134,7 +134,7 @@ class TablesServletSpec extends Specification {
                                                         "category": "General",
                                                         "name": "$it",
                                                         "longName": "$it",
-                                                        "uri": "http://localhost:9998/metrics/$it"
+                                                        "uri": "http://localhost:${jerseyTestBinder.getHarness().getPort()}/metrics/$it"
                                                     }"""
                                                 }
                                                 .join(',')


### PR DESCRIPTION
Addresses #356 (The next issue which needs to be accomplished before tests could _probably_ be parallel would be #462)

Convert static bindings to port 9998 into dynamically assigned ports

Ideally we would be able to specify a range, but we don't have any interface to do this and checking manually if a port is available is error prone since jersey has to actually bind to it.
