### PR TITLE
Fix tests with wrong time offset calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,10 @@ Current
 
 ### Fixed:
 
+- [Fix tests with wrong time offset calculation](https://github.com/yahoo/fili/pull/567)
+    * Time-checking based tests setup time offset in a wrong way. `timeZoneId.getOffset` is fixed to take the right
+      argument.
+
 - [Handle Number Format errors from empty or missing cardinality value](https://github.com/yahoo/fili/issues/549)
 
 - [Fix lucene search provider replace method](https://github.com/yahoo/fili/pull/551)

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/DefaultSqlBackedClientSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/DefaultSqlBackedClientSpec.groovy
@@ -188,8 +188,9 @@ class DefaultSqlBackedClientSpec extends Specification {
         setup:
         def timeZoneId = DateTimeZone.forID(timeZone)
         // shift the start and end dates by the offset from utc time
-        def start = new DateTime(START).plusMillis(-timeZoneId.getOffset(new DateTime(DateTimeZone.UTC))).toString()
-        def end = new DateTime(END).plusMillis(-timeZoneId.getOffset(new DateTime(DateTimeZone.UTC))).toString()
+        def raw = new DateTime(START)
+        def start = new DateTime(START).plusMillis(-timeZoneId.getOffset(raw)).toString()
+        def end = new DateTime(END).plusMillis(-timeZoneId.getOffset(raw)).toString()
 
         TimeSeriesQuery timeSeriesQuery = new TimeSeriesQuery(
                 dataSource(WIKITICKER, DAY, timeZoneId, [ADDED], [], "", ""),


### PR DESCRIPTION
Time-checking based tests setup time offset in a wrong way. `timeZoneId.getOffset` is fixed to take the right argument.