### PR TITLE
Expose RequestLog's LogInfo objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ Current
 
 ### Changed:
 
+- [Expose `RequestLog` `LogInfo` objects](https://github.com/yahoo/fili/pull/574)
+    * Exposes the `LogInfo` objects stored in the `RequestLog`, via `RequestLog::retrieveAll` making it easier
+        for customers to implement their own scheme for logging the `RequestLog`.
+
 - [Display corrected case on StorageStrategy serialization](https://github.com/yahoo/fili/pull/578)
     * The default serialization of enum is `name()` which is final and thus cannot be overridden. An API method is added
       to return the API name of a storage strategy.
@@ -251,7 +255,7 @@ Current
         - `SlicesApiRequestImpl`
         - `TablesApiRequestImpl`
     * Meanwhile, construction of testing API request is delegated to testing class, e.g. `TestingDataApiRequestImpl`
-    
+
 - [Reverted the druid name change in slices endpoint instead added to factName](https://github.com/yahoo/fili/pull/541)
     * Reverting the PR-419(https://github.com/yahoo/fili/pull/419) so that the name still points to apiName and added factName which points to druidName.
       `name` was not valid for cases when it is a Lookup dimension because it was pointing to the base dimension name , so reverted that change and added

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -351,6 +351,21 @@ public class RequestLog {
     }
 
     /**
+     * Returns a map of all the LogInfo blocks currently registered with this thread's RequestLog.
+     *
+     * @return A map of all the LogInfo objects registered to this thread's RequestLog
+     */
+    public static Map<String, LogInfo> retrieveAll() {
+        RequestLog requestLog = RLOG.get();
+        if (requestLog == null) {
+            String message = String.format("Attempted to retrieve log info while request log object was uninitialized");
+            LOG.error(message);
+            throw new IllegalStateException(message);
+        }
+        return requestLog.info.any();
+    }
+
+    /**
      * Write the request log object of the current thread as JSON.
      * The thread's request log is cleared after a call to this method.
      */


### PR DESCRIPTION
-- Some customers want to be able to customize how the RequestLog is
logged. By exposing the LogInfo objects and the durations, we
effectively give customers full control over how they want to log
each component of the RequestLog.