### PR TITLE
substitute preflight method wildcard with explicit methods

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/ResponseCorsFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/ResponseCorsFilter.java
@@ -37,7 +37,7 @@ public class ResponseCorsFilter implements ContainerResponseFilter {
         // allow all requested headers
         headers.add("Access-Control-Allow-Headers", requestedHeaders == null ? "" : requestedHeaders);
 
-        headers.add("Access-Control-Allow-Methods", "*");
+        headers.add("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS, PUT, PATCH");
         headers.add("Access-Control-Allow-Credentials", "true");
         RequestLog.stopTiming(this);
     }


### PR DESCRIPTION
While using fili, I got the error message:
`Method PUT is not allowed by Access-Control-Allow-Methods in preflight response`

After digging around I found that for preflight requests many browsers don't support a wildcard. 
https://stackoverflow.com/questions/44914330/method-put-is-not-allowed-by-access-control-allow-methods-in-preflight-response

my `PUT` requests work after applying this fix. 