### PR TITLE
The 'allRows' contract isn't being enforced in externally loaded data…

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/KeyValueStoreDimension.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/KeyValueStoreDimension.java
@@ -478,7 +478,6 @@ public class KeyValueStoreDimension implements Dimension {
         try {
             String dimRowIndexes = keyValueStore.get(DimensionStoreKeyUtils.getAllValuesKey());
             if (dimRowIndexes == null) {
-                LOG.debug("Null value for dimension {} while deleting: ", apiName);
                 return;
             }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncFunctionalSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/async/AsyncFunctionalSpec.groovy
@@ -152,6 +152,7 @@ abstract class AsyncFunctionalSpec extends Specification {
         expect: "All the asynchronous interactions behave appropriately"
         getResultsToTargetFunctions().each {interactionName, resultsToTarget ->
             //First, we make a request.
+            Thread.sleep(1000)
             Response response = makeAbstractRequest(
                     // To make a request, we need the target (i.e. path), which may be constructed using responses from
                     // previous requests


### PR DESCRIPTION
… and isn't really serving any value for most configurations.  So warning when it's not initialized during JersetTestBinder shut down is quite chatty and annoying.