### PR TITLE
Display corrected case on StorageStrategy serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,11 @@ Current
 
 
 ### Changed:
+
+- [Display corrected case on StorageStrategy serialization](https://github.com/yahoo/fili/pull/578)
+    * The default serialization of enum is `name()` which is final and thus cannot be overridden. An API method is added
+      to return the API name of a storage strategy.
+
 - [Made StorageStrategy lower case]
 
 - [Make shareable methods accessiable to all types of API requests](https://github.com/yahoo/fili/pull/565)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/metadata/StorageStrategy.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/metadata/StorageStrategy.java
@@ -2,8 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.dimension.metadata;
 
-import java.util.Locale;
-
 /**
  * Allows clients to be notified if a dimension's values are browsable and searchable.
  * <p>
@@ -17,14 +15,29 @@ public enum StorageStrategy {
     /**
      * Loaded dimension.
      */
-    LOADED,
+    LOADED("Loaded"),
     /**
      * Non-loaded dimension.
      */
-    NONE;
+    NONE("None");
 
-    @Override
-    public String toString() {
-        return name().toLowerCase(Locale.ENGLISH);
+    private final String apiName;
+
+    /**
+     * Constructor.
+     *
+     * @param apiName  The API name of this storage strategy
+     */
+    StorageStrategy(String apiName) {
+        this.apiName = apiName;
+    }
+
+    /**
+     * Returns the API name of this StorageStrategy.
+     *
+     * @return the API name of this StorageStrategy
+     */
+    public String getApiName() {
+        return apiName;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/metadata/StorageStrategy.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/metadata/StorageStrategy.java
@@ -2,6 +2,10 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.dimension.metadata;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
 /**
  * Allows clients to be notified if a dimension's values are browsable and searchable.
  * <p>
@@ -15,21 +19,19 @@ public enum StorageStrategy {
     /**
      * Loaded dimension.
      */
-    LOADED("Loaded"),
+    LOADED,
     /**
      * Non-loaded dimension.
      */
-    NONE("None");
+    NONE;
 
     private final String apiName;
 
     /**
      * Constructor.
-     *
-     * @param apiName  The API name of this storage strategy
      */
-    StorageStrategy(String apiName) {
-        this.apiName = apiName;
+    StorageStrategy() {
+        this.apiName = name().toLowerCase(Locale.ENGLISH);
     }
 
     /**
@@ -37,6 +39,7 @@ public enum StorageStrategy {
      *
      * @return the API name of this StorageStrategy
      */
+    @JsonValue
     public String getApiName() {
         return apiName;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -376,7 +376,7 @@ public class DimensionsServlet extends EndpointServlet {
         resultRow.put("longName", dimension.getLongName());
         resultRow.put("uri", getDimensionUrl(dimension, uriInfo));
         resultRow.put("cardinality", dimension.getCardinality());
-        resultRow.put("storageStrategy", dimension.getStorageStrategy().getApiName());
+        resultRow.put("storageStrategy", dimension.getStorageStrategy());
         return resultRow;
     }
 
@@ -402,7 +402,7 @@ public class DimensionsServlet extends EndpointServlet {
         resultRow.put("fields", dimension.getDimensionFields());
         resultRow.put("values", getDimensionValuesUrl(dimension, uriInfo));
         resultRow.put("cardinality", dimension.getCardinality());
-        resultRow.put("storageStrategy", dimension.getStorageStrategy().getApiName());
+        resultRow.put("storageStrategy", dimension.getStorageStrategy());
         resultRow.put(
                 "tables",
                 TablesServlet.getLogicalTableListSummaryView(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -376,7 +376,7 @@ public class DimensionsServlet extends EndpointServlet {
         resultRow.put("longName", dimension.getLongName());
         resultRow.put("uri", getDimensionUrl(dimension, uriInfo));
         resultRow.put("cardinality", dimension.getCardinality());
-        resultRow.put("storageStrategy", dimension.getStorageStrategy());
+        resultRow.put("storageStrategy", dimension.getStorageStrategy().getApiName());
         return resultRow;
     }
 
@@ -402,7 +402,7 @@ public class DimensionsServlet extends EndpointServlet {
         resultRow.put("fields", dimension.getDimensionFields());
         resultRow.put("values", getDimensionValuesUrl(dimension, uriInfo));
         resultRow.put("cardinality", dimension.getCardinality());
-        resultRow.put("storageStrategy", dimension.getStorageStrategy());
+        resultRow.put("storageStrategy", dimension.getStorageStrategy().getApiName());
         resultRow.put(
                 "tables",
                 TablesServlet.getLogicalTableListSummaryView(

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DimensionsServletComponentSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DimensionsServletComponentSpec.groovy
@@ -80,14 +80,14 @@ class DimensionsServletComponentSpec extends Specification {
         String expectedResponse = """{
                                         "dimensions":
                                         [
-                                            {"category": "General", "name": "color", "longName": "color", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color", "cardinality": 0, "storageStrategy":"LOADED"},
-                                            {"category": "General", "name": "shape", "longName": "shape", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape", "cardinality": 38, "storageStrategy":"LOADED"},
-                                            {"category": "General", "name": "size", "longName": "size", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size", "cardinality": 0, "storageStrategy":"LOADED"},
-                                            {"category": "General", "name": "model", "longName": "model", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model", "cardinality": 21, "storageStrategy":"LOADED"},
-                                            {"category": "General", "name": "other", "longName": "other", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other", "cardinality": 100000, "storageStrategy":"LOADED"},
-                                            {"category": "General", "name": "sex", "longName": "sex", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/sex", "cardinality": 0, "storageStrategy":"LOADED"},
-                                            {"category": "General", "name": "species", "longName": "species", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/species", "cardinality": 0, "storageStrategy":"LOADED"},
-                                            {"category": "General", "name": "breed", "longName": "breed", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/breed", "cardinality": 0, "storageStrategy":"LOADED"}
+                                            {"category": "General", "name": "color", "longName": "color", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color", "cardinality": 0, "storageStrategy":"Loaded"},
+                                            {"category": "General", "name": "shape", "longName": "shape", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape", "cardinality": 38, "storageStrategy":"Loaded"},
+                                            {"category": "General", "name": "size", "longName": "size", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size", "cardinality": 0, "storageStrategy":"Loaded"},
+                                            {"category": "General", "name": "model", "longName": "model", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model", "cardinality": 21, "storageStrategy":"Loaded"},
+                                            {"category": "General", "name": "other", "longName": "other", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other", "cardinality": 100000, "storageStrategy":"Loaded"},
+                                            {"category": "General", "name": "sex", "longName": "sex", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/sex", "cardinality": 0, "storageStrategy":"Loaded"},
+                                            {"category": "General", "name": "species", "longName": "species", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/species", "cardinality": 0, "storageStrategy":"Loaded"},
+                                            {"category": "General", "name": "breed", "longName": "breed", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/breed", "cardinality": 0, "storageStrategy":"Loaded"}
                                         ]
                                     }"""
 
@@ -115,7 +115,7 @@ class DimensionsServletComponentSpec extends Specification {
                                         ],
                                         "longName": "other",
                                         "name": "other",
-                                        "storageStrategy":"LOADED",
+                                        "storageStrategy":"Loaded",
                                         "tables": [
                                             {
                                                 "category": "General",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DimensionsServletComponentSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DimensionsServletComponentSpec.groovy
@@ -80,14 +80,14 @@ class DimensionsServletComponentSpec extends Specification {
         String expectedResponse = """{
                                         "dimensions":
                                         [
-                                            {"category": "General", "name": "color", "longName": "color", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color", "cardinality": 0, "storageStrategy":"Loaded"},
-                                            {"category": "General", "name": "shape", "longName": "shape", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape", "cardinality": 38, "storageStrategy":"Loaded"},
-                                            {"category": "General", "name": "size", "longName": "size", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size", "cardinality": 0, "storageStrategy":"Loaded"},
-                                            {"category": "General", "name": "model", "longName": "model", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model", "cardinality": 21, "storageStrategy":"Loaded"},
-                                            {"category": "General", "name": "other", "longName": "other", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other", "cardinality": 100000, "storageStrategy":"Loaded"},
-                                            {"category": "General", "name": "sex", "longName": "sex", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/sex", "cardinality": 0, "storageStrategy":"Loaded"},
-                                            {"category": "General", "name": "species", "longName": "species", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/species", "cardinality": 0, "storageStrategy":"Loaded"},
-                                            {"category": "General", "name": "breed", "longName": "breed", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/breed", "cardinality": 0, "storageStrategy":"Loaded"}
+                                            {"category": "General", "name": "color", "longName": "color", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/color", "cardinality": 0, "storageStrategy":"loaded"},
+                                            {"category": "General", "name": "shape", "longName": "shape", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/shape", "cardinality": 38, "storageStrategy":"loaded"},
+                                            {"category": "General", "name": "size", "longName": "size", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/size", "cardinality": 0, "storageStrategy":"loaded"},
+                                            {"category": "General", "name": "model", "longName": "model", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/model", "cardinality": 21, "storageStrategy":"loaded"},
+                                            {"category": "General", "name": "other", "longName": "other", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/other", "cardinality": 100000, "storageStrategy":"loaded"},
+                                            {"category": "General", "name": "sex", "longName": "sex", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/sex", "cardinality": 0, "storageStrategy":"loaded"},
+                                            {"category": "General", "name": "species", "longName": "species", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/species", "cardinality": 0, "storageStrategy":"loaded"},
+                                            {"category": "General", "name": "breed", "longName": "breed", "uri": "http://localhost:${jtb.getHarness().getPort()}/dimensions/breed", "cardinality": 0, "storageStrategy":"loaded"}
                                         ]
                                     }"""
 
@@ -115,7 +115,7 @@ class DimensionsServletComponentSpec extends Specification {
                                         ],
                                         "longName": "other",
                                         "name": "other",
-                                        "storageStrategy":"Loaded",
+                                        "storageStrategy":"loaded",
                                         "tables": [
                                             {
                                                 "category": "General",

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
@@ -114,7 +114,7 @@ class TablesServletSpec extends Specification {
                                                         "name": "$it",
                                                         "longName": "$it",
                                                         "cardinality": 0,
-                                                        "storageStrategy":"Loaded",
+                                                        "storageStrategy":"loaded",
                                                         "uri": "http://localhost:${jerseyTestBinder.getHarness().getPort()}/dimensions/$it"
                                                     }""" 
                                                 }

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
@@ -114,7 +114,7 @@ class TablesServletSpec extends Specification {
                                                         "name": "$it",
                                                         "longName": "$it",
                                                         "cardinality": 0,
-                                                        "storageStrategy":"LOADED",
+                                                        "storageStrategy":"Loaded",
                                                         "uri": "http://localhost:${jerseyTestBinder.getHarness().getPort()}/dimensions/$it"
                                                     }""" 
                                                 }

--- a/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
+++ b/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
@@ -121,7 +121,7 @@ class TablesServletSpec extends Specification {
                                                     "name": "$it",
                                                     "longName": "wiki $it",
                                                     "cardinality": 0,
-                                                    "storageStrategy":"Loaded",
+                                                    "storageStrategy":"loaded",
                                                     "uri": "http://localhost:${jerseyTestBinder.getHarness().getPort()}/dimensions/$it"
                                                     }"""
                                                 }

--- a/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
+++ b/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/TablesServletSpec.groovy
@@ -121,7 +121,7 @@ class TablesServletSpec extends Specification {
                                                     "name": "$it",
                                                     "longName": "wiki $it",
                                                     "cardinality": 0,
-                                                    "storageStrategy":"LOADED",
+                                                    "storageStrategy":"Loaded",
                                                     "uri": "http://localhost:${jerseyTestBinder.getHarness().getPort()}/dimensions/$it"
                                                     }"""
                                                 }


### PR DESCRIPTION
The default serialization of enum is `name()` which is final and thus cannot be overridden. An API method is added to return the API name of a storage strategy.