### PR TITLE
fix constantMaker make method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@ Current
 
 ### Fixed:
 
+- [Fix ConstantMaker make method with LogicalMetricInfo class](https://github.com/yahoo/fili/pull/540)
+    * The ConstantMaker make method needs to be rewritten with the LogicalMetricInfo class.
+    
 - [Slices endpoint returns druid name instead of api name](https://github.com/yahoo/fili/pull/491)
     * The slices endpoint now gives the druid name instead of the api name for dimensions.
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ConstantMaker.java
@@ -34,12 +34,12 @@ public class ConstantMaker extends MetricMaker {
     }
 
     @Override
-    public LogicalMetric make(String metricName, List<String> dependentMetrics) {
+    public LogicalMetric make(LogicalMetricInfo logicalMetricInfo, List<String> dependentMetrics) {
         // Check that we have the right number of metrics
-        assertRequiredDependentMetricCount(metricName, dependentMetrics);
+        assertRequiredDependentMetricCount(logicalMetricInfo.getName(), dependentMetrics);
 
         // Actually build the metric.
-        return makeInner(metricName, dependentMetrics);
+        return makeInner(logicalMetricInfo, dependentMetrics);
     }
 
     @Override


### PR DESCRIPTION
The ConstantMaker make method needs to be rewritten with the `LogicalMetricInfo` class.