### PR TITLE
revert the druid name and add it to fact name in slices endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,11 @@ Current
 
 ### Removed:
 
+- [Reverted the druid name change in slices endpoint instead added to factName](https://github.com/yahoo/fili/pull/541)
+    * Reverting the PR-419(https://github.com/yahoo/fili/pull/419) so that the name still points to apiName and added factName which points to druidName.
+      `name` was not valid for cases when it is a Lookup dimension because it was pointing to the base dimension name , so reverted that change and added
+      `druidName` which is the actual druid fact name and `name` being the apiName
+    
 - [Remove custom immutable collections in favor of Guava](https://github.com/yahoo/fili/pull/479)
     * `Utils.makeImmutable(...)` was misleading and uneeded so it has been removed. Use Guava's immutable collections.
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/SlicesApiRequest.java
@@ -179,7 +179,9 @@ public class SlicesApiRequest extends ApiRequestImpl {
                     Column key = e.getKey();
                     if (key instanceof DimensionColumn) {
                         Dimension dimension = ((DimensionColumn) key).getDimension();
-                        row.put("name", table.getPhysicalColumnName(dimension.getApiName()));
+                        String dimensionApiName = dimension.getApiName();
+                        row.put("name", dimensionApiName);
+                        row.put("factName", table.getPhysicalColumnName(dimensionApiName));
                         row.put("uri", DimensionsServlet.getDimensionUrl(dimension, uriInfo));
                         dimensionsResult.add(row);
                     } else {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SlicesApiRequestSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SlicesApiRequestSpec.groovy
@@ -94,9 +94,10 @@ class SlicesApiRequestSpec extends BaseDataSourceMetadataSpec {
         table.allAvailableIntervals.each {
             Map<String, Object> row = [:] as LinkedHashMap
             row["intervals"] = it.value
-            row["name"] = table.getPhysicalColumnName(it.key.name)
+            row["name"] = it.key.name
             if (it.key instanceof DimensionColumn) {
                 row["uri"] = uri + it.key.name
+                row["factName"] = table.getPhysicalColumnName(it.key.name)
                 dimensionsResult.add(row)
             } else {
                 metricsResult.add(row)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SlicesServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SlicesServletSpec.groovy
@@ -60,9 +60,9 @@ class SlicesServletSpec extends Specification {
             "timeZone":"UTC",
             "dimensions":
             [
-                {"name":"breed", "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/breed", "intervals":["$interval"]},
-                {"name":"class", "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/species", "intervals":["$interval"]},
-                {"name":"sex", "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/sex", "intervals":["$interval"]}
+                {"name":"breed","factName":"breed", "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/breed", "intervals":["$interval"]},
+                {"name":"species","factName":"class", "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/species", "intervals":["$interval"]},
+                {"name":"sex","factName":"sex", "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/sex", "intervals":["$interval"]}
             ],
             "segmentInfo": {},
             "metrics":

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
@@ -72,6 +72,7 @@ class SlicesServletSpec extends Specification {
                 """
                                 {
                                     "name":"$it",
+                                    "factName":"$it",
                                     "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/$it",
                                     "intervals":["$interval"]
                                 }

--- a/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
+++ b/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
@@ -70,6 +70,7 @@ class SlicesServletSpec extends Specification {
                         dimensionNames.collect {"""
                                 {
                                     "name":"$it",
+                                    "factName": "$it",
                                     "uri":"http://localhost:${jtb.getHarness().getPort()}/dimensions/$it",
                                     "intervals":["$interval"]
                                 }


### PR DESCRIPTION
Reverting this PR https://github.com/yahoo/fili/pull/491 so that the `name` still points to `apiName` and added `factName` which points to `druidName`