### PR TITLE
Remove testing constructor of *ApiRequestImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Current
 
 
 ### Changed:
+
 - [Substitute preflight method wildcard character with explicit allowed methods](https://github.com/yahoo/fili/pull/545)
     * Modify ResponseCorsFilter Allowed Methods header to explicitly list allowed methods. Some browsers do not support a wildcard header value.
 
@@ -214,6 +215,17 @@ Current
 
 ### Removed:
 
+- [Remove testing constructor of *ApiRequestImpl](https://github.com/yahoo/fili/pull/559)
+    * It is a better practice to separate testing code with implementation. All testing constructors of the following
+      API requests are removed:
+        - `ApiRequestImpl`
+        - `DataApiRequestImpl`
+        - `DimensionsApiRequestImpl`
+        - `MetricsApiRequestImpl`
+        - `SlicesApiRequestImpl`
+        - `TablesApiRequestImpl`
+    * Meanwhile, construction of testing API request is delegated to testing class, e.g. `TestingDataApiRequestImpl`
+    
 - [Reverted the druid name change in slices endpoint instead added to factName](https://github.com/yahoo/fili/pull/541)
     * Reverting the PR-419(https://github.com/yahoo/fili/pull/419) so that the name still points to apiName and added factName which points to druidName.
       `name` was not valid for cases when it is a Lookup dimension because it was pointing to the base dimension name , so reverted that change and added

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -39,7 +39,6 @@ import com.yahoo.bard.webservice.web.BadFilterException;
 import com.yahoo.bard.webservice.web.BadPaginationException;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 import com.yahoo.bard.webservice.web.FilterOperation;
-import com.yahoo.bard.webservice.web.ForTesting;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
 import com.yahoo.bard.webservice.web.TimeMacros;
 import com.yahoo.bard.webservice.web.util.PaginationLink;
@@ -155,18 +154,6 @@ public abstract class ApiRequestImpl implements ApiRequest {
             UriInfo uriInfo
     ) throws BadApiRequestException {
         this(format, SYNCHRONOUS_REQUEST_FLAG, perPage, page, uriInfo);
-    }
-
-    /**
-     * No argument constructor, meant to be used only for testing.
-     */
-    @ForTesting
-    protected ApiRequestImpl() {
-        this.uriInfo = null;
-        this.format = null;
-        this.paginationParameters = null;
-        this.builder = Response.status(Response.Status.OK);
-        this.asyncAfter = Long.MAX_VALUE;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
@@ -11,7 +11,6 @@ import com.yahoo.bard.webservice.web.ApiFilter;
 import com.yahoo.bard.webservice.web.BadApiRequestException;
 import com.yahoo.bard.webservice.web.BadFilterException;
 import com.yahoo.bard.webservice.web.DimensionsApiRequest;
-import com.yahoo.bard.webservice.web.ForTesting;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
 import com.yahoo.bard.webservice.web.util.PaginationParameters;
 
@@ -88,19 +87,6 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
                 this.format,
                 this.paginationParameters
         );
-    }
-
-    /**
-     * No argument constructor, meant to be used only for testing.
-     *
-     * @deprecated it's not a good practice to have testing code here. This constructor will be removed entirely.
-     */
-    @Deprecated
-    @ForTesting
-    protected DimensionsApiRequestImpl() {
-        super();
-        this.dimensions = null;
-        this.filters = null;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/MetricsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/MetricsApiRequestImpl.java
@@ -8,7 +8,6 @@ import static com.yahoo.bard.webservice.web.ErrorMessageFormat.METRICS_UNDEFINED
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.web.BadApiRequestException;
-import com.yahoo.bard.webservice.web.ForTesting;
 import com.yahoo.bard.webservice.web.MetricsApiRequest;
 
 import org.slf4j.Logger;
@@ -68,18 +67,6 @@ public class MetricsApiRequestImpl extends ApiRequestImpl implements MetricsApiR
                 this.format,
                 this.paginationParameters
         );
-    }
-
-    /**
-     * No argument constructor, meant to be used only for testing.
-     *
-     * @deprecated it's not a good practice to have testing code here. This constructor will be removed entirely.
-     */
-    @Deprecated
-    @ForTesting
-    protected MetricsApiRequestImpl() {
-        super();
-        this.metrics = null;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImpl.java
@@ -14,7 +14,6 @@ import com.yahoo.bard.webservice.table.PhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 import com.yahoo.bard.webservice.web.BadApiRequestException;
-import com.yahoo.bard.webservice.web.ForTesting;
 import com.yahoo.bard.webservice.web.SlicesApiRequest;
 import com.yahoo.bard.webservice.web.endpoints.DimensionsServlet;
 import com.yahoo.bard.webservice.web.endpoints.SlicesServlet;
@@ -90,19 +89,6 @@ public class SlicesApiRequestImpl extends ApiRequestImpl implements SlicesApiReq
                 this.format,
                 this.paginationParameters
         );
-    }
-
-    /**
-     * No argument constructor, meant to be used only for testing.
-     *
-     * @deprecated it's not a good practice to have testing code here. This constructor will be removed entirely.
-     */
-    @Deprecated
-    @ForTesting
-    protected SlicesApiRequestImpl() {
-        super();
-        this.slices = null;
-        this.slice = null;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequestImpl.java
@@ -19,7 +19,6 @@ import com.yahoo.bard.webservice.table.LogicalTableDictionary;
 import com.yahoo.bard.webservice.table.TableIdentifier;
 import com.yahoo.bard.webservice.web.ApiFilter;
 import com.yahoo.bard.webservice.web.BadApiRequestException;
-import com.yahoo.bard.webservice.web.ForTesting;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
 import com.yahoo.bard.webservice.web.TablesApiRequest;
 import com.yahoo.bard.webservice.web.util.BardConfigResources;
@@ -263,24 +262,6 @@ public class TablesApiRequestImpl extends ApiRequestImpl implements TablesApiReq
         this.logicalMetrics = metrics;
         this.intervals = intervals;
         this.apiFilters = filters;
-    }
-
-    /**
-     * No argument constructor, meant to be used only for testing.
-     *
-     * @deprecated it's not a good practice to have testing code here. This constructor will be removed entirely.
-     */
-    @Deprecated
-    @ForTesting
-    protected TablesApiRequestImpl() {
-        super();
-        this.tables = null;
-        this.table = null;
-        this.granularity = null;
-        this.dimensions = null;
-        this.logicalMetrics = null;
-        this.intervals = null;
-        this.apiFilters = null;
     }
 
     /**

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/AggregatabilityValidationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/AggregatabilityValidationSpec.groovy
@@ -16,6 +16,7 @@ import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.TableGroup
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import org.joda.time.DateTime
 
@@ -78,7 +79,7 @@ class AggregatabilityValidationSpec extends Specification {
     @Unroll
     def "Aggregatability validates successfully with #aggSize aggregatable and #nonAggSize non-aggregatable group by dimensions and #hasFilter filter#filterFormat"() {
         setup:
-        DataApiRequest apiRequest = new DataApiRequestImpl()
+        DataApiRequest apiRequest = new TestingDataApiRequestImpl()
         Set<Dimension> dims = apiRequest.generateDimensions(aggDims + nonAggDims, dimensionDict)
         Map<Dimension, Set<ApiFilter>> filters = apiRequest.generateFilters(filterString, table, dimensionDict)
 
@@ -164,7 +165,7 @@ class AggregatabilityValidationSpec extends Specification {
     @Unroll
     def "Aggregatability validation throws #exception.simpleName with #aggSize aggregatable and #nonAggSize non-aggregatable group by dimensions and #hasFilter filter#filterFormat"() {
         setup:
-        DataApiRequest apiRequest = new DataApiRequestImpl();
+        DataApiRequest apiRequest = new TestingDataApiRequestImpl()
         Set<Dimension> dims = apiRequest.generateDimensions(aggDims + nonAggDims, dimensionDict)
         Map<Dimension, Set<ApiFilter>> filters = apiRequest.generateFilters(filterString, table, dimensionDict)
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestFilterSpec.groovy
@@ -18,6 +18,7 @@ import com.yahoo.bard.webservice.table.TableGroup
 import com.yahoo.bard.webservice.util.FilterTokenizer
 import com.yahoo.bard.webservice.util.IntervalUtils
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -69,7 +70,7 @@ class DataApiRequestFilterSpec extends Specification {
     @Unroll
     def "Find #filterCount filters and #filterValueCount values when parsing filter string #filterString"() {
         when:
-        Map<Dimension, Set<ApiFilter>> filters = new DataApiRequestImpl().generateFilters(filterString, table, dimensionDict)
+        Map<Dimension, Set<ApiFilter>> filters = new TestingDataApiRequestImpl().generateFilters(filterString, table, dimensionDict)
 
         then:
         filters.size() == dimensions
@@ -99,7 +100,7 @@ class DataApiRequestFilterSpec extends Specification {
         DATA_FILTER_SUBSTRING_OPERATIONS.setOn(false)
 
         when: "We try to generate the filter"
-        new DataApiRequestImpl().generateFilters(filterString, table, dimensionDict)
+        new TestingDataApiRequestImpl().generateFilters(filterString, table, dimensionDict)
 
         then: "An error is thrown"
         thrown(BadApiRequestException)
@@ -117,7 +118,11 @@ class DataApiRequestFilterSpec extends Specification {
         setup:
         String expectedMessage = ErrorMessageFormat.FILTER_FIELD_NOT_IN_DIMENSIONS.format('unknown', 'locale')
         when:
-        new DataApiRequestImpl().generateFilters("locale|unknown-in[US,India],locale.id-eq[5]", table, dimensionDict)
+        new TestingDataApiRequestImpl().generateFilters(
+                "locale|unknown-in[US,India],locale.id-eq[5]",
+                table,
+                dimensionDict
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -133,7 +138,11 @@ class DataApiRequestFilterSpec extends Specification {
 
         String expectedMessage = ErrorMessageFormat.FILTER_DIMENSION_NOT_IN_TABLE.format('locale', 'name')
         when:
-        new DataApiRequestImpl().generateFilters("locale|id-in[US,India],locale.id-eq[5]", table, dimensionDict)
+        new TestingDataApiRequestImpl().generateFilters(
+                "locale|id-in[US,India],locale.id-eq[5]",
+                table,
+                dimensionDict
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -144,7 +153,11 @@ class DataApiRequestFilterSpec extends Specification {
         setup:
         String expectedMessage = ErrorMessageFormat.FILTER_DIMENSION_UNDEFINED.format('undefined')
         when:
-        new DataApiRequestImpl().generateFilters("undefined|id-in[US,India],locale.id-eq[5]", table, dimensionDict)
+        new TestingDataApiRequestImpl().generateFilters(
+                "undefined|id-in[US,India],locale.id-eq[5]",
+                table,
+                dimensionDict
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -156,7 +169,11 @@ class DataApiRequestFilterSpec extends Specification {
         // Split for filter splits to ],.  Everything before this is included in bad error.
         String expectedMessage = ErrorMessageFormat.FILTER_INVALID.format('locale.id-in[US,India]')
         when:
-        new DataApiRequestImpl().generateFilters("locale.id-in[US,India],locale.id-eq[5]", table, dimensionDict)
+        new TestingDataApiRequestImpl().generateFilters(
+                "locale.id-in[US,India],locale.id-eq[5]",
+                table,
+                dimensionDict
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -171,7 +188,7 @@ class DataApiRequestFilterSpec extends Specification {
 
         String expectedMessage = ErrorMessageFormat.FILTER_ERROR.format(filter, error)
         when:
-        new DataApiRequestImpl().generateFilters(filter, table, dimensionDict)
+        new TestingDataApiRequestImpl().generateFilters(filter, table, dimensionDict)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -183,7 +200,11 @@ class DataApiRequestFilterSpec extends Specification {
         // Split for filter splits to ],.  Everything before this is included in bad error.
         String expectedMessage = ErrorMessageFormat.FILTER_OPERATOR_INVALID.format('in:')
         when:
-        new DataApiRequestImpl().generateFilters("locale|id-in:[US,India],locale.id-eq[5]", table, dimensionDict)
+        new TestingDataApiRequestImpl().generateFilters(
+                "locale|id-in:[US,India],locale.id-eq[5]",
+                table,
+                dimensionDict
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestIntervalsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestIntervalsSpec.groovy
@@ -23,8 +23,7 @@ import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.TableGroup
 import com.yahoo.bard.webservice.util.DateTimeFormatterFactory
 import com.yahoo.bard.webservice.util.IntervalUtils
-import com.yahoo.bard.webservice.web.apirequest.ApiRequestImpl
-import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -50,12 +49,11 @@ class DataApiRequestIntervalsSpec extends Specification {
     DateTimeFormatter dateTimeFormatter
 
     @Shared
-    Function<TimeGrain, DateTime> dateParser = { new DataApiRequestImpl().getCurrentDate(new DateTime(), it)}
+    Function<TimeGrain, DateTime> dateParser = { new TestingDataApiRequestImpl().getCurrentDate(new DateTime(), it)}
 
     static final DateTimeZone originalTimeZone = DateTimeZone.default
 
-    class ConcreteApiRequest extends ApiRequestImpl {}
-    ConcreteApiRequest concreteApiRequest = new ConcreteApiRequest()
+    TestingDataApiRequestImpl apiRequest = new TestingDataApiRequestImpl()
 
     def setupSpec() {
         DateTimeZone.default = IntervalUtils.SYSTEM_ALIGNMENT_EPOCH.zone
@@ -96,10 +94,16 @@ class DataApiRequestIntervalsSpec extends Specification {
         Interval expectedInterval = new Interval(parsedStart, parsedStop)
 
         expect: "The interval string parses into a single interval"
-        new DataApiRequestImpl().generateIntervals(intervalString, concreteApiRequest.generateGranularity(name, granularityParser), dateTimeFormatter).size() == 1
+        new TestingDataApiRequestImpl().generateIntervals(
+                intervalString,
+                apiRequest.generateGranularity(name, granularityParser), dateTimeFormatter
+        ).size() == 1
 
         and: "It parses to the interval we expect"
-        new DataApiRequestImpl().generateIntervals(intervalString, concreteApiRequest.generateGranularity(name, granularityParser), dateTimeFormatter).first() == expectedInterval
+        new TestingDataApiRequestImpl().generateIntervals(
+                intervalString,
+                apiRequest.generateGranularity(name, granularityParser), dateTimeFormatter
+        ).first() == expectedInterval
 
         where:
         intervalString                                    | name  | parsedStart                                  | parsedStop
@@ -137,10 +141,16 @@ class DataApiRequestIntervalsSpec extends Specification {
         Interval expectedInterval = new Interval(parsedStart, parsedStop)
 
         expect: "The interval string parses into a single interval"
-        new DataApiRequestImpl().generateIntervals(intervalString, concreteApiRequest.generateGranularity(name, granularityParser), dateTimeFormatter).size() == 1
+        new TestingDataApiRequestImpl().generateIntervals(
+                intervalString,
+                apiRequest.generateGranularity(name, granularityParser), dateTimeFormatter
+        ).size() == 1
 
         and: "It parses to the interval we expect"
-        new DataApiRequestImpl().generateIntervals(intervalString, concreteApiRequest.generateGranularity(name, granularityParser), dateTimeFormatter).first() == expectedInterval
+        new TestingDataApiRequestImpl().generateIntervals(
+                intervalString,
+                apiRequest.generateGranularity(name, granularityParser), dateTimeFormatter
+        ).first() == expectedInterval
 
         where:
         intervalString                     | name      | parsedStart                                    | parsedStop
@@ -183,16 +193,16 @@ class DataApiRequestIntervalsSpec extends Specification {
         Interval expectedInterval = new Interval(parsedStart, parsedStop)
 
         expect: "The interval string parses into a single interval"
-        new DataApiRequestImpl().generateIntervals(
+        new TestingDataApiRequestImpl().generateIntervals(
                 intervalString,
-                concreteApiRequest.generateGranularity(name, granularityParser),
+                apiRequest.generateGranularity(name, granularityParser),
                 dateTimeFormatter
         ).size() == 1
 
         and: "It parses to the interval we expect"
-        new DataApiRequestImpl().generateIntervals(
+        new TestingDataApiRequestImpl().generateIntervals(
                 intervalString,
-                concreteApiRequest.generateGranularity(name, granularityParser),
+                apiRequest.generateGranularity(name, granularityParser),
                 dateTimeFormatter
         ).first() == expectedInterval
 
@@ -227,9 +237,9 @@ class DataApiRequestIntervalsSpec extends Specification {
     @Unroll
     def "check invalid usage of macros as time intervals string #intervalString"() {
         when:
-        new DataApiRequestImpl().generateIntervals(
+        new TestingDataApiRequestImpl().generateIntervals(
                 intervalString,
-                concreteApiRequest.generateGranularity(name, granularityParser),
+                apiRequest.generateGranularity(name, granularityParser),
                 dateTimeFormatter
         )
 
@@ -254,9 +264,9 @@ class DataApiRequestIntervalsSpec extends Specification {
         }
 
         expect:
-        Set<Interval> intervals = new DataApiRequestImpl().generateIntervals(
+        Set<Interval> intervals = new TestingDataApiRequestImpl().generateIntervals(
                 interval1 + "," + interval2,
-                concreteApiRequest.generateGranularity("day", granularityParser),
+                apiRequest.generateGranularity("day", granularityParser),
                 dateTimeFormatter
         )
         intervals == expected
@@ -269,9 +279,9 @@ class DataApiRequestIntervalsSpec extends Specification {
     @Unroll
     def "check bad generateIntervals throws #reason.simpleName"() {
         when:
-        new DataApiRequestImpl().generateIntervals(
+        new TestingDataApiRequestImpl().generateIntervals(
                 interval1 + "," + interval2,
-                concreteApiRequest.generateGranularity("day", granularityParser),
+                apiRequest.generateGranularity("day", granularityParser),
                 dateTimeFormatter
         )
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestSortSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestSortSpec.groovy
@@ -6,6 +6,7 @@ import com.yahoo.bard.webservice.application.JerseyTestBinder
 import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn
 import com.yahoo.bard.webservice.druid.model.orderby.SortDirection
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 import com.yahoo.bard.webservice.web.endpoints.DataServlet
 
 import spock.lang.Specification
@@ -32,7 +33,9 @@ class DataApiRequestSortSpec extends Specification {
         String expectedMessage = ErrorMessageFormat.DATE_TIME_SORT_VALUE_INVALID.format()
 
         when:
-        new DataApiRequestImpl().generateDateTimeSortColumn(["xyz":SortDirection.DESC, "dateTime":SortDirection.DESC])
+        new TestingDataApiRequestImpl().generateDateTimeSortColumn(
+                ["xyz":SortDirection.DESC, "dateTime":SortDirection.DESC]
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -42,7 +45,7 @@ class DataApiRequestSortSpec extends Specification {
     @Unroll
     def "Validate the sort column and direction map from #sortString string"() {
         expect:
-        new DataApiRequestImpl().generateSortColumns(sortString) == expected
+        new TestingDataApiRequestImpl().generateSortColumns(sortString) == expected
 
         where:
         sortString                        | expected
@@ -62,7 +65,7 @@ class DataApiRequestSortSpec extends Specification {
     @Unroll
     def "Generate dateTime sort column from columnDirection map #columnDirection"() {
         expect:
-        new DataApiRequestImpl().generateDateTimeSortColumn(columnDirection) == expected
+        new TestingDataApiRequestImpl().generateDateTimeSortColumn(columnDirection) == expected
 
         where:
         columnDirection                                                                          | expected
@@ -77,7 +80,7 @@ class DataApiRequestSortSpec extends Specification {
     @Unroll
     def "Remove dateTime sort column from columnDirection map #columnDirection"() {
         expect:
-        new DataApiRequestImpl().removeDateTimeSortColumn(columnDirection) == expected
+        new TestingDataApiRequestImpl().removeDateTimeSortColumn(columnDirection) == expected
 
         where:
         columnDirection                                                                          | expected
@@ -92,7 +95,7 @@ class DataApiRequestSortSpec extends Specification {
     @Unroll
     def "Check dateTime column is first in the sort column map #columnDirection "() {
         expect:
-        new DataApiRequestImpl().isDateTimeFirstSortField(columnDirection) == expected
+        new TestingDataApiRequestImpl().isDateTimeFirstSortField(columnDirection) == expected
 
         where:
         columnDirection                                                                          | expected

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/IntersectionReportingFlagOffSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/IntersectionReportingFlagOffSpec.groovy
@@ -16,6 +16,7 @@ import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.table.TableGroup
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import org.joda.time.DateTime
 
@@ -56,7 +57,7 @@ class IntersectionReportingFlagOffSpec extends Specification {
 
     def "When INTERSECTION_REPORTING feature flag is off, query with valid unfiltered metrics returns the correct metrics from the metric dictionary"() {
         when: "The metric string contains valid unfiltered metrics"
-        new DataApiRequestImpl().generateLogicalMetrics("met1,met2,met3", metricDict, dimensionDict, table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics("met1,met2,met3", metricDict, dimensionDict, table)
 
         then: "The metrics generated are the same ones as in the dictionary"
         ["met1", "met2", "met3" ].collect { metricDict.get(it) }
@@ -64,7 +65,12 @@ class IntersectionReportingFlagOffSpec extends Specification {
 
     def "When INTERSECTION_REPORTING feature flag is off, query with valid filtered metrics throws BadApiException"() {
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("met1(AND(app1,app2)),met2,met3", metricDict, dimensionDict, table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "met1(AND(app1,app2)),met2,met3",
+                metricDict,
+                dimensionDict,
+                table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingResources.groovy
@@ -42,6 +42,7 @@ import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.TableGroup
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -186,11 +187,31 @@ class SketchIntersectionReportingResources extends Specification {
         fooNoBarAggregation = fooNoBarInstance.make().templateDruidQuery.aggregations.first()
         Aggregation regFoosAggregation = regFoosInstance.make().templateDruidQuery.aggregations.first()
 
-        fooNoBarFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(filterObj, fooNoBarAggregation, dimensionDict, table, new DataApiRequestImpl())
-        fooNoBarPostAggregationInterim = SketchSetOperationHelper.makePostAggFromAgg(SketchSetOperationPostAggFunction.INTERSECT, "fooNoBar", new ArrayList<>(fooNoBarFilteredAggregationSet))
+        fooNoBarFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(
+                filterObj,
+                fooNoBarAggregation,
+                dimensionDict,
+                table,
+                new TestingDataApiRequestImpl()
+        )
+        fooNoBarPostAggregationInterim = SketchSetOperationHelper.makePostAggFromAgg(
+                SketchSetOperationPostAggFunction.INTERSECT,
+                "fooNoBar",
+                new ArrayList<>(fooNoBarFilteredAggregationSet)
+        )
 
-        fooRegFoosFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(filterObj, regFoosAggregation, dimensionDict, table, new DataApiRequestImpl())
-        fooRegFoosPostAggregationInterim = SketchSetOperationHelper.makePostAggFromAgg(SketchSetOperationPostAggFunction.INTERSECT, "regFoos", new ArrayList<>(fooRegFoosFilteredAggregationSet))
+        fooRegFoosFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(
+                filterObj,
+                regFoosAggregation,
+                dimensionDict,
+                table,
+                new TestingDataApiRequestImpl()
+        )
+        fooRegFoosPostAggregationInterim = SketchSetOperationHelper.makePostAggFromAgg(
+                SketchSetOperationPostAggFunction.INTERSECT,
+                "regFoos",
+                new ArrayList<>(fooRegFoosFilteredAggregationSet)
+        )
 
         interimPostAggDictionary = [:]
         interimPostAggDictionary.put(fooNoBarAggregation.getName(), fooNoBarFilteredAggregationSet as List)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchIntersectionReportingSpec.groovy
@@ -15,6 +15,7 @@ import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationP
 import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationPostAggregation
 import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import spock.lang.Specification
 /**
@@ -39,7 +40,12 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When the format of the metric filter is invalid, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country|id-in[US,IN]property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country|id-in[US,IN]property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -49,7 +55,12 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When the API query contains duplicate metrics, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("foos,foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos,foos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -58,7 +69,12 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When the queried metric is not present in Metric Dictionary, BadApiRequestException is thrown"() {
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("dinga", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "dinga",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -67,7 +83,12 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When metric filter contains 'OR' condition, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("foos(OR(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(OR(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -75,7 +96,12 @@ class SketchIntersectionReportingSpec extends Specification {
     }
 
     def "When the INTERSECTION_REPORTING flag is enabled and the query contains unfiltered metrics, the Logical Metrics returned are equal to the Logical Metrics from the Metric Dictionary"() {
-        Set<LogicalMetric> logicalMetrics = new DataApiRequestImpl().generateLogicalMetrics("pageViews,foos", resources.metricDict, resources.dimensionDict, resources.table)
+        Set<LogicalMetric> logicalMetrics = new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "pageViews,foos",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
         HashSet<Dimension> expected =
                 ["pageViews", "foos"].collect { String name ->
                     LogicalMetric metric = resources.metricDict.get(name)
@@ -89,7 +115,12 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When metric filter contains invalid dimension, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country1|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country1|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -102,7 +133,7 @@ class SketchIntersectionReportingSpec extends Specification {
                 resources.filterObj,
                 resources.dimensionDict,
                 resources.table,
-                new DataApiRequestImpl()
+                new TestingDataApiRequestImpl()
         )
 
         expect:
@@ -116,7 +147,7 @@ class SketchIntersectionReportingSpec extends Specification {
                 resources.filterObj,
                 resources.dimensionDict,
                 resources.table,
-                new DataApiRequestImpl()
+                new TestingDataApiRequestImpl()
         )
 
         Set<Aggregation> aggregations = templateDruidQuery.aggregations;
@@ -156,7 +187,12 @@ class SketchIntersectionReportingSpec extends Specification {
 
     def "When invalid(non-sketch) metric is used for filtering, IllegalArgumentException is thrown "(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("pageViews(AND(country|id-in[US,IN],property|id-in[news,sports]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "pageViews(AND(country|id-in[US,IN],property|id-in[news,sports]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(IllegalArgumentException)
@@ -164,7 +200,12 @@ class SketchIntersectionReportingSpec extends Specification {
     }
 
     def "When API request contains filtered metrics, the Logical Metric returned by generateLogicalMetrics is filtered and therefore not equal to the Logical Metric from the Metric dictionary "(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         HashSet<Dimension> expected =
                 ["foos"].collect { String name ->
@@ -178,10 +219,15 @@ class SketchIntersectionReportingSpec extends Specification {
     }
 
     def "An exception is thrown when validateMetrics is passed an intersection expression using invalid metrics"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("regFoos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "regFoos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         when:
-        new DataApiRequestImpl().validateMetrics(logicalMetrics,resources.table)
+        new TestingDataApiRequestImpl().validateMetrics(logicalMetrics,resources.table)
 
         then:
         String expectedMessage = "Requested metric(s) '[regFoos]' are not supported by the table 'NETWORK'."
@@ -191,17 +237,27 @@ class SketchIntersectionReportingSpec extends Specification {
     }
 
     def "No exception is thrown when validateMetrics is passed an intersection expression using valid metrics"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         when:
-        new DataApiRequestImpl().validateMetrics(logicalMetrics, resources.table)
+        new TestingDataApiRequestImpl().validateMetrics(logicalMetrics, resources.table)
 
         then:
         noExceptionThrown()
     }
 
     def "The dimensions returned from the filtered logical metric are correct"() {
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         expect:
         logicalMetrics.first().templateDruidQuery.metricDimensions.sort() == [resources.propertyDim, resources.countryDim].sort()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchNestedQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/SketchNestedQuerySpec.groovy
@@ -17,6 +17,7 @@ import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationP
 import com.yahoo.bard.webservice.druid.model.postaggregation.SketchSetOperationPostAggregation
 import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import spock.lang.Specification
 
@@ -75,7 +76,12 @@ class SketchNestedQuerySpec extends Specification {
     }
 
     def "Intersection reporting when Logical Metric has nested query"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
         TemplateDruidQuery nestedQuery = logicalMetrics.first().getTemplateDruidQuery().getInnerQuery().get()
 
         Set<Aggregation> expectedNestedAggs = new HashSet<>()
@@ -99,7 +105,12 @@ class SketchNestedQuerySpec extends Specification {
     }
 
     def "metric filter on viz metric and expect children of unRegFoos have right sketch operation function"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("viz(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "viz(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
         ArithmeticPostAggregation postAggregation = logicalMetrics.first().templateDruidQuery.getPostAggregations().first()
 
         FuzzySetPostAggregation unRegFoo1;
@@ -118,7 +129,12 @@ class SketchNestedQuerySpec extends Specification {
 
     def "When metrics of Ratio category are filtered, BadApiException is thrown"() {
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("ratioMetric(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "ratioMetric(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -126,7 +142,12 @@ class SketchNestedQuerySpec extends Specification {
     }
 
     def "The dimensions returned from the filtered nested logical metric are correct"() {
-        LinkedHashSet<LogicalMetric> logicalMetrics = new DataApiRequestImpl().generateLogicalMetrics("dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics = new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "dayAvgFoos(AND(country|id-in[US,IN],property|id-in[114,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         expect:
         logicalMetrics.first().templateDruidQuery.getMetricDimensions().sort() == [resources.propertyDim, resources.countryDim].sort()

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingResources.groovy
@@ -43,6 +43,7 @@ import com.yahoo.bard.webservice.table.PhysicalTable
 import com.yahoo.bard.webservice.table.StrictPhysicalTable
 import com.yahoo.bard.webservice.table.TableGroup
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -184,11 +185,31 @@ class ThetaSketchIntersectionReportingResources extends Specification {
         fooNoBarAggregation = fooNoBarInstance.make().templateDruidQuery.aggregations.first()
         Aggregation regFoosAggregation = regFoosInstance.make().templateDruidQuery.aggregations.first()
 
-        fooNoBarFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(filterObj, fooNoBarAggregation, dimensionDict, table, new DataApiRequestImpl())
-        fooNoBarPostAggregationInterim = ThetaSketchSetOperationHelper.makePostAggFromAgg(SketchSetOperationPostAggFunction.INTERSECT, "fooNoBar", new ArrayList<>(fooNoBarFilteredAggregationSet))
+        fooNoBarFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(
+                filterObj,
+                fooNoBarAggregation,
+                dimensionDict,
+                table,
+                new TestingDataApiRequestImpl()
+        )
+        fooNoBarPostAggregationInterim = ThetaSketchSetOperationHelper.makePostAggFromAgg(
+                SketchSetOperationPostAggFunction.INTERSECT,
+                "fooNoBar",
+                new ArrayList<>(fooNoBarFilteredAggregationSet)
+        )
 
-        fooRegFoosFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(filterObj, regFoosAggregation, dimensionDict, table, new DataApiRequestImpl())
-        fooRegFoosPostAggregationInterim = ThetaSketchSetOperationHelper.makePostAggFromAgg(SketchSetOperationPostAggFunction.INTERSECT, "regFoos", new ArrayList<>(fooRegFoosFilteredAggregationSet))
+        fooRegFoosFilteredAggregationSet = FieldConverterSupplier.metricsFilterSetBuilder.getFilteredAggregation(
+                filterObj,
+                regFoosAggregation,
+                dimensionDict,
+                table,
+                new TestingDataApiRequestImpl()
+        )
+        fooRegFoosPostAggregationInterim = ThetaSketchSetOperationHelper.makePostAggFromAgg(
+                SketchSetOperationPostAggFunction.INTERSECT,
+                "regFoos",
+                new ArrayList<>(fooRegFoosFilteredAggregationSet)
+        )
 
         interimPostAggDictionary = [:]
         interimPostAggDictionary.put(fooNoBarAggregation.getName(), fooNoBarFilteredAggregationSet as List)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ThetaSketchIntersectionReportingSpec.groovy
@@ -15,6 +15,7 @@ import com.yahoo.bard.webservice.druid.model.postaggregation.ThetaSketchEstimate
 import com.yahoo.bard.webservice.druid.model.postaggregation.ThetaSketchSetOperationPostAggregation
 import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import spock.lang.Specification
 
@@ -35,7 +36,12 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When the format of the metric filter is invalid, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country|id-in[US,IN]property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country|id-in[US,IN]property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -45,7 +51,12 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When the API query contains duplicate metrics, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("foos,foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos,foos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -54,7 +65,12 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When the queried metric is not present in Metric Dictionary, BadApiRequestException is thrown"() {
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("dinga", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "dinga",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -63,7 +79,12 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When metric filter contains 'OR' condition, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("foos(OR(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(OR(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -71,7 +92,12 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     }
 
     def "When the INTERSECTION_REPORTING flag is enabled and the query contains unfiltered metrics, the Logical Metrics returned are equal to the Logical Metrics from the Metric Dictionary"() {
-        Set<LogicalMetric> logicalMetrics = new DataApiRequestImpl().generateLogicalMetrics("pageViews,foos", resources.metricDict, resources.dimensionDict, resources.table)
+        Set<LogicalMetric> logicalMetrics = new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "pageViews,foos",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
         HashSet<Dimension> expected =
                 ["pageViews", "foos"].collect { String name ->
                     LogicalMetric metric = resources.metricDict.get(name)
@@ -85,7 +111,12 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When metric filter contains invalid dimension, BadApiRequestException is thrown"(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country1|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country1|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -98,7 +129,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
                 resources.filterObj,
                 resources.dimensionDict,
                 resources.table,
-                new DataApiRequestImpl()
+                new TestingDataApiRequestImpl()
         )
 
         expect:
@@ -112,7 +143,7 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
                 resources.filterObj,
                 resources.dimensionDict,
                 resources.table,
-                new DataApiRequestImpl()
+                new TestingDataApiRequestImpl()
         )
 
         Set<Aggregation> aggregations = templateDruidQuery.aggregations;
@@ -152,7 +183,12 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
 
     def "When invalid(non-sketch) metric is used for filtering, IllegalArgumentException is thrown "(){
         when:
-        new DataApiRequestImpl().generateLogicalMetrics("pageViews(AND(country|id-in[US,IN],property|id-in[news,sports]))", resources.metricDict, resources.dimensionDict, resources.table)
+        new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "pageViews(AND(country|id-in[US,IN],property|id-in[news,sports]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         then:
         Exception e = thrown(IllegalArgumentException)
@@ -160,7 +196,12 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     }
 
     def "When API request contains filtered metrics, the Logical Metric returned by generateLogicalMetrics is filtered and therefore not equal to the Logical Metric from the Metric dictionary "(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         HashSet<Dimension> expected =
                 ["foos"].collect { String name ->
@@ -174,10 +215,15 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     }
 
     def "An exception is thrown when validateMetrics is passed an intersection expression using invalid metrics"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("regFoos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "regFoos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         when:
-        new DataApiRequestImpl().validateMetrics(logicalMetrics, resources.table)
+        new TestingDataApiRequestImpl().validateMetrics(logicalMetrics, resources.table)
 
         then:
         String expectedMessage = "Requested metric(s) '[regFoos]' are not supported by the table 'NETWORK'."
@@ -187,19 +233,30 @@ class ThetaSketchIntersectionReportingSpec extends Specification {
     }
 
     def "No exception is thrown when validateMetrics is passed an intersection expression using valid metrics"(){
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         when:
-        new DataApiRequestImpl().validateMetrics(logicalMetrics, resources.table)
+        new TestingDataApiRequestImpl().validateMetrics(logicalMetrics, resources.table)
 
         then:
         noExceptionThrown()
     }
 
     def "The dimensions returned from the filtered logical metric are correct"() {
-        LinkedHashSet<LogicalMetric> logicalMetrics =  new DataApiRequestImpl().generateLogicalMetrics("foos(AND(country|id-in[US,IN],property|id-in[14,125]))", resources.metricDict, resources.dimensionDict, resources.table)
+        LinkedHashSet<LogicalMetric> logicalMetrics =  new TestingDataApiRequestImpl().generateLogicalMetrics(
+                "foos(AND(country|id-in[US,IN],property|id-in[14,125]))",
+                resources.metricDict,
+                resources.dimensionDict,
+                resources.table
+        )
 
         expect:
-        logicalMetrics.first().templateDruidQuery.metricDimensions.sort() == [resources.propertyDim, resources.countryDim].sort()
+        logicalMetrics.first().templateDruidQuery.metricDimensions.sort() ==
+                [resources.propertyDim, resources.countryDim].sort()
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImplSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImplSpec.groovy
@@ -23,6 +23,7 @@ import com.yahoo.bard.webservice.util.IntervalUtils
 import com.yahoo.bard.webservice.web.BadApiRequestException
 import com.yahoo.bard.webservice.web.ErrorMessageFormat
 import com.yahoo.bard.webservice.web.ResponseFormatType
+import com.yahoo.bard.webservice.web.apirequest.utils.TestingDataApiRequestImpl
 
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -90,14 +91,14 @@ class DataApiRequestImplSpec extends Specification {
 
         where:
         responseFormat          | expectedFormat
-        ResponseFormatType.JSON | new DataApiRequestImpl().generateAcceptFormat(null)
-        ResponseFormatType.JSON | new DataApiRequestImpl().generateAcceptFormat("json")
-        ResponseFormatType.CSV  | new DataApiRequestImpl().generateAcceptFormat("csv")
+        ResponseFormatType.JSON | new TestingDataApiRequestImpl().generateAcceptFormat(null)
+        ResponseFormatType.JSON | new TestingDataApiRequestImpl().generateAcceptFormat("json")
+        ResponseFormatType.CSV  | new TestingDataApiRequestImpl().generateAcceptFormat("csv")
     }
 
     def "check invalid parsing generateFormat"() {
         when:
-        new DataApiRequestImpl().generateAcceptFormat("bad")
+        new TestingDataApiRequestImpl().generateAcceptFormat("bad")
 
         then:
         thrown BadApiRequestException
@@ -105,7 +106,7 @@ class DataApiRequestImplSpec extends Specification {
 
     def "check parsing generateLogicalMetrics"() {
 
-        Set<LogicalMetric> logicalMetrics = new DataApiRequestImpl().generateLogicalMetrics(
+        Set<LogicalMetric> logicalMetrics = new TestingDataApiRequestImpl().generateLogicalMetrics(
                 "met1,met2,met3",
                 metricDict,
                 dimensionDict,
@@ -125,7 +126,7 @@ class DataApiRequestImplSpec extends Specification {
     @Unroll
     def "check valid granularity name #name parses to granularity #expected"() {
         expect:
-        new DataApiRequestImpl().generateGranularity(name, granularityParser) == expected
+        new TestingDataApiRequestImpl().generateGranularity(name, granularityParser) == expected
 
         where:
         name    | expected
@@ -139,7 +140,7 @@ class DataApiRequestImplSpec extends Specification {
         String expectedMessage = ErrorMessageFormat.UNKNOWN_GRANULARITY.format(timeGrainName)
 
         when:
-        new DataApiRequestImpl().generateGranularity(timeGrainName, granularityParser)
+        new TestingDataApiRequestImpl().generateGranularity(timeGrainName, granularityParser)
 
         then:
         Exception e = thrown(BadApiRequestException)
@@ -149,7 +150,10 @@ class DataApiRequestImplSpec extends Specification {
     def "check weekly granularity has the expected alignment description"() {
         setup:
         String expectedMessage = " Week must start on a Monday and end on a Monday."
-        Granularity<?> granularity = new DataApiRequestImpl().generateGranularity("week", new StandardGranularityParser())
+        Granularity<?> granularity = new TestingDataApiRequestImpl().generateGranularity(
+                "week",
+                new StandardGranularityParser()
+        )
 
         expect:
         granularity.getAlignmentDescription() == expectedMessage

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/utils/TestingDataApiRequestImpl.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/utils/TestingDataApiRequestImpl.groovy
@@ -1,0 +1,39 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.utils
+
+import static javax.ws.rs.core.Response.Status.OK
+
+import com.yahoo.bard.webservice.data.filterbuilders.DefaultDruidFilterBuilder
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
+import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+
+import javax.ws.rs.core.Response
+
+class TestingDataApiRequestImpl extends DataApiRequestImpl {
+    TestingDataApiRequestImpl() {
+        super(
+                null,
+                null,
+                null,
+                Response.status(OK),
+                null,
+                DefaultTimeGrain.DAY,
+                [] as Set,
+                null,
+                [] as Set,
+                [] as Set,
+                [:],
+                null,
+                null,
+                null,
+                0,
+                0,
+                Long.MAX_VALUE,
+                null,
+                new DefaultDruidFilterBuilder(),
+                null,
+                null
+        )
+    }
+}


### PR DESCRIPTION
Addresses issue https://github.com/yahoo/fili/issues/534

* It is a better practice to separate testing code with implementation. All testing constructors of the following API requests are removed:
    - `ApiRequestImpl`
    - `DataApiRequestImpl`
    - `DimensionsApiRequestImpl`
    - `MetricsApiRequestImpl`
    - `SlicesApiRequestImpl`
    - `TablesApiRequestImpl`
* Meanwhile, construction of testing API request is delegated to testing class, e.g. `TestingDataApiRequestImpl`