### PR TITLE
Check initialization of dimension storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Current
 
 ### Added:
 
+- [Check initialization of dimension storage](https://github.com/yahoo/fili/pull/571)
+    * Uninitialized dimension storage causes a null based error when search provider attempts to retrieve
+      cardinality. A default method is added to search provider interface that forces a null check.
+
 - [Have Table Endpoint Filter Using QueryPlanningConstraint](https://github.com/yahoo/fili/pull/439)
     * Enable tables endpoint to fiilter availabilities based on availability-constraint
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/SearchProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/SearchProvider.java
@@ -7,6 +7,8 @@ import com.yahoo.bard.webservice.util.Pagination;
 import com.yahoo.bard.webservice.web.ApiFilter;
 import com.yahoo.bard.webservice.web.util.PaginationParameters;
 
+import com.google.common.base.Preconditions;
+
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashSet;
@@ -33,7 +35,17 @@ public interface SearchProvider {
      *
      * @param keyValueStore  KeyValueStore that holds the data rows indexed by the Search Provider
      */
-    void setKeyValueStore(KeyValueStore keyValueStore);
+    default void setKeyValueStore(KeyValueStore keyValueStore) {
+        Preconditions.checkNotNull(keyValueStore);
+        setKeyValueStoreInner(keyValueStore);
+    }
+
+    /**
+     * Inner setter for store.
+     *
+     * @param keyValueStore  KeyValueStore that holds the data rows indexed by the Search Provider
+     */
+    void setKeyValueStoreInner(KeyValueStore keyValueStore);
 
     /**
      * Gets the number of distinct dimension rows (assuming the key field is unique) in the index.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/LuceneSearchProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/LuceneSearchProvider.java
@@ -195,7 +195,7 @@ public class LuceneSearchProvider implements SearchProvider {
     }
 
     @Override
-    public void setKeyValueStore(KeyValueStore keyValueStore) {
+    public void setKeyValueStoreInner(KeyValueStore keyValueStore) {
         this.keyValueStore = keyValueStore;
         // Check initialization for the cardinality in a keyValueStore
         if (keyValueStore.get(DimensionStoreKeyUtils.getCardinalityKey()) == null) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/NoOpSearchProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/NoOpSearchProvider.java
@@ -49,7 +49,7 @@ public class NoOpSearchProvider implements SearchProvider {
     }
 
     @Override
-    public void setKeyValueStore(KeyValueStore keyValueStore) {
+    public void setKeyValueStoreInner(KeyValueStore keyValueStore) {
         // do nothing
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/ScanSearchProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/ScanSearchProvider.java
@@ -58,7 +58,7 @@ public class ScanSearchProvider implements SearchProvider, FilterDimensionRows {
     }
 
     @Override
-    public void setKeyValueStore(KeyValueStore keyValueStore) {
+    public void setKeyValueStoreInner(KeyValueStore keyValueStore) {
         this.keyValueStore = keyValueStore;
 
         // Check initialization for the cardinality in a keyValueStore

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/impl/SearchProviderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/dimension/impl/SearchProviderSpec.groovy
@@ -140,6 +140,14 @@ abstract class SearchProviderSpec<T extends SearchProvider> extends Specificatio
      */
     abstract void cleanSearchProvider(String dimensionName)
 
+    def "setKeyValueStore() throws IllegalArgumentException on null dimension store"() {
+        when:
+        searchProvider.setKeyValueStore(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
     def "getDimensionCardinality returns cardinality count"() {
         expect:
         searchProvider.getDimensionCardinality() == dimensionRows.size()


### PR DESCRIPTION
Address issue https://github.com/yahoo/fili/issues/549

Uninitialized dimension storage causes a null based error when search provider attempts to retrieve cardinality. A default method is added to search provider interface that forces a null check.