### PR TITLE
Move avroDimensionRowParsing to a stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,8 @@ Current
 
 ### Changed:
 
-- [Make AvroDimensionRowParser.parseAvroFileDimensionRows return a stream instead of a Set](https://github.com/yahoo/fili/issues/483)
-    * In order to do deferred file reading, the stream must be closed to ensure that the file is closed.
+- [Make AvroDimensionRowParser.parseAvroFileDimensionRows support consumer model](https://github.com/yahoo/fili/issues/483)
+    * In order to do deferred/buffered file reading, create a call back style method.
 
 - [Make HttpResponseMaker injectable and change functions signature related to custom response creation](https://github.com/yahoo/fili/pull/447)
     * Make `HttpResponseMaker` injectable. `DataServlet` and `JobsServlet` takes `HttpResponseMaker` as input parameter now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Current
 
 ### Changed:
 
+- [Make AvroDimensionRowParser.parseAvroFileDimensionRows return a stream instead of a Set](https://github.com/yahoo/fili/issues/483)
+    * In order to do deferred file reading, the stream must be closed to ensure that the file is closed.
+
 - [Make HttpResponseMaker injectable and change functions signature related to custom response creation](https://github.com/yahoo/fili/pull/447)
     * Make `HttpResponseMaker` injectable. `DataServlet` and `JobsServlet` takes `HttpResponseMaker` as input parameter now
     * Add `ApiRequest` to `BuildResponse`, `HttpReponseChannel` and `createResponseBuilder` to enable passing information needed by customizable serialization

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParser.java
@@ -107,7 +107,7 @@ public class AvroDimensionRowParser {
     }
 
     /**
-     * Returns a stream which parses avro records into dimension rows
+     * Returns a stream which parses avro records into dimension rows.
      *
      * @param dataFileReader  An open file reader for avro records
      * @param dimension  The dimension object used to configure the dimension
@@ -135,7 +135,7 @@ public class AvroDimensionRowParser {
     }
 
     /**
-     * Parses the avro file and sends dimension rows to a consumer
+     * Parses the avro file and sends dimension rows to a consumer.
      *
      * @param dimension  The dimension object used to configure the dimension
      * @param avroFilePath  The path of the AVRO data file (.avro)
@@ -160,7 +160,7 @@ public class AvroDimensionRowParser {
     }
 
     /**
-     * Parses the avro file and returns the dimension rows
+     * Parses the avro file and returns the dimension rows.
      *
      * @param dimension The dimension object used to configure the dimension
      * @param avroFilePath The path of the AVRO data file (.avro)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParser.java
@@ -123,7 +123,10 @@ public class AvroDimensionRowParser {
             Runnable fileCloser = () -> {
                 try {
                     dataFileReader.close();
-                } catch (IOException ignore) {
+                } catch (IOException e) {
+                    String msg = String.format("Error closing avro file, at the location %s", avroFilePath);
+                    LOG.error(msg, e);
+                    throw new IllegalArgumentException(msg, e);
                 }
             };
             // Generates a set of dimension Rows after retrieving the appropriate fields

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParser.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -129,24 +128,10 @@ public class AvroDimensionRowParser {
             LOG.error(msg);
             throw new IllegalArgumentException(msg);
         }
-        Function<GenericRecord, Map<String, String>> recordMapFunction =
-                genericRecord -> {
-                    try {
-                        return recordToMap(genericRecord, dimension);
-                    } catch (RuntimeException unknown) {
-                        try {
-                            dataFileReader.close();
-                        } catch (IOException warn) {
-                            String msg = String.format("Error closing avro file, at the location %s", avroFilePath);
-                            LOG.warn(msg, warn);
-                        }
-                        throw unknown;
-                    }
-                };
 
         // Generates a set of dimension Rows after retrieving the appropriate fields
         return StreamSupport.stream(dataFileReader.spliterator(), false)
-                .map(recordMapFunction)
+                .map(record -> recordToMap(record, dimension))
                 .map(dimension::parseDimensionRow);
 
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParserSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/AvroDimensionRowParserSpec.groovy
@@ -2,7 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.dimension
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
 import com.yahoo.bard.webservice.data.dimension.impl.ScanSearchProviderManager
 
@@ -10,6 +9,7 @@ import org.apache.avro.generic.GenericRecord
 
 import spock.lang.Specification
 
+import java.util.stream.Collectors
 
 class AvroDimensionRowParserSpec extends Specification {
     LinkedHashSet<DimensionField> dimensionFields
@@ -29,7 +29,8 @@ class AvroDimensionRowParserSpec extends Specification {
         Set<DimensionRow> dimSet = [dimensionRow1, dimensionRow2] as Set
 
         expect:
-        avroDimensionRowParser.parseAvroFileDimensionRows(dimension, "target/avro/avroFilesTesting/sampleData.avro") == dimSet
+        avroDimensionRowParser.parseAvroFileDimensionRows(dimension, "target/avro/avroFilesTesting/sampleData.avro")
+            .collect(Collectors.toSet())== dimSet
     }
 
     def "Schema file does not contain all the dimension fields throws an IllegalArgumentException"() {
@@ -37,7 +38,8 @@ class AvroDimensionRowParserSpec extends Specification {
         dimensionFields.add(BardDimensionField.FIELD1)
 
         when:
-        avroDimensionRowParser.parseAvroFileDimensionRows(dimension, "target/avro/avroFilesTesting/sampleData.avro")
+        avroDimensionRowParser.parseAvroFileDimensionRows(dimension, "target/avro/avroFilesTesting/sampleData.avro").
+                collect(Collectors.toSet())
 
         then:
         IllegalArgumentException exception = thrown(IllegalArgumentException)


### PR DESCRIPTION
Performance from pulling the entire file into memory is pretty unacceptable.  This change makes the caller responsible for pulling the values off the stream and expects the stream to get closed to notify the file to close.