### PR TITLE
Fixing the performance problems around feature flags by making them c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ Current
 
 ### Fixed:
 
+- [Fix performance bug around feature flag](https://github.com/yahoo/fili/issues/473)
+    * BardFeatureFlag, when used in a tight loop, is very expensive.  Underlying map configuration copies the config map on each access.
+    * Switching to lazy value evaluation
+    * Added reset contract so changes to feature flags can be directly reverted rather than going through the `SystemConfig` directly
+
 - [Fix deploy branch issue where substrings of whitelisted branches could be released](https://github.com/yahoo/fili/issues/453)
 
 - [Fix availability testing utils to be compatible with composite tables](https://github.com/yahoo/fili/pull/419)
@@ -68,11 +73,6 @@ Current
 
 - [Fix metric and dimension names for wikipedia-example](https://github.com/yahoo/fili/pull/415)
     * The metrics and dimensions configured in the `fili-wikipedia-example` were different from those in Druid and as a result the queries sent to Druid were incorrect
-
-- [Fix performance bug around feature flag](https://github.com/yahoo/fili/issues/473)
-    * BardFeatureFlag, when used in a tight loop, is very expensive.  Underlying map configuration copies the config map on each access.
-    * Switching to lazy value evaluation
-    * Added reset contract so changes to feature flags can be directly reverted rather than going through the `SystemConfig` directly
 
 
 ### Known Issues:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ Current
 - [Fix metric and dimension names for wikipedia-example](https://github.com/yahoo/fili/pull/415)
     * The metrics and dimensions configured in the `fili-wikipedia-example` were different from those in Druid and as a result the queries sent to Druid were incorrect
 
+- [Fix performance bug around feature flag](https://github.com/yahoo/fili/issues/473)
+    * BardFeatureFlag, when used in a tight loop, is very expensive.  Underlying map configuration copies the config map on each access.
+    * Switching to lazy value evaluation
+    * Added reset contract so changes to feature flags can be directly reverted rather than going through the `SystemConfig` directly
+
 
 ### Known Issues:
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
@@ -48,8 +48,7 @@ public enum BardFeatureFlag implements FeatureFlag {
     @Override
     public void setOn(Boolean newValue) {
         SYSTEM_CONFIG.setProperty(SYSTEM_CONFIG.getPackageVariableName(propertyName), newValue.toString());
-        on = null;
-        isOn();
+        on = newValue;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
@@ -21,8 +21,7 @@ public enum BardFeatureFlag implements FeatureFlag {
     static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
 
     private final String propertyName;
-    private Boolean isOn = null;
-
+    
     /**
      * Constructor.
      *
@@ -39,22 +38,22 @@ public enum BardFeatureFlag implements FeatureFlag {
 
     @Override
     public boolean isOn() {
-        if (isOn == null) {
-            isOn = SYSTEM_CONFIG.getBooleanProperty(SYSTEM_CONFIG.getPackageVariableName(propertyName), false);
+        if (on == null) {
+            on = SYSTEM_CONFIG.getBooleanProperty(SYSTEM_CONFIG.getPackageVariableName(propertyName), false);
         }
-        return isOn;
+        return on;
     }
 
     @Override
     public void setOn(Boolean newValue) {
         SYSTEM_CONFIG.setProperty(SYSTEM_CONFIG.getPackageVariableName(propertyName), newValue.toString());
-        isOn = null;
+        on = null;
         isOn();
     }
 
     @Override
     public void reset() {
         SYSTEM_CONFIG.clearProperty(SYSTEM_CONFIG.getPackageVariableName(propertyName));
-        isOn = null;
+        on = null;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
@@ -21,7 +21,8 @@ public enum BardFeatureFlag implements FeatureFlag {
     static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
 
     private final String propertyName;
-    
+    private Boolean on = null;
+
     /**
      * Constructor.
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
@@ -21,6 +21,7 @@ public enum BardFeatureFlag implements FeatureFlag {
     static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
 
     private final String propertyName;
+    private Boolean isOn = null;
 
     /**
      * Constructor.
@@ -38,11 +39,22 @@ public enum BardFeatureFlag implements FeatureFlag {
 
     @Override
     public boolean isOn() {
-        return SYSTEM_CONFIG.getBooleanProperty(SYSTEM_CONFIG.getPackageVariableName(propertyName), false);
+        if (isOn == null) {
+            isOn = SYSTEM_CONFIG.getBooleanProperty(SYSTEM_CONFIG.getPackageVariableName(propertyName), false);
+        }
+        return isOn;
     }
 
     @Override
     public void setOn(Boolean newValue) {
         SYSTEM_CONFIG.setProperty(SYSTEM_CONFIG.getPackageVariableName(propertyName), newValue.toString());
+        isOn = null;
+        isOn();
+    }
+
+    @Override
+    public void reset() {
+        SYSTEM_CONFIG.clearProperty(SYSTEM_CONFIG.getPackageVariableName(propertyName));
+        isOn = null;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/config/CacheFeatureFlag.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/config/CacheFeatureFlag.java
@@ -30,7 +30,6 @@ public enum CacheFeatureFlag implements FeatureFlag {
     private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
 
     private final String value;
-    Boolean on = null;
 
     /**
      * Constructor.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/config/CacheFeatureFlag.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/config/CacheFeatureFlag.java
@@ -30,6 +30,7 @@ public enum CacheFeatureFlag implements FeatureFlag {
     private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
 
     private final String value;
+    Boolean on = null;
 
     /**
      * Constructor.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/config/FeatureFlag.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/config/FeatureFlag.java
@@ -51,4 +51,9 @@ public interface FeatureFlag {
      * @param newValue  The new status of the feature flag.
      */
     void setOn(Boolean newValue);
+
+    /**
+     * Restores the feature flag to the startup state (if supported by the underlying conf mechanism).
+     */
+    void reset();
 }


### PR DESCRIPTION
…ache.

The performance on these objects is terrible because the entire underlying config map gets copied on access.  This protects against that problem.