### PR TITLE
Remove the druid_coordinator_metadata feature flag.

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -2,7 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.application;
 
-import static com.yahoo.bard.webservice.config.BardFeatureFlag.DRUID_COORDINATOR_METADATA;
 import static com.yahoo.bard.webservice.config.BardFeatureFlag.DRUID_DIMENSIONS_LOADER;
 import static com.yahoo.bard.webservice.web.handlers.CacheRequestHandler.CACHE_HITS;
 import static com.yahoo.bard.webservice.web.handlers.CacheRequestHandler.CACHE_REQUESTS;
@@ -115,8 +114,6 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import rx.subjects.PublishSubject;
-
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Constructor;
@@ -136,6 +133,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.validation.constraints.NotNull;
+
+import rx.subjects.PublishSubject;
 
 /**
  *   Abstract Binder factory implements the standard buildBinder functionality.
@@ -227,11 +226,8 @@ public abstract class AbstractBinderFactory implements BinderFactory {
                 bind(nonUiDruidWebService).named("nonUiDruidWebService").to(DruidWebService.class);
 
                 // A separate web service for metadata
-                DruidWebService metadataDruidWebService = null;
-                if (DRUID_COORDINATOR_METADATA.isOn()) {
-                    metadataDruidWebService = buildMetadataDruidWebService(getMappers().getMapper());
-                    bind(metadataDruidWebService).named("metadataDruidWebService").to(DruidWebService.class);
-                }
+                DruidWebService metadataDruidWebService = buildMetadataDruidWebService(getMappers().getMapper());
+                bind(metadataDruidWebService).named("metadataDruidWebService").to(DruidWebService.class);
 
                 // Bind the timeGrain provider
                 bind(getGranularityDictionary()).to(GranularityDictionary.class);
@@ -286,16 +282,14 @@ public abstract class AbstractBinderFactory implements BinderFactory {
                         dataSourceMetadataService
                 );
 
-                if (DRUID_COORDINATOR_METADATA.isOn()) {
-                    DataSourceMetadataLoadTask dataSourceMetadataLoader = buildDataSourceMetadataLoader(
-                            metadataDruidWebService,
-                            loader.getPhysicalTableDictionary(),
-                            dataSourceMetadataService,
-                            getMappers().getMapper()
-                    );
+                DataSourceMetadataLoadTask dataSourceMetadataLoader = buildDataSourceMetadataLoader(
+                        metadataDruidWebService,
+                        loader.getPhysicalTableDictionary(),
+                        dataSourceMetadataService,
+                        getMappers().getMapper()
+                );
 
-                    setupDataSourceMetaData(healthCheckRegistry, dataSourceMetadataLoader);
-                }
+                setupDataSourceMetaData(healthCheckRegistry, dataSourceMetadataLoader);
 
                 bind(querySigningService).to(QuerySigningService.class);
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/config/BardFeatureFlag.java
@@ -14,7 +14,6 @@ public enum BardFeatureFlag implements FeatureFlag {
     DATA_FILTER_SUBSTRING_OPERATIONS("data_filter_substring_operations_enabled"),
     INTERSECTION_REPORTING("intersection_reporting_enabled"),
     UPDATED_METADATA_COLLECTION_NAMES("updated_metadata_collection_names_enabled"),
-    DRUID_COORDINATOR_METADATA("druid_coordinator_metadata_enabled"),
     DRUID_DIMENSIONS_LOADER("druid_dimensions_loader_enabled"),
     CASE_SENSITIVE_KEYS("case_sensitive_keys_enabled");
 

--- a/fili-core/src/main/resources/moduleConfig.properties
+++ b/fili-core/src/main/resources/moduleConfig.properties
@@ -89,10 +89,6 @@ bard__default_per_page = 10000
 bard__druid_broker = [SET ME IN APPLICATION CONFIG]
 bard__druid_coord = [SET ME IN APPLICATION CONFIG]
 
-# Flag to enable usage of metadata supplied by the druid coordinator
-# It requires coordinator URL to be set (see setting druid_coord)
-bard__druid_coordinator_metadata_enabled = true
-
 # Disabling the druid dimension loader by default
 # When set to true you will also need to populate the list of dimensions using druid_dim_loader_dimensions
 bard__druid_dimensions_loader_enabled = false

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/application/AbstractBinderFactorySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/application/AbstractBinderFactorySpec.groovy
@@ -8,7 +8,6 @@ import static com.yahoo.bard.webservice.application.AbstractBinderFactory.HEALTH
 import static com.yahoo.bard.webservice.application.AbstractBinderFactory.HEALTH_CHECK_VERSION
 import static com.yahoo.bard.webservice.config.BardFeatureFlag.DRUID_CACHE
 import static com.yahoo.bard.webservice.config.BardFeatureFlag.DRUID_CACHE_V2
-import static com.yahoo.bard.webservice.config.BardFeatureFlag.DRUID_COORDINATOR_METADATA
 import static com.yahoo.bard.webservice.config.BardFeatureFlag.PARTIAL_DATA
 import static com.yahoo.bard.webservice.data.config.names.TestApiDimensionName.COLOR
 import static com.yahoo.bard.webservice.data.config.names.TestApiDimensionName.SHAPE
@@ -70,7 +69,6 @@ public class AbstractBinderFactorySpec extends Specification {
     @Shared boolean partialDataStatus = PARTIAL_DATA.isOn()
     @Shared boolean cacheStatus = DRUID_CACHE.isOn()
     @Shared boolean cacheV2Status = DRUID_CACHE_V2.isOn()
-    @Shared boolean coordinatorStatus = DRUID_COORDINATOR_METADATA.isOn()
 
     String oldUiURL
     String oldNonUiURL
@@ -85,7 +83,6 @@ public class AbstractBinderFactorySpec extends Specification {
      */
     def setup() {
         DRUID_CACHE.setOn(false)
-        DRUID_COORDINATOR_METADATA.setOn(true)
         try {
             oldUiURL = systemConfig.getStringProperty(UI_DRUID_BROKER_URL_KEY)
         } catch (SystemConfigException e) {
@@ -121,7 +118,6 @@ public class AbstractBinderFactorySpec extends Specification {
     def cleanup() {
         systemConfig.clearProperty(DIMENSION_BACKEND_KEY)
         PARTIAL_DATA.setOn(partialDataStatus)
-        DRUID_COORDINATOR_METADATA.setOn(coordinatorStatus)
         DRUID_CACHE.setOn(cacheStatus)
         DRUID_CACHE_V2.setOn(cacheV2Status)
         propertyRestore(UI_DRUID_BROKER_URL_KEY, oldUiURL)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/application/healthchecks/DataSourceMetadataLoadTaskHealthCheckSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/application/healthchecks/DataSourceMetadataLoadTaskHealthCheckSpec.groovy
@@ -2,7 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.application.healthchecks
 
-import static com.yahoo.bard.webservice.config.BardFeatureFlag.DRUID_COORDINATOR_METADATA
 
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataLoadTask
 
@@ -29,18 +28,6 @@ class DataSourceMetadataLoadTaskHealthCheckSpec extends Specification {
         DataSourceMetadataLoadTask loader = Mock(DataSourceMetadataLoadTask.class)
         loader.getLastRunTimestamp() >> { return DateTime.now().minus(timeToSubtract)}
         new DataSourceMetadataLoaderHealthCheck(loader, window)
-    }
-
-
-    @Shared boolean coordinatorStatus
-
-    def setupSpec() {
-        coordinatorStatus = DRUID_COORDINATOR_METADATA.isOn();
-        DRUID_COORDINATOR_METADATA.setOn(true)
-    }
-
-    def cleanupSpec() {
-        DRUID_COORDINATOR_METADATA.setOn(coordinatorStatus)
     }
 
     @Unroll

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/config/FeatureFlagRegistrySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/config/FeatureFlagRegistrySpec.groovy
@@ -37,7 +37,7 @@ class FeatureFlagRegistrySpec extends Specification {
         then:
         values == ["partial_data_enabled", "druid_cache_enabled", "druid_cache_v2_enabled", "query_split_enabled",
                    "top_n_enabled", "data_filter_substring_operations_enabled", "intersection_reporting_enabled",
-                   "updated_metadata_collection_names_enabled", "druid_coordinator_metadata_enabled",
+                   "updated_metadata_collection_names_enabled",
                    "druid_dimensions_loader_enabled", "case_sensitive_keys_enabled"] as Set
     }
 
@@ -49,7 +49,7 @@ class FeatureFlagRegistrySpec extends Specification {
         where:
         flagName << ["partial_data_enabled", "druid_cache_enabled", "druid_cache_v2_enabled", "query_split_enabled",
                      "top_n_enabled", "data_filter_substring_operations_enabled", "intersection_reporting_enabled",
-                     "updated_metadata_collection_names_enabled", "druid_coordinator_metadata_enabled",
+                     "updated_metadata_collection_names_enabled",
                      "druid_dimensions_loader_enabled", "case_sensitive_keys_enabled"]
     }
 }

--- a/fili-core/src/test/resources/testApplicationConfig.properties
+++ b/fili-core/src/test/resources/testApplicationConfig.properties
@@ -14,10 +14,6 @@ bard__ui_druid_broker = http://ui-broker
 bard__non_ui_druid_broker = http://nonui-broker
 bard__druid_coord = http://coordinator
 
-# Flag to enable usage of metadata supplied by the druid coordinator
-# It requires coordinator URL to be set (see setting druid_coord)
-bard__druid_coordinator_metadata_enabled = false
-
 # Disabling the druid dimension loader by default
 # When set to true you will also need to populate the list of dimensions using druid_dim_loader_dimensions
 bard__druid_dimensions_loader_enabled = false

--- a/fili-generic-example/src/main/resources/applicationConfig.properties
+++ b/fili-generic-example/src/main/resources/applicationConfig.properties
@@ -36,10 +36,6 @@ bard__dimension_backend=memory
 # 4. NoCache
 bard__query_response_caching_strategy = NoCache
 
-# Flag to enable usage of metadata supplied by the druid coordinator
-# It requires coordinator URL (bard__druid_coord) to be set
-bard__druid_coordinator_metadata_enabled = true
-
 # Lucene index files path
 bard__lucene_index_path=/home/y/var/
 

--- a/fili-generic-example/src/test/resources/userConfig.properties.sample
+++ b/fili-generic-example/src/test/resources/userConfig.properties.sample
@@ -22,7 +22,5 @@ bard__dimension_backend = memory
 # 4. NoCache
 bard__query_response_caching_strategy = LocalSignature
 
-bard__druid_coordinator_metadata_enabled = true
-
 # Default the timeout to 10 minutes, in milliseconds
 bard__druid_request_timeout = 600000

--- a/fili-sql/src/main/resources/moduleConfig.properties
+++ b/fili-sql/src/main/resources/moduleConfig.properties
@@ -8,8 +8,6 @@ moduleDependencies = fili-core
 
 #This tells the dimension loader to start querying and loading values into the dimension cache.
 bard__druid_dimensions_loader_enabled = true
-#This tells fili to load metadata directly from the druid coordinator which will fail if fili is only backed by sql data
-bard__druid_coordinator_metadata_enabled = false
 
 # Add support for SQL backend
 bard__database_url = [SET ME IN APPLICATION CONFIG]

--- a/fili-wikipedia-example/src/main/resources/applicationConfig.properties
+++ b/fili-wikipedia-example/src/main/resources/applicationConfig.properties
@@ -34,10 +34,6 @@ bard__dimension_backend=memory
 # 4. NoCache
 bard__query_response_caching_strategy = NoCache
 
-# Flag to enable usage of metadata supplied by the druid coordinator
-# It requires coordinator URL (bard__druid_coord) to be set
-bard__druid_coordinator_metadata_enabled = true
-
 # Lucene index files path
 bard__lucene_index_path=/home/y/var/
 

--- a/fili-wikipedia-example/src/test/resources/userConfig.properties.sample
+++ b/fili-wikipedia-example/src/test/resources/userConfig.properties.sample
@@ -22,7 +22,5 @@ bard__dimension_backend = memory
 # 4. NoCache
 bard__query_response_caching_strategy = LocalSignature
 
-bard__druid_coordinator_metadata_enabled = true
-
 # Default the timeout to 10 minutes, in milliseconds
 bard__druid_request_timeout = 600000


### PR DESCRIPTION
-- This feature flag no longer makes any sense, because customers must
either:
    1. Write a custom `PhysicalTable` with an Availability service
    that does not rely on the DataSourceMetadataService, in which case
    the feature flag has zero impact.
    2. Turn on the feature flag, so that availability gets
    populated.

Otherwise, the availability information will never get populated, and
every data request will fail with an error about how the metadata
service doesn't know anything about the specified datasource, a message
that can be a little bit misleading.

In other words, vanilla Fili doesn't work if that feature flag isn't
turned on, so there's no point in including it.