### PR TITLE
Fix datasource name and physical table name mismatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ Current
 
 ### Fixed:
 
+- [Fix datasource name physical table name mismatch in VolatileDataRequestHandler](https://github.com/yahoo/fili/issues/505)
+    * Fix fetching from `physicaltableDictionary` using datasource name. Now use proper physical table name instead.
+
 - [Fix performance bug around feature flag](https://github.com/yahoo/fili/issues/473)
     * BardFeatureFlag, when used in a tight loop, is very expensive.  Underlying map configuration copies the config map on each access.
     * Switching to lazy value evaluation

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/VolatileDataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/VolatileDataRequestHandler.java
@@ -57,15 +57,17 @@ public class VolatileDataRequestHandler implements DataRequestHandler {
         MappingResponseProcessor mappingResponse = (MappingResponseProcessor) response;
 
         // Gather the volatile intervals. A volatile interval in one data source make that interval volatile overall.
-        SimplifiedIntervalList volatileIntervals = druidQuery.getInnermostQuery().getDataSource().getNames().stream()
-                .map(physicalTableDictionary::get)
-                .map(table -> volatileIntervalsService.getVolatileIntervals(
-                             druidQuery.getGranularity(),
-                             druidQuery.getIntervals(),
-                             table
-                ))
-                .flatMap(SimplifiedIntervalList::stream)
-                .collect(SimplifiedIntervalList.getCollector());
+        SimplifiedIntervalList volatileIntervals = volatileIntervalsService.getVolatileIntervals(
+                druidQuery.getGranularity(),
+                druidQuery.getIntervals(),
+                physicalTableDictionary.get(
+                        druidQuery
+                                .getInnermostQuery()
+                                .getDataSource()
+                                .getPhysicalTable()
+                                .getName()
+                )
+        );
 
         if (!volatileIntervals.isEmpty()) {
             ResponseContext responseContext = response.getResponseContext();


### PR DESCRIPTION
This PR fixes the use of datasource name querying `physicalTableDictionary` which use physical table name as key in `VolatileDataRequestHandler`. 