### PR TITLE
Implement Query Split Counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Current
         - Currently there is only a binary flag (`BardQueryInfo.cached`) that is inconsistently set for split queries
         - Three new metrics are added
             1. Number of split queries satisfied by cache
-            2. Number of split queries not satisfied by cache
+            2. Number of split queries actually sent to the fact store. (not satisfied by cache)
             3. Number of weight-checked queries
 
 - [Documentation that `Dimension::getFieldByName` should throw an `IllegalArgumentException` if there is no field with the passed in name](https://github.com/yahoo/fili/pull/547)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Current
 
 ### Added:
 
+- [Implement Query Split Logging](https://github.com/yahoo/fili/pull/537)
+    * Include metrics in logging to allow for better evaluation of the impact of caching for split queries.
+        - Currently there is only a binary flag (`BardQueryInfo.cached`) that is inconsistently set for split queries
+        - Three new metrics are added
+            1. Number of split queries satisfied by cache
+            2. Number of split queries not satisfied by cache
+            3. Number of weight-checked queries
+
 - [Documentation that `Dimension::getFieldByName` should throw an `IllegalArgumentException` if there is no field with the passed in name](https://github.com/yahoo/fili/pull/547)
 
 - [Evaluate format type from both URI and Accept header](https://github.com/yahoo/fili/pull/495)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogBlock.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogBlock.java
@@ -37,6 +37,17 @@ public class LogBlock {
     }
 
     /**
+     * Return a part of logging information in this LogBlock.
+     *
+     * @param name  Name of a {@link LogInfo} object to be returned
+     *
+     * @return a part of logging information in this LogBlock
+     */
+    public LogInfo get(String name) {
+        return body.get(name);
+    }
+
+    /**
      * Create a new LogBlock with the same body but updated uuid.
      *
      * @param uuid  New uuid.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -338,14 +338,14 @@ public class RequestLog {
                     cls.getSimpleName()
             );
             LOG.error(message);
-            throw new NullPointerException(message);
+            throw new IllegalStateException(message);
         }
         try {
             return requestLog.info.get(cls.getSimpleName());
         } catch (NullPointerException exception) {
             String message = ErrorMessageFormat.RESOURCE_RETRIEVAL_FAILURE.format(cls.getSimpleName());
             LOG.error(message);
-            throw new RuntimeException(message, exception);
+            throw new IllegalStateException(message, exception);
         }
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -306,7 +306,7 @@ public class RequestLog {
     /**
      * Record logging information in the logging context.
      *
-     * @param logPhase  the name of the class destined to hold this logging information
+     * @param logPhase  The name of the class destined to hold this logging information
      *
      * @see LogBlock
      */
@@ -318,6 +318,34 @@ public class RequestLog {
                     "Attempted to append log info while request log object was uninitialized: {}",
                     logPhase.getClass().getSimpleName()
             );
+        }
+    }
+
+    /**
+     * Retrieve logging information in the logging context.
+     *
+     * @param cls  The class destined to hold this logging information
+     *
+     * @return the logging information in the logging context
+     *
+     * @see LogBlock
+     */
+    public static LogInfo retrieve(Class cls) {
+        RequestLog requestLog = RLOG.get();
+        if (requestLog == null) {
+            String message = String.format(
+                    "Attempted to retrieve log info while request log object was uninitialized: %s",
+                    cls.getSimpleName()
+            );
+            LOG.error(message);
+            throw new NullPointerException(message);
+        }
+        try {
+            return requestLog.info.get(cls.getSimpleName());
+        } catch (NullPointerException exception) {
+            String message = ErrorMessageFormat.RESOURCE_RETRIEVAL_FAILURE.format(cls.getSimpleName());
+            LOG.error(message);
+            throw new RuntimeException(message, exception);
         }
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -340,13 +340,14 @@ public class RequestLog {
             LOG.error(message);
             throw new IllegalStateException(message);
         }
-        try {
-            return requestLog.info.get(cls.getSimpleName());
-        } catch (NullPointerException exception) {
+
+        LogInfo logInfo = requestLog.info.get(cls.getSimpleName());
+        if (logInfo == null) {
             String message = ErrorMessageFormat.RESOURCE_RETRIEVAL_FAILURE.format(cls.getSimpleName());
             LOG.error(message);
-            throw new IllegalStateException(message, exception);
+            throw new IllegalStateException(message);
         }
+        return logInfo;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/blocks/BardQueryInfo.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/blocks/BardQueryInfo.java
@@ -7,7 +7,6 @@ import com.yahoo.bard.webservice.logging.RequestLog;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,13 +22,9 @@ import java.util.stream.Stream;
  */
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class BardQueryInfo implements LogInfo {
-    @JsonIgnore
     private static final Logger LOG = LoggerFactory.getLogger(BardQueryInfo.class);
-    @JsonIgnore
     private static final String WEIGHT_CHECK = "weight check queries count";
-    @JsonIgnore
     private static final String FACT_QUERIES = "fact queries count";
-    @JsonIgnore
     private static final String FACT_QUERY_CACHE_HIT  = "fact query cache hit count";
 
     protected static final Map<String, AtomicInteger> QUERY_COUNTER = Stream.of(
@@ -91,12 +86,12 @@ public class BardQueryInfo implements LogInfo {
      * @param queryType  The type of the query
      */
     protected static void incrementCountFor(String queryType) {
-        try {
-            QUERY_COUNTER.get(queryType).incrementAndGet();
-        } catch (NullPointerException exception) {
+        AtomicInteger count = QUERY_COUNTER.get(queryType);
+        if (count == null) {
             String message = ErrorMessageFormat.RESOURCE_RETRIEVAL_FAILURE.format(queryType);
             LOG.error(message);
-            throw new IllegalArgumentException(message, exception);
+            throw new IllegalArgumentException(message);
         }
+        count.incrementAndGet();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/blocks/BardQueryInfo.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/blocks/BardQueryInfo.java
@@ -3,25 +3,68 @@
 package com.yahoo.bard.webservice.logging.blocks;
 
 import com.yahoo.bard.webservice.logging.LogInfo;
+import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Main log of a request served by the TablesServlet.
  */
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class BardQueryInfo implements LogInfo {
+    @JsonIgnore
+    public static final String WEIGHT_CHECK = "weight check queries count";
+    @JsonIgnore
+    public static final String FACT_QUERIES = "fact queries count";
+    @JsonIgnore
+    public static final String FACT_QUERY_CACHE_HIT  = "fact query cache hit count";
+
+    @JsonIgnore
+    private static final Logger LOG = LoggerFactory.getLogger(BardQueryInfo.class);
+
     protected final String type;
-    protected final boolean cached;
+    protected final Map<String, AtomicInteger> queryCounter;
 
     /**
      * Constructor.
      *
      * @param type  Type of Bard query
-     * @param cached  Indicates if the query was served from the data cache or not
      */
-    public BardQueryInfo(String type, boolean cached) {
+    public BardQueryInfo(String type) {
         this.type = type;
-        this.cached = cached;
+        this.queryCounter = Stream.of(
+                new AbstractMap.SimpleImmutableEntry<>(WEIGHT_CHECK, new AtomicInteger()),
+                new AbstractMap.SimpleImmutableEntry<>(FACT_QUERIES, new AtomicInteger()),
+                new AbstractMap.SimpleImmutableEntry<>(FACT_QUERY_CACHE_HIT, new AtomicInteger())
+        ).collect(Collectors.toMap(
+                AbstractMap.SimpleImmutableEntry::getKey,
+                AbstractMap.SimpleImmutableEntry::getValue
+        ));
+    }
+
+    /**
+     * Increments the number of a kind query, whose possible type are all specified in
+     * {@link com.yahoo.bard.webservice.logging.blocks.BardQueryInfo}.
+     *
+     * @param query  The type of the query
+     */
+    public void incrementCountFor(String query) {
+        try {
+            queryCounter.get(query).incrementAndGet();
+        } catch (NullPointerException exception) {
+            String message = ErrorMessageFormat.RESOURCE_RETRIEVAL_FAILURE.format(query);
+            LOG.error(message);
+            throw new RuntimeException(message, exception);
+        }
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -154,7 +154,7 @@ public enum ErrorMessageFormat implements MessageFormatter {
     ),
     LOG_UNABLE_TO_DESERIALIZE("Unable to deserialize results for job %s from %s"),
 
-    RESOURCE_RETRIEVAL_FAILURE("Unable to retrieve the resource for given resource name: %s. %s"),
+    RESOURCE_RETRIEVAL_FAILURE("Unable to retrieve the resource for given resource name: %s."),
     RESOURCE_STORAGE_FAILURE("Unable to store the resource for resource name %s. %s"),
     RESOURCE_DELETION_FAILURE("Unable to delete the resource for resource name %s. %s"),
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
@@ -226,7 +226,7 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
         LogicalTable table = request.getTable();
         REGISTRY.meter("request.logical.table." + table.getName() + "." + table.getGranularity()).mark();
 
-        RequestLog.record(new BardQueryInfo(druidQuery.getQueryType().toJson(), false));
+        RequestLog.record(new BardQueryInfo(druidQuery.getQueryType().toJson()));
         RequestLog.record(
                 new DataRequest(
                         table,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandler.java
@@ -52,9 +52,7 @@ public class AsyncWebServiceRequestHandler extends BaseDataRequestHandler {
         HttpErrorCallback error = response.getErrorCallback(druidQuery);
         FailureCallback failure = response.getFailureCallback(druidQuery);
 
-        ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
-                BardQueryInfo.FACT_QUERIES
-        );
+        BardQueryInfo.incrementCountFactHits();
         druidWebService.postDruidQuery(context, success, error, failure, druidQuery);
         return true;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandler.java
@@ -8,6 +8,7 @@ import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
 import com.yahoo.bard.webservice.druid.client.SuccessCallback;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.responseprocessors.LoggingContext;
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor;
@@ -51,6 +52,9 @@ public class AsyncWebServiceRequestHandler extends BaseDataRequestHandler {
         HttpErrorCallback error = response.getErrorCallback(druidQuery);
         FailureCallback failure = response.getFailureCallback(druidQuery);
 
+        ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
+                BardQueryInfo.FACT_QUERIES
+        );
         druidWebService.postDruidQuery(context, success, error, failure, druidQuery);
         return true;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheRequestHandler.java
@@ -84,9 +84,7 @@ public class CacheRequestHandler extends BaseDataRequestHandler {
                 if (jsonResult != null) {
                     try {
                         if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
-                            ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
-                                    BardQueryInfo.FACT_QUERY_CACHE_HIT
-                            );
+                            BardQueryInfo.incrementCountCacheHits();
                             RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
                         }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheRequestHandler.java
@@ -84,14 +84,15 @@ public class CacheRequestHandler extends BaseDataRequestHandler {
                 if (jsonResult != null) {
                     try {
                         if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
-                            RequestLog.record(new BardQueryInfo(druidQuery.getQueryType().toJson(), true));
+                            ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
+                                    BardQueryInfo.FACT_QUERY_CACHE_HIT
+                            );
                             RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
                         }
 
                         if (context.getNumberOfIncoming().decrementAndGet() == 0) {
                             RequestLog.startTiming(RESPONSE_WORKFLOW_TIMER);
                         }
-
                         CACHE_HITS.mark(1);
                         RequestLog logCtx = RequestLog.dump();
                         nextResponse.processResponse(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
@@ -100,14 +100,15 @@ public class CacheV2RequestHandler extends BaseDataRequestHandler {
                     ) {
                         try {
                             if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
-                                RequestLog.record(new BardQueryInfo(druidQuery.getQueryType().toJson(), true));
+                                ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
+                                        BardQueryInfo.FACT_QUERY_CACHE_HIT
+                                );
                                 RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
                             }
 
                             if (context.getNumberOfIncoming().decrementAndGet() == 0) {
                                 RequestLog.startTiming(RESPONSE_WORKFLOW_TIMER);
                             }
-
                             CACHE_HITS.mark(1);
                             RequestLog logCtx = RequestLog.dump();
                             nextResponse.processResponse(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandler.java
@@ -100,9 +100,7 @@ public class CacheV2RequestHandler extends BaseDataRequestHandler {
                     ) {
                         try {
                             if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
-                                ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
-                                        BardQueryInfo.FACT_QUERY_CACHE_HIT
-                                );
+                                BardQueryInfo.incrementCountCacheHits();
                                 RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
                             }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/EtagCacheRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/EtagCacheRequestHandler.java
@@ -90,9 +90,7 @@ public class EtagCacheRequestHandler extends BaseDataRequestHandler {
                             );
 
                     if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
-                        ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
-                                BardQueryInfo.FACT_QUERY_CACHE_HIT
-                        );
+                        BardQueryInfo.incrementCountCacheHits();
                         RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
                     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/EtagCacheRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/EtagCacheRequestHandler.java
@@ -90,7 +90,9 @@ public class EtagCacheRequestHandler extends BaseDataRequestHandler {
                             );
 
                     if (context.getNumberOfOutgoing().decrementAndGet() == 0) {
-                        RequestLog.record(new BardQueryInfo(druidQuery.getQueryType().toJson(), true));
+                        ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
+                                BardQueryInfo.FACT_QUERY_CACHE_HIT
+                        );
                         RequestLog.stopTiming(REQUEST_WORKFLOW_TIMER);
                     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandler.java
@@ -8,6 +8,8 @@ import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
 import com.yahoo.bard.webservice.druid.client.SuccessCallback;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
+import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor;
@@ -71,6 +73,9 @@ public class WeightCheckRequestHandler extends BaseDataRequestHandler {
             return next.handleRequest(context, request, druidQuery, response);
         }
 
+        ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
+                BardQueryInfo.WEIGHT_CHECK
+        );
         final WeightCheckResponseProcessor weightCheckResponse = new WeightCheckResponseProcessor(response);
         final DruidAggregationQuery<?> weightEvaluationQuery = queryWeightUtil.makeWeightEvaluationQuery(druidQuery);
         Granularity granularity = druidQuery.getInnermostQuery().getGranularity();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandler.java
@@ -8,7 +8,6 @@ import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
 import com.yahoo.bard.webservice.druid.client.SuccessCallback;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
-import com.yahoo.bard.webservice.logging.RequestLog;
 import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo;
 import com.yahoo.bard.webservice.web.DataApiRequest;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
@@ -73,9 +72,7 @@ public class WeightCheckRequestHandler extends BaseDataRequestHandler {
             return next.handleRequest(context, request, druidQuery, response);
         }
 
-        ((BardQueryInfo) RequestLog.retrieve(BardQueryInfo.class)).incrementCountFor(
-                BardQueryInfo.WEIGHT_CHECK
-        );
+        BardQueryInfo.incrementCountWeightCheck();
         final WeightCheckResponseProcessor weightCheckResponse = new WeightCheckResponseProcessor(response);
         final DruidAggregationQuery<?> weightEvaluationQuery = queryWeightUtil.makeWeightEvaluationQuery(druidQuery);
         Granularity granularity = druidQuery.getInnermostQuery().getGranularity();

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/BardQueryInfoSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/BardQueryInfoSpec.groovy
@@ -1,0 +1,68 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.logging.blocks
+
+import com.yahoo.bard.webservice.web.ErrorMessageFormat
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BardQueryInfoSpec extends Specification {
+    BardQueryInfo bardQueryInfo
+
+    def setup() {
+        bardQueryInfo = BardQueryInfoUtils.initializeBardQueryInfo()
+    }
+
+    def cleanup() {
+        BardQueryInfoUtils.resetBardQueryInfo()
+    }
+
+    def "getBardQueryInfo() returns registered BardQueryInfo instance"() {
+        expect:
+        BardQueryInfo.getBardQueryInfo() == bardQueryInfo
+    }
+
+    @Unroll
+    def "incrementCountFor(#queryType) increment count of #queryType by 1"() {
+        expect: "count for #queryType is 0"
+        BardQueryInfo.QUERY_COUNTER.get(queryType).get() == 0
+
+        when: "calling incrementCountFor(#queryType)"
+        BardQueryInfo.incrementCountFor(queryType)
+
+        then:
+        BardQueryInfo.QUERY_COUNTER.get(queryType).get() == 1
+
+        where:
+        queryType                          | _
+        BardQueryInfo.WEIGHT_CHECK         | _
+        BardQueryInfo.FACT_QUERIES         | _
+        BardQueryInfo.FACT_QUERY_CACHE_HIT | _
+    }
+
+    def "incrementCountFor(String) throws IllegalArgumentException on non-existing query type"() {
+        when:
+        BardQueryInfo.incrementCountFor("nonExistingQueryType")
+
+        then:
+        IllegalArgumentException illegalArgumentException = thrown()
+        illegalArgumentException.message == ErrorMessageFormat.RESOURCE_RETRIEVAL_FAILURE.format("nonExistingQueryType")
+    }
+
+    def "incrementCount*() methods increment their corresponding query counts by 1"() {
+        expect: "all query counts are 0"
+        BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.WEIGHT_CHECK).get() == 0
+        BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERIES).get() == 0
+        BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERY_CACHE_HIT).get() == 0
+
+        when:
+        BardQueryInfo.incrementCountWeightCheck()
+        BardQueryInfo.incrementCountFactHits()
+        BardQueryInfo.incrementCountCacheHits()
+
+        then:
+        BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.WEIGHT_CHECK).get() == 1
+        BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERIES).get() == 1
+        BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERY_CACHE_HIT).get() == 1
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/BardQueryInfoSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/BardQueryInfoSpec.groovy
@@ -23,14 +23,14 @@ class BardQueryInfoSpec extends Specification {
     }
 
     @Unroll
-    def "incrementCountFor(#queryType) increment count of #queryType by 1"() {
+    def "incrementCountFor(#queryType) increments count of #queryType by 1"() {
         expect: "count for #queryType is 0"
         BardQueryInfo.QUERY_COUNTER.get(queryType).get() == 0
 
         when: "calling incrementCountFor(#queryType)"
         BardQueryInfo.incrementCountFor(queryType)
 
-        then:
+        then: "count of #queryType is incremented by 1"
         BardQueryInfo.QUERY_COUNTER.get(queryType).get() == 1
 
         where:
@@ -41,26 +41,26 @@ class BardQueryInfoSpec extends Specification {
     }
 
     def "incrementCountFor(String) throws IllegalArgumentException on non-existing query type"() {
-        when:
+        when: "BardQueryInfo is given an unknown query type"
         BardQueryInfo.incrementCountFor("nonExistingQueryType")
 
-        then:
+        then: "IllegalArgumentException is thrown with exception message"
         IllegalArgumentException illegalArgumentException = thrown()
         illegalArgumentException.message == ErrorMessageFormat.RESOURCE_RETRIEVAL_FAILURE.format("nonExistingQueryType")
     }
 
-    def "incrementCount*() methods increment their corresponding query counts by 1"() {
+    def "incrementCount*() methods increment their corresponding query type counts by 1"() {
         expect: "all query counts are 0"
         BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.WEIGHT_CHECK).get() == 0
         BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERIES).get() == 0
         BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERY_CACHE_HIT).get() == 0
 
-        when:
+        when: "calling incrementCount*() methods for all query types"
         BardQueryInfo.incrementCountWeightCheck()
         BardQueryInfo.incrementCountFactHits()
         BardQueryInfo.incrementCountCacheHits()
 
-        then:
+        then: "counts of all query types are incremented by 1"
         BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.WEIGHT_CHECK).get() == 1
         BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERIES).get() == 1
         BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERY_CACHE_HIT).get() == 1

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/BardQueryInfoUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/BardQueryInfoUtils.groovy
@@ -1,0 +1,34 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.logging.blocks
+
+import com.yahoo.bard.webservice.logging.RequestLog
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class BardQueryInfoUtils {
+    /**
+     * Constructs and returns a testing BardQueryInfo instance without a query type.
+     *
+     * @return a testing BardQueryInfo instance without a query type
+     */
+    static BardQueryInfo initializeBardQueryInfo() {
+        resetBardQueryInfo()
+        BardQueryInfo bardQueryInfo = new BardQueryInfo(null)
+        RequestLog.getId() // initialize RequestLog
+        RequestLog.record(bardQueryInfo)
+        return bardQueryInfo
+    }
+
+    /**
+     * Resets counts of all query types in BardQueryInfo.
+     */
+    static void resetBardQueryInfo() {
+        RequestLog.dump()
+
+        // reset counts of all query types after each individual test
+        for (Map.Entry<String, AtomicInteger> entry : BardQueryInfo.QUERY_COUNTER.entrySet()) {
+            entry.value = new AtomicInteger()
+        }
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/DruidFilterInfoSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/DruidFilterInfoSpec.groovy
@@ -1,3 +1,5 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.logging.blocks
 
 import com.yahoo.bard.webservice.data.dimension.Dimension

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandlerSpec.groovy
@@ -5,7 +5,10 @@ package com.yahoo.bard.webservice.web.handlers
 import com.yahoo.bard.webservice.druid.client.DruidWebService
 import com.yahoo.bard.webservice.druid.client.SuccessCallback
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
+import com.yahoo.bard.webservice.logging.RequestLog
+import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo
 import com.yahoo.bard.webservice.web.DataApiRequest
+import com.yahoo.bard.webservice.web.responseprocessors.LoggingContext
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -17,6 +20,11 @@ import spock.lang.Specification
 import java.util.concurrent.Future
 
 class AsyncWebServiceRequestHandlerSpec extends Specification {
+
+    def setup() {
+        RequestLog.getId()
+        RequestLog.record(new BardQueryInfo(""))
+    }
 
     def "Test handle request invokes asynch call"() {
         setup:
@@ -34,6 +42,7 @@ class AsyncWebServiceRequestHandlerSpec extends Specification {
 
         SuccessCallback sc = null
         boolean success
+
         when:
         success = handler.handleRequest(rc, request, groupByQuery, response)
 
@@ -51,6 +60,6 @@ class AsyncWebServiceRequestHandlerSpec extends Specification {
         sc.invoke(rootNode)
 
         then:
-        1 * response.processResponse(rootNode, groupByQuery, _)
+        1 * response.processResponse(rootNode, groupByQuery, _ as LoggingContext)
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandlerSpec.groovy
@@ -46,6 +46,9 @@ class AsyncWebServiceRequestHandlerSpec extends Specification {
         SuccessCallback sc = null
         boolean success
 
+        expect:
+        BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERIES).get() == 0
+
         when:
         success = handler.handleRequest(rc, request, groupByQuery, response)
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/AsyncWebServiceRequestHandlerSpec.groovy
@@ -5,8 +5,8 @@ package com.yahoo.bard.webservice.web.handlers
 import com.yahoo.bard.webservice.druid.client.DruidWebService
 import com.yahoo.bard.webservice.druid.client.SuccessCallback
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
-import com.yahoo.bard.webservice.logging.RequestLog
 import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo
+import com.yahoo.bard.webservice.logging.blocks.BardQueryInfoUtils
 import com.yahoo.bard.webservice.web.DataApiRequest
 import com.yahoo.bard.webservice.web.responseprocessors.LoggingContext
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor
@@ -22,8 +22,11 @@ import java.util.concurrent.Future
 class AsyncWebServiceRequestHandlerSpec extends Specification {
 
     def setup() {
-        RequestLog.getId()
-        RequestLog.record(new BardQueryInfo(""))
+        BardQueryInfoUtils.initializeBardQueryInfo()
+    }
+
+    def cleanup() {
+        BardQueryInfoUtils.resetBardQueryInfo()
     }
 
     def "Test handle request invokes asynch call"() {
@@ -55,6 +58,7 @@ class AsyncWebServiceRequestHandlerSpec extends Specification {
             sc = a1
             return Mock(Future)
         }
+        BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERIES).get() == 1
 
         when:
         sc.invoke(rootNode)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheRequestHandlerSpec.groovy
@@ -144,7 +144,7 @@ class CacheRequestHandlerSpec extends Specification {
         and: "The request is marked as processed"
         requestProcessed
 
-        and: "The count of fact query cache hit is noe incremented"
+        and: "The count of fact query cache hit is not incremented"
         BardQueryInfo.QUERY_COUNTER.get(BardQueryInfo.FACT_QUERY_CACHE_HIT).get() == 0
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheRequestHandlerSpec.groovy
@@ -7,6 +7,8 @@ import com.yahoo.bard.webservice.data.cache.DataCache
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.druid.model.query.TimeSeriesQuery
 import com.yahoo.bard.webservice.druid.model.query.TopNQuery
+import com.yahoo.bard.webservice.logging.RequestLog
+import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo
 import com.yahoo.bard.webservice.web.DataApiRequest
 import com.yahoo.bard.webservice.web.RequestUtils
 import com.yahoo.bard.webservice.web.responseprocessors.CachingResponseProcessor
@@ -50,6 +52,7 @@ class CacheRequestHandlerSpec extends Specification {
         containerRequestContext.getHeaders() >> (["Bard-Testing": "###BYPASS###", "ClientId": "UI"] as
                 MultivaluedHashMap<String, String>)
         requestContext = new RequestContext(containerRequestContext, true)
+        RequestLog.record(new BardQueryInfo(""))
     }
 
     def "Test constructor initializes object"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/CacheV2RequestHandlerSpec.groovy
@@ -8,6 +8,8 @@ import com.yahoo.bard.webservice.data.cache.TupleDataCache
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.druid.model.query.TimeSeriesQuery
 import com.yahoo.bard.webservice.druid.model.query.TopNQuery
+import com.yahoo.bard.webservice.logging.RequestLog
+import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo
 import com.yahoo.bard.webservice.metadata.QuerySigningService
 import com.yahoo.bard.webservice.metadata.SegmentIntervalsHashIdGenerator
 import com.yahoo.bard.webservice.web.DataApiRequest
@@ -56,6 +58,7 @@ class CacheV2RequestHandlerSpec extends Specification {
         containerRequestContext.getHeaders() >> (["Bard-Testing": "###BYPASS###", "ClientId": "UI"] as
                 MultivaluedHashMap<String, String>)
         requestContext = new RequestContext(containerRequestContext, true)
+        RequestLog.record(new BardQueryInfo(""))
     }
 
     def "Test constructor initializes object"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandlerSpec.groovy
@@ -12,6 +12,8 @@ import com.yahoo.bard.webservice.druid.client.SuccessCallback
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.druid.model.query.WeightEvaluationQuery
+import com.yahoo.bard.webservice.logging.RequestLog
+import com.yahoo.bard.webservice.logging.blocks.BardQueryInfo
 import com.yahoo.bard.webservice.web.DataApiRequest
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor
 import com.yahoo.bard.webservice.web.responseprocessors.WeightCheckResponseProcessor
@@ -52,6 +54,8 @@ class WeightCheckRequestHandlerSpec extends Specification {
         groupByQuery = Mock(GroupByQuery)
         groupByQuery.getInnermostQuery() >> groupByQuery
         response = Mock(WeightCheckResponseProcessor)
+        RequestLog.getId()
+        RequestLog.record(new BardQueryInfo(""))
     }
 
     def "Test constructor"() {


### PR DESCRIPTION
Include metrics in logging to allow for better evaluation of the impact of caching for split queries. Currently there is only a binary flag (`BardQueryInfo.cached`) that is inconsistently set for split queries.

Three new metrics are added
1. Number of split queries satisfied by cache
2. Number of split queries not satisfied by cache
3. Number of weight-checked queries

Implementation strategy:
* Rewrite internals of `BardQueryInfo`. Add fields for
    - `weightCheckQueries`
    - `factQueries`
    - `factQueryCacheHits`
* Make use of `RequestLog`. Get `BardQueryInfo` out of `RequestLog` whenever we want to update it
* Instead of overwriting using `RequestLog.record`, use incrementing methods 
    * `incrementCountFactHits`
    * `incrementCountCacheHits`
    * `incrementCountWeightCheck`

to update counts of the queries 