### PR TITLE
Make BaseKeyValueStoreSpec extendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ Current
 
 ### Changed:
 
+- [Make BaseKeyValueStoreSpec extendable](https://github.com/yahoo/fili/pull/533)
+    * 1. Change `assert store.isOpen()` to `store.open()` in test `setup()`
+    * 2. Add `childSetup()` and `childCleanup` so that derived classes could add their own setup and cleanup logic
+
 - [Fix wrong default druid url and broken getInnerMostQuery](https://github.com/yahoo/fili/pull/528)
     * Comment out the wrong default druid broker url in module config that break old url config compatibility, add check for validate url in `DruidClientConfigHelper `
     * Fix broken `getInnermostQuery` method in `DruidQuery`

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/BaseKeyValueStoreSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/BaseKeyValueStoreSpec.groovy
@@ -7,24 +7,38 @@ import spock.lang.Timeout
 
 @Timeout(30)
 abstract class BaseKeyValueStoreSpec extends Specification {
+    private static final String STORE_NAME = "test_store1"
 
     abstract KeyValueStore getInstance(String storeName)
 
     abstract void removeInstance(String storeName)
 
-    /** A common store used by most tests.
+    /**
+     * A common store used by most tests.
      */
     KeyValueStore store1
 
     def setup() {
-        store1 = getInstance("test_store1")
-        assert store1.isOpen()
+        store1 = getInstance(STORE_NAME)
+        store1.open()
+        childSetup()
     }
 
     def cleanup() {
         store1.close()
-        removeInstance("test_store1")
+        removeInstance(STORE_NAME)
+        childCleanup()
     }
+
+    /**
+     * Override this method with any child-specific setup the child class needs to perform.
+     */
+    void childSetup() {}
+
+    /**
+     * Override this method with any child-specific cleanup the child class needs to perform.
+     */
+    void childCleanup() {}
 
     def "get a nonexistent key returns null"() {
         given: 'the key does not exist in the store'


### PR DESCRIPTION
1. Change `assert store.isOpen()` to `store.open()` in test `setup()`
2. Add `childSetup()` and `childCleanup` so that derived classes could add their own setup and cleanup logic