### PR TITLE
Change tests to use the ObjectMapperSuite instead of ObjectMapper directly

### DIFF
--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/application/AbstractBinderFactorySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/application/AbstractBinderFactorySpec.groovy
@@ -30,8 +30,8 @@ import com.yahoo.bard.webservice.data.cache.StubDataCache
 import com.yahoo.bard.webservice.data.cache.TupleDataCache
 import com.yahoo.bard.webservice.data.config.ConfigurationLoader
 import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig
-import com.yahoo.bard.webservice.data.config.dimension.TypeAwareDimensionLoader
 import com.yahoo.bard.webservice.data.config.dimension.TestDimensions
+import com.yahoo.bard.webservice.data.config.dimension.TypeAwareDimensionLoader
 import com.yahoo.bard.webservice.data.config.metric.MetricLoader
 import com.yahoo.bard.webservice.data.config.table.TableLoader
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
@@ -45,8 +45,6 @@ import com.yahoo.bard.webservice.table.PhysicalTableDictionary
 import com.codahale.metrics.health.HealthCheck
 import com.codahale.metrics.health.HealthCheckRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.joda.JodaModule
 
 import org.glassfish.hk2.api.DynamicConfiguration
 import org.glassfish.hk2.utilities.Binder
@@ -57,9 +55,7 @@ import spock.lang.Specification
 
 public class AbstractBinderFactorySpec extends Specification {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new JodaModule())
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     final SystemConfig systemConfig = SystemConfigProvider.getInstance()
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/application/DruidDimensionsLoaderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/application/DruidDimensionsLoaderSpec.groovy
@@ -26,9 +26,7 @@ import spock.lang.Specification
 
 class DruidDimensionsLoaderSpec extends Specification {
 
-    static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new JodaModule())
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     static final List<String> LOADED_DIMENSIONS = [
             TestApiDimensionName.SHAPE,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncFunctionalSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncFunctionalSpec.groovy
@@ -1,6 +1,7 @@
 package com.yahoo.bard.webservice.async
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
 import com.yahoo.bard.webservice.table.availability.AvailabilityTestingUtils
 import com.yahoo.bard.webservice.web.endpoints.BaseDataServletComponentSpec
@@ -8,7 +9,6 @@ import com.yahoo.bard.webservice.web.endpoints.DataServlet
 import com.yahoo.bard.webservice.web.endpoints.JobsServlet
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.Interval
 
@@ -42,8 +42,7 @@ import javax.ws.rs.core.Response
 @Timeout(30)
 abstract class AsyncFunctionalSpec extends Specification {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     JerseyTestBinder jtb
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/jobs/jobrows/JobRowSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/jobs/jobrows/JobRowSpec.groovy
@@ -12,6 +12,7 @@ import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.JOB_T
 import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.QUERY
 import static com.yahoo.bard.webservice.async.jobs.jobrows.DefaultJobField.STATUS
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.async.jobs.JobTestUtils
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -20,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Specification
 
 class JobRowSpec extends Specification {
-    static final ObjectMapper MAPPER = new ObjectMapper()
+    static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
 
     def "The JobRow constructor throws an IllegalArgumentException if the valuesMap does not contain the key field"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidHavingBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidHavingBuilderSpec.groovy
@@ -2,14 +2,13 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.druid.model.having.Having
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 import com.yahoo.bard.webservice.web.ApiHaving
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-import com.fasterxml.jackson.datatype.joda.JodaModule
 
 import spock.lang.Shared
 import spock.lang.Specification
@@ -19,9 +18,7 @@ public class DruidHavingBuilderSpec extends Specification {
 
     @Shared QueryBuildingTestingResources resources
 
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new JodaModule())
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     def setupSpec() {
         resources = new QueryBuildingTestingResources()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidResponseParserSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidResponseParserSpec.groovy
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.data
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.dimension.BardDimensionField
 import com.yahoo.bard.webservice.data.dimension.DimensionColumn
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
@@ -22,7 +23,6 @@ import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -33,8 +33,7 @@ import spock.lang.Unroll
 import java.util.stream.Stream
 
 class DruidResponseParserSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     DimensionDictionary dimensionDictionary
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/ResultSerializationProxySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/ResultSerializationProxySpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 import com.yahoo.bard.webservice.util.JsonSortStrategy
 
@@ -15,7 +16,7 @@ import spock.lang.Unroll
  */
 class ResultSerializationProxySpec extends Specification {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper()
+    private static final ObjectMapper objectMapper = new ObjectMappersSuite().getMapper()
     SerializationResources resources
     ResultSerializationProxy serializeResult
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/ResultSetSerializationProxySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/ResultSetSerializationProxySpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 import com.yahoo.bard.webservice.util.JsonSortStrategy
 
@@ -13,7 +14,7 @@ import spock.lang.Specification
  */
 class ResultSetSerializationProxySpec extends Specification {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper()
+    private static final ObjectMapper objectMapper = new ObjectMappersSuite().getMapper()
     SerializationResources resources
     ResultSetSerializationProxy serializeResultSet
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/TopNMetricSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/TopNMetricSpec.groovy
@@ -1,21 +1,21 @@
 // Copyright 2016 Yahoo Inc.
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data
+
 import static com.yahoo.bard.webservice.druid.model.orderby.TopNMetric.TopNMetricType.ALPHA_NUMERIC
 import static com.yahoo.bard.webservice.druid.model.orderby.TopNMetric.TopNMetricType.LEXICOGRAPHIC
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.model.orderby.SortDirection
 import com.yahoo.bard.webservice.druid.model.orderby.TopNMetric
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 
 class TopNMetricSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     def "Check json serialization"() {
         expect:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/time/DefaultTimeGrainSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/time/DefaultTimeGrainSpec.groovy
@@ -10,10 +10,10 @@ import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.QUARTER
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.WEEK
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.YEAR
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTime
 
@@ -21,8 +21,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class DefaultTimeGrainSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Unroll
     def "#timeGrain serializes to #expectedJson with default timezone (UTC)"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImplSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImplSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.client.impl
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.client.DruidClientConfigHelper
 import com.yahoo.bard.webservice.druid.model.query.QueryContext
 import com.yahoo.bard.webservice.druid.model.query.WeightEvaluationQuery
@@ -14,6 +15,8 @@ import spock.lang.Specification
 import java.util.function.Supplier
 
 class AsyncDruidWebServiceImplSpec extends Specification {
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
+
     def "Ensure that headersToAppend are added to request when calling postDruidQuery"() {
         setup:
         WeightEvaluationQuery weightEvaluationQuery = Mock(WeightEvaluationQuery)
@@ -30,7 +33,7 @@ class AsyncDruidWebServiceImplSpec extends Specification {
 
         AsyncDruidWebServiceImplWrapper webServiceImplWrapper = new AsyncDruidWebServiceImplWrapper(
                 DruidClientConfigHelper.getNonUiServiceConfig(),
-                new ObjectMapper(),
+                MAPPER,
                 supplier
         )
 
@@ -55,7 +58,7 @@ class AsyncDruidWebServiceImplSpec extends Specification {
 
         AsyncDruidWebServiceImplWrapper webServiceImplWrapper = new AsyncDruidWebServiceImplWrapper(
                 DruidClientConfigHelper.getNonUiServiceConfig(),
-                new ObjectMapper(),
+                MAPPER,
                 supplier
         )
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/client/impl/HeaderNestingJsonBuilderStrategySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/client/impl/HeaderNestingJsonBuilderStrategySpec.groovy
@@ -2,12 +2,12 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.client.impl
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.client.DruidServiceConfig
-import com.fasterxml.jackson.databind.ObjectMapper
-
-import spock.lang.Specification
 
 import org.asynchttpclient.Response
+
+import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
 import java.util.function.Supplier
@@ -35,7 +35,7 @@ class HeaderNestingJsonBuilderStrategySpec extends Specification {
         druidServiceConfig.getUrl() >> "url"
         AsyncDruidWebServiceImpl asyncDruidWebServiceImplV2 = new AsyncDruidWebServiceImpl(
                 druidServiceConfig,
-                new ObjectMapper(),
+                new ObjectMappersSuite().getMapper(),
                 Mock(Supplier),
                 new HeaderNestingJsonBuilderStrategy(AsyncDruidWebServiceImpl.DEFAULT_JSON_NODE_BUILDER_STRATEGY)
         )

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/CardinalityAggregationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/aggregation/CardinalityAggregationSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.aggregation
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource
@@ -12,15 +13,13 @@ import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 
 import spock.lang.Specification
 
 class CardinalityAggregationSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     static String expectedJson = """
     { "type":"cardinality", "name":"name", "fieldNames": ["d1DruidName", "d2DruidName"], "byRow": true}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/postaggregation/SketchSetOperationPostAggregationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/postaggregation/SketchSetOperationPostAggregationSpec.groovy
@@ -2,18 +2,17 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.postaggregation
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
 import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 
 class SketchSetOperationPostAggregationSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     Aggregation agg1
     Aggregation agg2

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/postaggregation/ThetaSketchSetOperationPostAggregationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/postaggregation/ThetaSketchSetOperationPostAggregationSpec.groovy
@@ -2,18 +2,17 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.postaggregation
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
 import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 
 class ThetaSketchSetOperationPostAggregationSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     Aggregation agg1
     Aggregation agg2

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/AllGranularitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/AllGranularitySpec.groovy
@@ -2,10 +2,10 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.query
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
 
 import org.joda.time.DateTime
@@ -22,7 +22,7 @@ class AllGranularitySpec extends Specification {
 
     def "All granularity serializes to 'all'"() {
         setup:
-        ObjectWriter writer = new ObjectMapper().writer()
+        ObjectWriter writer = new ObjectMappersSuite().getMapper().writer()
 
         expect:
         writer.writeValueAsString(allGranularity) == /"all"/

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/DruidSearchQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/DruidSearchQuerySpec.groovy
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.druid.model.query
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionField
 import com.yahoo.bard.webservice.data.dimension.MapStore
@@ -18,7 +19,6 @@ import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
@@ -27,8 +27,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class DruidSearchQuerySpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     DateTimeZone currentTZ

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.druid.model.query
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 import static com.yahoo.bard.webservice.table.TableTestUtils.buildTable
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.dimension.BardDimensionField
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionColumn
@@ -33,7 +34,6 @@ import com.yahoo.bard.webservice.table.ConstrainedTable
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
@@ -44,8 +44,7 @@ import spock.lang.Specification
 import java.util.stream.Collectors
 
 class GroupByQuerySpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     DateTimeZone currentTZ

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/LookbackQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/LookbackQuerySpec.groovy
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.druid.model.query
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
 import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
 import com.yahoo.bard.webservice.druid.model.datasource.QueryDataSource
@@ -14,7 +15,6 @@ import com.yahoo.bard.webservice.util.GroovyTestUtils
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
@@ -25,8 +25,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class LookbackQuerySpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     DateTimeZone currentTZ

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/SegmentMetadataQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/SegmentMetadataQuerySpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.query
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
@@ -10,7 +11,6 @@ import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
@@ -19,8 +19,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class SegmentMetadataQuerySpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     DateTimeZone currentTZ

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeBoundaryQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeBoundaryQuerySpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.query
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
@@ -9,15 +10,13 @@ import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 
 import spock.lang.Specification
 
 class TimeBoundaryQuerySpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     def "TimeBoundaryQuery serializes to JSON correctly"() {
         given: "A Table data source"

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuerySpec.groovy
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.druid.model.query
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
 import com.yahoo.bard.webservice.druid.model.datasource.TableDataSource
 import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation
@@ -12,7 +13,6 @@ import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
@@ -21,8 +21,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class TimeSeriesQuerySpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     DateTimeZone currentTZ

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TopNQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TopNQuerySpec.groovy
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.druid.model.query
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.dimension.BardDimensionField
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionField
@@ -18,7 +19,6 @@ import com.yahoo.bard.webservice.table.TableTestUtils
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
@@ -27,8 +27,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class TopNQuerySpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     DateTimeZone currentTZ

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/DimensionToDefaultDimensionSpecSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/DimensionToDefaultDimensionSpecSpec.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.druid.serializers
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.HOUR
 import static org.joda.time.DateTimeZone.UTC
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.DruidQueryBuilder
 import com.yahoo.bard.webservice.data.PartialDataHandler
 import com.yahoo.bard.webservice.data.QueryBuildingTestingResources
@@ -35,7 +36,7 @@ class DimensionToDefaultDimensionSpecSpec extends Specification {
     DruidAggregationQuery<?> druidQuery
 
     def setup() {
-        objectMapper = new ObjectMapper()
+        objectMapper = new ObjectMappersSuite().getMapper()
         resources = new QueryBuildingTestingResources()
         DefaultPhysicalTableResolver resolver = new DefaultPhysicalTableResolver(new PartialDataHandler(), new DefaultingVolatileIntervalsService())
         builder = new DruidQueryBuilder(resources.logicalDictionary, resolver)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/DimensionToNameSerializerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/DimensionToNameSerializerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.serializers
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.dimension.Dimension
 import com.yahoo.bard.webservice.data.dimension.DimensionField
 import com.yahoo.bard.webservice.data.dimension.DimensionRow
@@ -21,7 +22,7 @@ class DimensionToNameSerializerSpec extends Specification {
     // NOTE: Dimension serialization is properly tested in GroupByQuerySpec.groovy
     def "allows implementing classes to override default serialization"() {
         setup:
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = new ObjectMappersSuite().getMapper()
 
         expect:
         // NOTE: The fact that this doesn't show an exception demonstrates that it does not hit the DimensionToNameSerializer as well

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/LookupDimensionToDimensionSpecSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/LookupDimensionToDimensionSpecSpec.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.druid.serializers
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.HOUR
 import static org.joda.time.DateTimeZone.UTC
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.DruidQueryBuilder
 import com.yahoo.bard.webservice.data.PartialDataHandler
 import com.yahoo.bard.webservice.data.QueryBuildingTestingResources
@@ -36,7 +37,7 @@ class LookupDimensionToDimensionSpecSpec extends Specification{
     DruidAggregationQuery<?> druidQuery
 
     def setup() {
-        objectMapper = new ObjectMapper()
+        objectMapper = new ObjectMappersSuite().getMapper()
         resources = new QueryBuildingTestingResources()
         resolver = new DefaultPhysicalTableResolver(new PartialDataHandler(), new DefaultingVolatileIntervalsService())
         builder = new DruidQueryBuilder(resources.logicalDictionary, resolver)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/RegisteredLookupDimensionToDimensionSpecSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/serializers/RegisteredLookupDimensionToDimensionSpecSpec.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.druid.serializers
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.HOUR
 import static org.joda.time.DateTimeZone.UTC
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.DruidQueryBuilder
 import com.yahoo.bard.webservice.data.PartialDataHandler
 import com.yahoo.bard.webservice.data.QueryBuildingTestingResources
@@ -36,7 +37,7 @@ class RegisteredLookupDimensionToDimensionSpecSpec extends Specification{
     DruidAggregationQuery<?> druidQuery
 
     def setup() {
-        objectMapper = new ObjectMapper()
+        objectMapper = new ObjectMappersSuite().getMapper()
         resources = new QueryBuildingTestingResources()
         resolver = new DefaultPhysicalTableResolver(new PartialDataHandler(), new DefaultingVolatileIntervalsService())
         builder = new DruidQueryBuilder(resources.logicalDictionary, resolver)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/TimingSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/TimingSpec.groovy
@@ -5,9 +5,10 @@ package com.yahoo.bard.webservice.logging
 import static spock.util.matcher.HamcrestMatchers.closeTo
 import static spock.util.matcher.HamcrestSupport.expect
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import ch.qos.logback.classic.spi.ILoggingEvent
 import spock.lang.Ignore
@@ -21,8 +22,7 @@ import spock.lang.Unroll
  */
 @Timeout(30)    // Fail test if hangs
 class TimingSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     String pkgString = "com.yahoo.bard.webservice.logging.blocks."

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/EpilogueSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/EpilogueSpec.groovy
@@ -4,20 +4,19 @@ package com.yahoo.bard.webservice.logging.blocks
 
 import static javax.ws.rs.core.Response.Status.OK
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.util.CacheLastObserver
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
 
+import rx.Observable
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import rx.Observable
-
-
 class EpilogueSpec extends Specification {
 
-    static final ObjectMapper JSON_SERIALIZER = new ObjectMapper()
+    static final ObjectMapper JSON_SERIALIZER = new ObjectMappersSuite().getMapper()
 
     @Unroll
     def "When the responseLengthObserver receives #messages and #errorType Epilogue serializes correctly"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/GroovyTestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/GroovyTestUtils.groovy
@@ -4,20 +4,21 @@ package com.yahoo.bard.webservice.util
 
 import static com.yahoo.bard.webservice.util.JsonSortStrategy.SORT_MAPS
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import groovy.json.JsonException
 import groovy.util.logging.Slf4j
 import spock.lang.Specification
+
 /**
  * Abstract to not run as a test suite, but sub-classes Specification so power assert works correctly
  */
 @Slf4j(value = "LOG")
 abstract class GroovyTestUtils extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     private static final JsonSlurper JSON_PARSER = new JsonSlurper()
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.web
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 import static org.joda.time.DateTimeZone.UTC
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.config.metric.MetricInstance
 import com.yahoo.bard.webservice.data.config.metric.makers.AggregationAverageMaker
 import com.yahoo.bard.webservice.data.config.metric.makers.ArithmeticMaker
@@ -36,9 +37,9 @@ import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationP
 import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier
 import com.yahoo.bard.webservice.druid.util.SketchFieldConverter
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
-import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.TableGroup
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -46,6 +47,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
 
 import spock.lang.Specification
+
 /**
  * This class is a resource container for intersection report tests.
  *
@@ -72,7 +74,7 @@ class SketchIntersectionReportingResources extends Specification {
     public ObjectMapper mapper
 
     SketchIntersectionReportingResources init() {
-        mapper = new ObjectMapper()
+        mapper = new ObjectMappersSuite().getMapper()
 
         LinkedHashSet<DimensionField> dimensionFields = new LinkedHashSet<>()
         dimensionFields.add(BardDimensionField.ID)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.web
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 import static org.joda.time.DateTimeZone.UTC
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.config.metric.MetricInstance
 import com.yahoo.bard.webservice.data.config.metric.makers.AggregationAverageMaker
 import com.yahoo.bard.webservice.data.config.metric.makers.ArithmeticMaker
@@ -37,9 +38,9 @@ import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier
 import com.yahoo.bard.webservice.druid.util.ThetaSketchFieldConverter
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.table.Column
-import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.PhysicalTable
+import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.TableGroup
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -70,7 +71,7 @@ class ThetaSketchIntersectionReportingResources extends Specification {
     public ObjectMapper mapper
 
     ThetaSketchIntersectionReportingResources init() {
-        mapper = new ObjectMapper()
+        mapper = new ObjectMappersSuite().getMapper()
 
         LinkedHashSet<DimensionField> dimensionFields = new LinkedHashSet<>()
         dimensionFields.add(BardDimensionField.ID)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.web.endpoints
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.time.GranularityParser
 import com.yahoo.bard.webservice.data.time.StandardGranularityParser
 import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
@@ -11,7 +12,6 @@ import com.yahoo.bard.webservice.util.GroovyTestUtils
 import com.yahoo.bard.webservice.util.JsonSortStrategy
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
@@ -35,8 +35,7 @@ import javax.ws.rs.core.Response
 abstract class BaseDataServletComponentSpec extends Specification {
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseDataServletComponentSpec.class)
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     private static GranularityParser granularityParser = new StandardGranularityParser()
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseTableServletComponentSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseTableServletComponentSpec.groovy
@@ -3,11 +3,11 @@
 package com.yahoo.bard.webservice.web.endpoints
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 import com.yahoo.bard.webservice.util.JsonSortStrategy
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 import spock.lang.Timeout
@@ -15,8 +15,7 @@ import spock.lang.Timeout
 @Timeout(30)
 // Fail test if hangs
 abstract class BaseTableServletComponentSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     JerseyTestBinder jtb
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DebugDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DebugDataServletSpec.groovy
@@ -3,16 +3,15 @@
 package com.yahoo.bard.webservice.web.endpoints
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 
 class DebugDataServletSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     JerseyTestBinder jtb
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTablesFullViewEndpointSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTablesFullViewEndpointSpec.groovy
@@ -2,12 +2,12 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.endpoints
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.logging.TestLogAppender
 import com.yahoo.bard.webservice.web.LoggingTestUtils
 import com.yahoo.bard.webservice.web.filters.BardLoggingFilter
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Shared
 import spock.lang.Timeout
@@ -18,8 +18,7 @@ import spock.lang.Timeout
 @Timeout(30)    // Fail test if hangs
 class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     TestLogAppender logAppender

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/exceptionmappers/LogExceptionMapperSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/exceptionmappers/LogExceptionMapperSpec.groovy
@@ -3,13 +3,13 @@
 package com.yahoo.bard.webservice.web.exceptionmappers
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.logging.TestLogAppender
 import com.yahoo.bard.webservice.web.endpoints.TestLoggingServlet
 import com.yahoo.bard.webservice.web.filters.BardLoggingFilter
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Shared
 import spock.lang.Specification
@@ -23,8 +23,7 @@ import javax.ws.rs.core.Response
 @Timeout(30)
 // Fail test if hangs
 class LogExceptionMapperSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     TestLogAppender logAppender

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/LogFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/LogFilterSpec.groovy
@@ -3,12 +3,12 @@
 package com.yahoo.bard.webservice.web.filters
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.logging.TestLogAppender
 import com.yahoo.bard.webservice.web.LoggingTestUtils
 import com.yahoo.bard.webservice.web.endpoints.TestFilterServlet
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Shared
 import spock.lang.Specification
@@ -23,8 +23,7 @@ import javax.ws.rs.core.Response
 @Timeout(30)
 // Fail test if hangs
 class LogFilterSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     @Shared
     TestLogAppender logAppender

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheRequestHandlerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.handlers
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.cache.DataCache
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.druid.model.query.TimeSeriesQuery
@@ -16,7 +17,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 
@@ -42,7 +42,7 @@ class CacheRequestHandlerSpec extends Specification {
     ContainerRequestContext containerRequestContext
     RequestContext requestContext
 
-    ObjectMapper mapper = new ObjectMapper().registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    ObjectMapper mapper = new ObjectMappersSuite().getMapper()
 
     def setup() {
         handler = new CacheRequestHandler(next, dataCache, mapper)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandlerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.handlers
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.cache.MemTupleDataCache
 import com.yahoo.bard.webservice.data.cache.TupleDataCache
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
@@ -19,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 
@@ -46,7 +46,7 @@ class CacheV2RequestHandlerSpec extends Specification {
     RequestContext requestContext
     QuerySigningService<Long> querySigningService
 
-    ObjectMapper mapper = new ObjectMapper().registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    ObjectMapper mapper = new ObjectMappersSuite().getMapper()
 
     def setup() {
         querySigningService = Mock(SegmentIntervalsHashIdGenerator)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/RequestHandlerUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/RequestHandlerUtilsSpec.groovy
@@ -2,15 +2,14 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.handlers
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.util.GroovyTestUtils
-import com.yahoo.bard.webservice.util.JsonSlurper
 import com.yahoo.bard.webservice.web.RequestUtils
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -19,8 +18,7 @@ import javax.ws.rs.ProcessingException
 import javax.ws.rs.core.Response
 
 class RequestHandlerUtilsSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     ObjectWriter writer = MAPPER.writer()
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WebServiceSelectorRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WebServiceSelectorRequestHandlerSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.handlers
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.client.DruidServiceConfig
 import com.yahoo.bard.webservice.druid.client.DruidWebService
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
@@ -11,7 +12,6 @@ import com.yahoo.bard.webservice.web.DataApiRequestTypeIdentifier
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -26,7 +26,7 @@ class WebServiceSelectorRequestHandlerSpec extends Specification {
     DruidWebService nonUiWebService = Mock(DruidWebService)
     DataRequestHandler uiWebServiceNext = Mock(DataRequestHandler)
     DataRequestHandler nonUiWebServiceNext = Mock(DataRequestHandler)
-    ObjectMapper mapper = new ObjectMapper().registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    ObjectMapper mapper = new ObjectMappersSuite().getMapper()
     GroupByQuery groupByQuery = Mock(GroupByQuery)
     GroupByQuery modifiedGroupByQuery = Mock(GroupByQuery)
     RequestContext rc

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandlerSpec.groovy
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.web.handlers
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.client.DruidWebService
 import com.yahoo.bard.webservice.druid.client.FailureCallback
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback
@@ -22,13 +23,11 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 
 class WeightCheckRequestHandlerSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     DataRequestHandler next
     DruidWebService webService
@@ -202,7 +201,7 @@ class WeightCheckRequestHandlerSpec extends Specification {
                 next,
                 webService,
                 queryWeightUtil,
-                new ObjectMapper().registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+                mapper
         )
         int expectedCount = 200
         int limit = 100
@@ -235,7 +234,7 @@ class WeightCheckRequestHandlerSpec extends Specification {
                 next,
                 webService,
                 queryWeightUtil,
-                new ObjectMapper()
+                mapper
         )
         int expectedCount = 200
         int limit = 100

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/workflow/DruidWorkflowSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/workflow/DruidWorkflowSpec.groovy
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.web.handlers.workflow
 
 import static com.yahoo.bard.webservice.config.BardFeatureFlag.QUERY_SPLIT
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.config.SystemConfig
 import com.yahoo.bard.webservice.config.SystemConfigProvider
 import com.yahoo.bard.webservice.data.PartialDataHandler
@@ -28,13 +29,11 @@ import com.yahoo.bard.webservice.web.handlers.WeightCheckRequestHandler
 import com.yahoo.bard.webservice.web.util.QueryWeightUtil
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import spock.lang.Specification
 
 class DruidWorkflowSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
     private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance()
     private static final String TTL_CACHE_CONFIG_KEY = SYSTEM_CONFIG.getPackageVariableName("druid_cache_enabled")
     private static final String LOCAL_SIGNATURE_CACHE_CONFIG_KEY = SYSTEM_CONFIG.getPackageVariableName("druid_cache_v2_enabled")

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CacheV2ResponseProcessorSpec.groovy
@@ -6,6 +6,7 @@ import static com.yahoo.bard.webservice.async.ResponseContextUtils.createRespons
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.MISSING_INTERVALS_CONTEXT_KEY
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.VOLATILE_INTERVALS_CONTEXT_KEY
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.config.SystemConfig
 import com.yahoo.bard.webservice.config.SystemConfigProvider
 import com.yahoo.bard.webservice.data.cache.TupleDataCache
@@ -21,7 +22,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.Interval
 
@@ -30,8 +30,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class CacheV2ResponseProcessorSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.instance
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CachingResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/CachingResponseProcessorSpec.groovy
@@ -6,6 +6,7 @@ import static com.yahoo.bard.webservice.async.ResponseContextUtils.createRespons
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.MISSING_INTERVALS_CONTEXT_KEY
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.VOLATILE_INTERVALS_CONTEXT_KEY
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.config.SystemConfig
 import com.yahoo.bard.webservice.config.SystemConfigProvider
 import com.yahoo.bard.webservice.data.cache.DataCache
@@ -20,7 +21,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.Interval
 
@@ -29,8 +29,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 class CachingResponseProcessorSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.instance
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/DruidPartialDataResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/DruidPartialDataResponseProcessorSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.responseprocessors
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback
 import com.yahoo.bard.webservice.druid.model.datasource.DataSource
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery
@@ -13,7 +14,6 @@ import com.yahoo.bard.webservice.web.ErrorMessageFormat
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.Interval
 
@@ -22,8 +22,7 @@ import spock.lang.Specification
 import java.util.stream.Collectors
 
 class DruidPartialDataResponseProcessorSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
     private static final int ERROR_STATUS_CODE = 500
     private static final String REASON_PHRASE = 'The server encountered an unexpected condition which ' +
             'prevented it from fulfilling the request.'

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/EtagCacheResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/EtagCacheResponseProcessorSpec.groovy
@@ -6,6 +6,7 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR
 import static javax.ws.rs.core.Response.Status.NOT_MODIFIED
 import static javax.ws.rs.core.Response.Status.OK
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.cache.TupleDataCache
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery
@@ -13,15 +14,11 @@ import com.yahoo.bard.webservice.web.ErrorMessageFormat
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
-
-import org.slf4j.Logger
 
 import spock.lang.Specification
 
 class EtagCacheResponseProcessorSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
     private static final int INTERNAL_SERVER_ERROR_STATUS_CODE = INTERNAL_SERVER_ERROR.getStatusCode()
     private static final String CACHE_KEY = "cacheKey"
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorSpec.groovy
@@ -56,8 +56,7 @@ class ResultSetResponseProcessorSpec extends Specification {
 
     private static final ObjectMappersSuite MAPPERS = new ObjectMappersSuite()
 
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = MAPPERS.getMapper()
 
     HttpResponseMaker httpResponseMaker
     GroupByQuery groupByQuery

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/SplitQueryResponseProcessorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/responseprocessors/SplitQueryResponseProcessorSpec.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.responseprocessors
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.data.cache.HashDataCache.Pair
 import com.yahoo.bard.webservice.druid.client.FailureCallback
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback
@@ -11,7 +12,6 @@ import com.yahoo.bard.webservice.web.DataApiRequest
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
@@ -21,8 +21,7 @@ import spock.lang.Specification
 import java.util.concurrent.atomic.AtomicInteger
 
 public class SplitQueryResponseProcessorSpec extends Specification {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new Jdk8Module().configureAbsentsAsNulls(false))
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     SplitQueryResponseProcessor sqrp
     DataApiRequest apiRequest = Mock(DataApiRequest)

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/models/druid/client/impl/TestDruidWebService.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/models/druid/client/impl/TestDruidWebService.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.models.druid.client.impl;
 
+import com.yahoo.bard.webservice.application.ObjectMappersSuite;
 import com.yahoo.bard.webservice.druid.client.DruidServiceConfig;
 import com.yahoo.bard.webservice.druid.client.DruidWebService;
 import com.yahoo.bard.webservice.druid.client.FailureCallback;
@@ -17,7 +18,6 @@ import com.yahoo.bard.webservice.web.handlers.RequestContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
 import org.asynchttpclient.Response;
@@ -40,9 +40,8 @@ public class TestDruidWebService implements DruidWebService {
 
     public static String DEFAULT_NAME = "unnamed";
 
-    private static ObjectMapper mapper = new ObjectMapper().registerModule(
-            new Jdk8Module().configureAbsentsAsNulls(false)
-    );
+    private static ObjectMapper mapper = new ObjectMappersSuite().getMapper();
+
     private static ObjectWriter writer = mapper.writer();
 
     public Producer<String> jsonResponse = () -> "[]";

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/MultipleDatasourceDruidConfigLoaderSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/MultipleDatasourceDruidConfigLoaderSpec.groovy
@@ -1,9 +1,12 @@
 package com.yahoo.wiki.webservice.web.endpoints
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
 import com.yahoo.wiki.webservice.data.config.auto.DataSourceConfiguration
 import com.yahoo.wiki.webservice.data.config.auto.DruidNavigator
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
 import spock.lang.Specification
 
 class MultipleDatasourceDruidConfigLoaderSpec extends Specification {
@@ -12,6 +15,7 @@ class MultipleDatasourceDruidConfigLoaderSpec extends Specification {
     private String[] table1_dimensions = ["1_dim1", "1_dim2"]
     private String[] table2_metrics = ["2_metric1", "2_metric2"]
     private String[] table2_dimensions = ["2_dim1", "2_dim2"]
+    private static final ObjectMapper MAPPER = new ObjectMappersSuite().getMapper()
 
     private TestDruidWebService druidWebService
 
@@ -19,7 +23,7 @@ class MultipleDatasourceDruidConfigLoaderSpec extends Specification {
         druidWebService = new TestDruidWebService("testInstance")
         druidWebService.jsonResponse = {
             if (druidWebService.lastUrl.equals("/datasources/")) {
-                return new ObjectMapper().writeValueAsString(datasources)
+                return MAPPER.writeValueAsString(datasources)
             } else if (druidWebService.lastUrl.equals("/datasources/table1/?full")) {
                 return getFullTable(datasources[0], table1_metrics, table1_dimensions)
             } else if (druidWebService.lastUrl.equals("/datasources/table2/?full")) {

--- a/fili-navi/src/test/groovy/com/yahoo/bard/webservice/data/dimension/TaggedDimensionFieldSpec.groovy
+++ b/fili-navi/src/test/groovy/com/yahoo/bard/webservice/data/dimension/TaggedDimensionFieldSpec.groovy
@@ -1,9 +1,11 @@
 package com.yahoo.bard.webservice.data.dimension
 
-import static com.yahoo.bard.webservice.data.dimension.TestTaggedDimensionField.TEST_TWO_TAG
-import static com.yahoo.bard.webservice.data.dimension.TestTaggedDimensionField.TEST_ONE_TAG
 import static com.yahoo.bard.webservice.data.dimension.TestTaggedDimensionField.TEST_NO_TAG
+import static com.yahoo.bard.webservice.data.dimension.TestTaggedDimensionField.TEST_ONE_TAG
+import static com.yahoo.bard.webservice.data.dimension.TestTaggedDimensionField.TEST_TWO_TAG
 import static com.yahoo.bard.webservice.data.dimension.impl.DefaultDimensionFieldTag.PRIMARY_KEY
+
+import com.yahoo.bard.webservice.application.ObjectMappersSuite
 
 import com.fasterxml.jackson.databind.ObjectMapper
 
@@ -21,7 +23,7 @@ class TaggedDimensionFieldSpec extends Specification {
     TaggedDimensionField twoTagField
 
     def setup() {
-        objectMapper = new ObjectMapper()
+        objectMapper = new ObjectMappersSuite().getMapper()
 
         mockTag = Mock(Tag)
         mockTag.getName() >> "mockTag"


### PR DESCRIPTION
Tests should use the same configuration for ObjectMappers as the core code.

IntelliJ also optimized imports as I went through these classes