### PR TITLE
Cleanup RequestLog timing usage on servlets

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -114,6 +115,7 @@ public class DimensionsServlet extends EndpointServlet {
             @Context final UriInfo uriInfo,
             @Context final ContainerRequestContext containerRequestContext
     ) {
+        Supplier<Response> responseSender;
         try {
             RequestLog.startTiming(this);
             RequestLog.record(new DimensionRequest("all", "no"));
@@ -143,18 +145,19 @@ public class DimensionsServlet extends EndpointServlet {
                     null
             );
             LOG.debug("Dimensions Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
-            return response;
+            responseSender = () -> response;
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
-            return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
+            responseSender = () -> Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
+            responseSender = () -> Response.status(Status.BAD_REQUEST).entity(msg).build();
+        } finally {
             RequestLog.stopTiming(this);
-            return Response.status(Status.BAD_REQUEST).entity(msg).build();
         }
+
+        return responseSender.get();
     }
 
     /**
@@ -176,6 +179,7 @@ public class DimensionsServlet extends EndpointServlet {
             @Context final UriInfo uriInfo,
             @Context final ContainerRequestContext containerRequestContext
     ) {
+        Supplier<Response> responseSender;
         try {
             RequestLog.startTiming(this);
             RequestLog.record(new DimensionRequest(dimensionName, "no"));
@@ -202,23 +206,23 @@ public class DimensionsServlet extends EndpointServlet {
 
             String output = objectMappers.getMapper().writeValueAsString(result);
             LOG.debug("Dimension Endpoint Response: {}", output);
-            RequestLog.stopTiming(this);
-            return Response.status(Status.OK).entity(output).build();
+            responseSender = () -> Response.status(Status.OK).entity(output).build();
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
-            return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
+            responseSender = () -> Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (JsonProcessingException e) {
             String msg = String.format("Internal server error. JsonProcessingException : %s", e.getMessage());
             LOG.error(msg, e);
-            RequestLog.stopTiming(this);
-            return Response.status(Status.INTERNAL_SERVER_ERROR).entity(msg).build();
+            responseSender = () -> Response.status(Status.INTERNAL_SERVER_ERROR).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
+            responseSender = () -> Response.status(Status.BAD_REQUEST).entity(msg).build();
+        } finally {
             RequestLog.stopTiming(this);
-            return Response.status(Status.BAD_REQUEST).entity(msg).build();
         }
+
+        return responseSender.get();
     }
 
     /**
@@ -263,6 +267,7 @@ public class DimensionsServlet extends EndpointServlet {
             @Context final UriInfo uriInfo,
             @Context final ContainerRequestContext containerRequestContext
     ) {
+        Supplier<Response> responseSender;
         try {
             RequestLog.startTiming(this);
             RequestLog.record(new DimensionRequest(dimensionName, "yes"));
@@ -313,23 +318,23 @@ public class DimensionsServlet extends EndpointServlet {
             );
 
             LOG.debug("Dimension Value Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
-            return response;
+            responseSender = () -> response;
         } catch (RequestValidationException e) {
             LOG.debug(e.getMessage(), e);
-            RequestLog.stopTiming(this);
-            return Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
+            responseSender = () -> Response.status(e.getStatus()).entity(e.getErrorHttpMsg()).build();
         } catch (RowLimitReachedException e) {
             String msg = String.format("Row limit exceeded for dimension %s: %s", dimensionName, e.getMessage());
             LOG.debug(msg, e);
-            RequestLog.stopTiming(this);
-            return Response.status(INSUFFICIENT_STORAGE).entity(msg).build();
+            responseSender = () -> Response.status(INSUFFICIENT_STORAGE).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.debug(msg, e);
+            responseSender = () -> Response.status(BAD_REQUEST).entity(msg).build();
+        } finally {
             RequestLog.stopTiming(this);
-            return Response.status(BAD_REQUEST).entity(msg).build();
         }
+
+        return responseSender.get();
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -123,6 +124,7 @@ public class FeatureFlagsServlet extends EndpointServlet {
             @QueryParam("format") String format,
             @Context UriInfo uriInfo
     ) {
+        Supplier<Response> responseSender;
         try {
             RequestLog.startTiming(this);
             RequestLog.record(new FeatureFlagRequest("all"));
@@ -142,14 +144,16 @@ public class FeatureFlagsServlet extends EndpointServlet {
                     Arrays.asList("name", "value")
             );
             LOG.debug("Feature Flags Endpoint Response: {}", response.getEntity());
-            RequestLog.stopTiming(this);
-            return response;
+            responseSender = () -> response;
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
+            responseSender = () -> Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
+        } finally {
             RequestLog.stopTiming(this);
-            return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
+
+        return responseSender.get();
     }
 
     /**
@@ -178,6 +182,7 @@ public class FeatureFlagsServlet extends EndpointServlet {
             @QueryParam("format") String format,
             @Context UriInfo uriInfo
     ) {
+        Supplier<Response> responseSender;
         try {
             RequestLog.startTiming(this);
             RequestLog.record(new FeatureFlagRequest(flagName));
@@ -190,18 +195,19 @@ public class FeatureFlagsServlet extends EndpointServlet {
             String output = objectMappers.getMapper().writeValueAsString(status);
 
             LOG.debug("Feature Flags Endpoint Response: {}", output);
-            RequestLog.stopTiming(this);
-            return Response.status(Response.Status.OK).entity(output).build();
+            responseSender = () -> Response.status(Response.Status.OK).entity(output).build();
         } catch (JsonProcessingException e) {
             String msg = String.format("Internal server error. JsonProcessingException : %s", e.getMessage());
             LOG.error(msg, e);
-            RequestLog.stopTiming(this);
-            return Response.status(INTERNAL_SERVER_ERROR).entity(msg).build();
+            responseSender = () -> Response.status(INTERNAL_SERVER_ERROR).entity(msg).build();
         } catch (Error | Exception e) {
             String msg = String.format("Exception processing request: %s", e.getMessage());
             LOG.info(msg, e);
+            responseSender = () -> Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
+        } finally {
             RequestLog.stopTiming(this);
-            return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
         }
+
+        return responseSender.get();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
@@ -109,7 +109,7 @@ public class JobsServlet extends EndpointServlet {
             JobPayloadBuilder jobPayloadBuilder,
             PreResponseStore preResponseStore,
             BroadcastChannel<String> broadcastChannel,
-            @Named(JobsApiRequest.REQUEST_MAPPER_NAMESPACE)RequestMapper requestMapper,
+            @Named(JobsApiRequest.REQUEST_MAPPER_NAMESPACE) RequestMapper requestMapper,
             HttpResponseMaker httpResponseMaker
     ) {
         super(objectMappers);
@@ -151,7 +151,7 @@ public class JobsServlet extends EndpointServlet {
             RequestLog.startTiming(this);
             RequestLog.record(new JobRequest("all"));
 
-            JobsApiRequest apiRequest = new JobsApiRequest (
+            JobsApiRequest apiRequest = new JobsApiRequest(
                     format,
                     null, //asyncAfter is null so it behaves like a synchronous request
                     perPage,
@@ -218,7 +218,7 @@ public class JobsServlet extends EndpointServlet {
         try {
             RequestLog.startTiming(this);
             RequestLog.record(new JobRequest(ticket));
-            JobsApiRequest apiRequest = new JobsApiRequest (
+            JobsApiRequest apiRequest = new JobsApiRequest(
                     ResponseFormatType.JSON.toString(),
                     null,
                     "",
@@ -279,7 +279,7 @@ public class JobsServlet extends EndpointServlet {
             RequestLog.startTiming(this);
             RequestLog.record(new JobRequest(ticket));
 
-            JobsApiRequest apiRequest = new JobsApiRequest (
+            JobsApiRequest apiRequest = new JobsApiRequest(
                     format,
                     asyncAfter,
                     perPage,
@@ -442,7 +442,7 @@ public class JobsServlet extends EndpointServlet {
                             }
                         }
                 )
-                 //map the jsonResponse String to a Response
+                //map the jsonResponse String to a Response
                 .map(this::getResponse)
                 .onErrorReturn(this::getErrorResponse);
     }
@@ -534,7 +534,8 @@ public class JobsServlet extends EndpointServlet {
                 .map(pair -> Utils.withRight(pair, pair.getRight().getAsInt()))
                 .map(pair -> Utils.withRight(
                         pair,
-                        uriInfo.getRequestUriBuilder().replaceQueryParam("page", pair.getRight()))
+                        uriInfo.getRequestUriBuilder().replaceQueryParam("page", pair.getRight())
+                        )
                 )
                 .map(pair -> Utils.withRight(pair, pair.getRight().build()))
                 .collect(StreamUtils.toLinkedMap(Pair::getLeft, Pair::getRight));


### PR DESCRIPTION
Addresses #362 

- Calls to stop `RequestLog` timers should be in finally blocks

**NOTES:** 

- I think there were some problems with the handling of `RequestLog` in `JobsServlet`, I've made the most significant changes there
- I'm not super familiar with ReactiveX so there's probably something I could have done better.
