### PR TITLE
Fix having with scoped metrics bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,10 @@ Current
 
 ### Fixed:
 
+- [Scoped metric dictionaries and the having clause now work together by default](https://github.com/yahoo/fili/pull/580)
+    * Add a new ApiHavingGenerator that builds a temporary metric dictionary from the set of requested metrics(not from globally scoped metric dictionary), and then using those to resolve the having clause.
+    * Add a table generating functions in BaseTableLoader that effectively allow the customer to provide a different metric dictionary at lower scope(not from the globally scoped metric dictionary) for use when building each table.
+
 - [Debug BardQueryInfo to show query split counting](https://github.com/yahoo/fili/pull/596/files)
     * Query counter in `BardQueryInfo` does not show up in logging because the counter used to be static and JSON
       serializer does not serialize static fields.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -101,6 +101,7 @@ import com.yahoo.bard.webservice.web.SlicesApiRequest;
 import com.yahoo.bard.webservice.web.TablesApiRequest;
 import com.yahoo.bard.webservice.web.apirequest.DefaultHavingApiGenerator;
 import com.yahoo.bard.webservice.web.apirequest.HavingGenerator;
+import com.yahoo.bard.webservice.web.apirequest.PerRequestDictionaryHavingGenerator;
 import com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow;
 import com.yahoo.bard.webservice.web.handlers.workflow.RequestWorkflowProvider;
 import com.yahoo.bard.webservice.web.util.QueryWeightUtil;
@@ -635,7 +636,7 @@ public abstract class AbstractBinderFactory implements BinderFactory {
      * @return An object to generate having maps from having string.
      */
     protected HavingGenerator buildHavingGenerator(ConfigurationLoader loader) {
-        return new DefaultHavingApiGenerator(loader);
+        return new PerRequestDictionaryHavingGenerator(new DefaultHavingApiGenerator(loader.getMetricDictionary()));
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
@@ -116,7 +116,7 @@ public abstract class BaseTableLoader implements TableLoader {
     }
 
     /**
-     * Load several logical tables into the logicalDictionary.
+     * Load several logical tables into the logicalDictionary, all with the globally-scoped metric dictionary.
      * <p>
      * Note: This builds the logical tables as well.
      *
@@ -129,12 +129,42 @@ public abstract class BaseTableLoader implements TableLoader {
             Set<? extends Granularity> validGrains,
             ResourceDictionaries dictionaries
     ) {
-        // For every logical table name, group pair
+        loadLogicalTablesWithGranularities(
+                nameGroupMap,
+                validGrains,
+                dictionaries.getLogicalDictionary(),
+                nameGroupMap.keySet().stream()
+                        .collect(Collectors.toMap(Function.identity(), i -> dictionaries.getMetricDictionary()))
+        );
+    }
+
+    /**
+     * Load several logical tables into the logicalDictionary, each with their own scoped metric dictionary.
+     * <p>
+     * Note: This builds the logical tables as well.
+     *
+     * @param nameGroupMap  A map of logical table name to table group information
+     * @param validGrains  The accepted grains for the logical table
+     * @param tableDictionary  The logical table dictionary to be populated
+     * @param scopedMetrics  A mapping from table name to the scoped MetricDictionary to use for that table
+     */
+    public void loadLogicalTablesWithGranularities(
+            Map<String, TableGroup> nameGroupMap,
+            Set<? extends Granularity> validGrains,
+            LogicalTableDictionary tableDictionary,
+            Map<String, MetricDictionary> scopedMetrics
+    ) {
         for (Map.Entry<String, TableGroup> entry : nameGroupMap.entrySet()) {
             String logicalTableName = entry.getKey();
             TableGroup group = entry.getValue();
 
-            loadLogicalTableWithGranularities(logicalTableName, group, validGrains, dictionaries);
+            loadLogicalTableWithGranularities(
+                    logicalTableName,
+                    group,
+                    validGrains,
+                    tableDictionary,
+                    scopedMetrics.get(logicalTableName)
+            );
         }
     }
 
@@ -154,16 +184,39 @@ public abstract class BaseTableLoader implements TableLoader {
             Set<? extends Granularity> validGrains,
             ResourceDictionaries dictionaries
     ) {
-        LogicalTableDictionary logicalDictionary = dictionaries.getLogicalDictionary();
-        MetricDictionary metricDictionary = dictionaries.getMetricDictionary();
+        loadLogicalTableWithGranularities(
+                logicalTableName,
+                nameGroup,
+                validGrains,
+                dictionaries.getLogicalDictionary(),
+                dictionaries.getMetricDictionary()
+        );
+    }
 
+    /**
+     * Load a logical table into the logicalDictionary.
+     * <p>
+     * Note: This builds the logical table as well.
+     *
+     * @param logicalTableName  The logical table name
+     * @param nameGroup  The table group information for the logical table
+     * @param validGrains  The accepted grains for the logical table
+     * @param tableDictionary  The dictionary to load the logical table into
+     * @param metricDictionary  The dictionary to use when looking up metrics for this table
+     */
+    public void loadLogicalTableWithGranularities(
+            String logicalTableName,
+            TableGroup nameGroup,
+            Set<? extends Granularity> validGrains,
+            LogicalTableDictionary tableDictionary,
+            MetricDictionary metricDictionary
+    ) {
         // For every legal grain
         for (Granularity grain : validGrains) {
             // Build the logical table
             LogicalTable logicalTable = new LogicalTable(logicalTableName, grain, nameGroup, metricDictionary);
-
             // Load it into the dictionary
-            logicalDictionary.put(new TableIdentifier(logicalTable), logicalTable);
+            tableDictionary.put(new TableIdentifier(logicalTable), logicalTable);
         }
     }
 
@@ -351,7 +404,7 @@ public abstract class BaseTableLoader implements TableLoader {
     /**
      * Build a logical table, supplying it with a name, grain, table group, and metrics.
      * <p>
-     * Note: This builds a logical table with all valid metrics for the grain of the table
+     * Note: This builds a logical table with all valid metrics for the grain of the table.
      *
      * @param name  The name for this logical table
      * @param granularity  The granularity for this logical table

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ApiHaving.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ApiHaving.java
@@ -9,16 +9,16 @@ import static com.yahoo.bard.webservice.web.ErrorMessageFormat.HAVING_NON_NUMERI
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.HAVING_OPERATOR_INVALID;
 
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
-import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.util.FilterTokenizer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Collections;
-import java.util.Objects;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -58,7 +58,11 @@ public class ApiHaving {
      *
      * @throws BadHavingException  when having pattern is not matched or when any of its properties are not valid.
      */
-    public ApiHaving(@NotNull String havingQuery, MetricDictionary metricDictionary) throws BadHavingException {
+    public ApiHaving(
+            @NotNull String havingQuery,
+            Map<String, LogicalMetric> metricDictionary
+    ) throws BadHavingException {
+
         LOG.trace("Having query: {} MetricDictionary: {}", havingQuery, metricDictionary);
 
         Matcher tokenizedQuery = QUERY_PATTERN.matcher(havingQuery);
@@ -125,7 +129,7 @@ public class ApiHaving {
      */
     private LogicalMetric extractMetric(
             Matcher tokenizedQuery,
-            MetricDictionary metricDictionary
+            Map<String, LogicalMetric> metricDictionary
     ) throws BadHavingException {
         String metricName = tokenizedQuery.group(1);
         LogicalMetric extractedMetric = metricDictionary.get(metricName);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/PerRequestDictionaryHavingGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/PerRequestDictionaryHavingGenerator.java
@@ -1,0 +1,45 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest;
+
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.web.ApiHaving;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A having generator decorator that uses the metrics from the query as the dictionary of metrics for building havings.
+ */
+public class PerRequestDictionaryHavingGenerator implements HavingGenerator {
+
+    private final DefaultHavingApiGenerator havingGenerator;
+
+    /**
+     * Constructor.
+     *
+     * @param havingGenerator  A default having generator to decorate.
+     */
+    public PerRequestDictionaryHavingGenerator(DefaultHavingApiGenerator havingGenerator) {
+        this.havingGenerator = havingGenerator;
+    }
+
+    /**
+     * Wrap the enclosed having generator in a query scoped metric dictionary.
+     *
+     * @param havingString  The having clause from the URI
+     * @param logicalMetrics The set of metrics provided
+     *
+     * @return  A collection of ApiHaving objects grouped by Logical Metric
+     */
+    @Override
+    public Map<LogicalMetric, Set<ApiHaving>> apply(String havingString, Set<LogicalMetric> logicalMetrics) {
+        return havingGenerator
+                .withMetricDictionary(
+                        logicalMetrics.stream().collect(Collectors.toMap(LogicalMetric::getName, Function.identity()))
+                )
+                .apply(havingString, logicalMetrics);
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTablesFullViewEndpointSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ExpectedTablesFullViewEndpointSpec.groovy
@@ -1108,6 +1108,12 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "longName": "width",
                       "name": "width",
                       "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/width"
+                    },
+                    {
+                      "category": "General",
+                      "longName": "scopedWidth",
+                      "name": "scopedWidth",
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/scopedWidth"
                     }
                   ],
                   "name": "all",
@@ -1284,6 +1290,12 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "longName": "width",
                       "name": "width",
                       "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/width"
+                    },
+                    {
+                      "category": "General",
+                      "longName": "scopedWidth",
+                      "name": "scopedWidth",
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/scopedWidth"
                     }
                   ],
                   "name": "day",
@@ -1472,6 +1484,12 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "longName": "width",
                       "name": "width",
                       "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/width"
+                    },
+                    {
+                      "category": "General",
+                      "longName": "scopedWidth",
+                      "name": "scopedWidth",
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/scopedWidth"
                     }
                   ],
                   "name": "month",
@@ -1660,6 +1678,12 @@ class ExpectedTablesFullViewEndpointSpec extends BaseTableServletComponentSpec {
                       "longName": "width",
                       "name": "width",
                       "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/width"
+                    },
+                    {
+                      "category": "General",
+                      "longName": "scopedWidth",
+                      "name": "scopedWidth",
+                      "uri": "http://localhost:${jtb.getHarness().getPort()}/metrics/scopedWidth"
                     }
                   ],
                   "name": "week",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ScopedMetricHavingDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ScopedMetricHavingDataServletSpec.groovy
@@ -1,0 +1,99 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.endpoints
+
+class ScopedMetricHavingDataServletSpec extends BaseDataServletComponentSpec {
+
+    @Override
+    Class<?>[] getResourceClasses() {
+        [DataServlet.class]
+    }
+
+    @Override
+    String getTarget() {
+        return "data/shapes/week/color"
+    }
+
+    @Override
+    Map<String, List<String>> getQueryParams() {
+        [
+                "metrics" : ["scopedWidth"],
+                "dateTime": ["2014-06-02/2014-06-09"],
+                "having": ["scopedWidth-gt[10]"]
+        ]
+    }
+
+    @Override
+    String getExpectedApiResponse() {
+        """{
+            "rows": [
+                {
+                    "color|desc": "",
+                    "color|id": "Bar",
+                    "dateTime": "2014-06-02 00:00:00.000",
+                    "scopedWidth": 11
+                },
+                {
+                    "color|desc": "",
+                    "color|id": "Baz",
+                    "dateTime": "2014-06-02 00:00:00.000",
+                    "scopedWidth": 12
+                }
+            ]
+        }"""
+    }
+
+    @Override
+    String getExpectedDruidQuery() {
+        """{
+                "aggregations": [
+                    {
+                        "fieldName": "width",
+                        "name": "scopedWidth",
+                        "type": "longSum"
+                    }
+                ],
+                "dataSource": {
+                    "name": "color_shapes",
+                    "type": "table"
+                },
+                "dimensions": [
+                    "color"
+                ],
+                "granularity": ${getTimeGrainString("week")},
+                "having": {
+                    "aggregation": "scopedWidth",
+                    "type": "greaterThan",
+                    "value": 10
+                },
+                "intervals": [
+                    "2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"
+                ],
+                "postAggregations": [],
+                "queryType": "groupBy",
+                "context": {}
+        }"""
+    }
+
+    @Override
+    String getFakeDruidResponse() {
+        """[
+              {
+                "version" : "v1",
+                "timestamp" : "2014-06-02T00:00:00.000Z",
+                "event" : {
+                  "color" : "Bar",
+                  "scopedWidth" : 11
+                }
+              },
+              {
+                "version" : "v1",
+                "timestamp" : "2014-06-02T00:00:00.000Z",
+                "event" : {
+                  "color" : "Baz",
+                  "scopedWidth" : 12
+                }
+              }
+            ]"""
+    }
+}

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/metric/TestMetricLoader.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/metric/TestMetricLoader.java
@@ -11,6 +11,7 @@ import static com.yahoo.bard.webservice.data.config.names.TestApiMetricName.A_HE
 import static com.yahoo.bard.webservice.data.config.names.TestApiMetricName.A_LIMBS;
 import static com.yahoo.bard.webservice.data.config.names.TestApiMetricName.A_OTHER_USERS;
 import static com.yahoo.bard.webservice.data.config.names.TestApiMetricName.A_ROW_NUM;
+import static com.yahoo.bard.webservice.data.config.names.TestApiMetricName.A_SCOPED_WIDTH;
 import static com.yahoo.bard.webservice.data.config.names.TestApiMetricName.A_USERS;
 import static com.yahoo.bard.webservice.data.config.names.TestApiMetricName.A_VOLUME;
 import static com.yahoo.bard.webservice.data.config.names.TestApiMetricName.A_WIDTH;
@@ -26,6 +27,7 @@ import com.yahoo.bard.webservice.data.config.metric.makers.ArithmeticMaker;
 import com.yahoo.bard.webservice.data.config.metric.makers.LongSumMaker;
 import com.yahoo.bard.webservice.data.config.metric.makers.RowNumMaker;
 import com.yahoo.bard.webservice.data.config.metric.makers.SketchCountMaker;
+import com.yahoo.bard.webservice.data.metric.LogicalMetricInfo;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.druid.model.postaggregation.ArithmeticPostAggregation.ArithmeticPostAggregationFunction;
 
@@ -103,8 +105,11 @@ public class TestMetricLoader implements MetricLoader {
         );
 
         metrics.stream().map(MetricInstance::make).forEach(metricDictionary::add);
+        metricDictionary.getScope("shapes").add(
+                new MetricInstance(new LogicalMetricInfo(A_SCOPED_WIDTH.asName()), longSumMaker, WIDTH.asName()).make()
+        );
         //Allows us to add some non-numeric LogicalMetrics without having to write a Maker for them. Makers should
         //be written if using complex metrics in production code.
-        NonNumericMetrics.getLogicalMetrics().stream().forEach(metricDictionary::add);
+        NonNumericMetrics.getLogicalMetrics().forEach(metricDictionary::add);
     }
 }

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/names/TestApiMetricName.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/names/TestApiMetricName.java
@@ -37,7 +37,8 @@ public enum TestApiMetricName implements ApiMetricName {
     A_STRING_METRIC,
     A_BOOLEAN_METRIC,
     A_JSON_NODE_METRIC,
-    A_NULL_METRIC;
+    A_NULL_METRIC,
+    A_SCOPED_WIDTH;
 
     private final String apiName;
     private final List<TimeGrain> supportedGrains;
@@ -121,7 +122,8 @@ public enum TestApiMetricName implements ApiMetricName {
                         A_STRING_METRIC,
                         A_BOOLEAN_METRIC,
                         A_NULL_METRIC,
-                        A_JSON_NODE_METRIC
+                        A_JSON_NODE_METRIC,
+                        A_SCOPED_WIDTH
                 );
             case MONTHLY:
                 return Utils.asLinkedHashSet(A_LIMBS, A_DAY_AVG_LIMBS);

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/table/TestTableLoader.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/table/TestTableLoader.java
@@ -12,9 +12,11 @@ import com.yahoo.bard.webservice.data.config.dimension.TestDimensions;
 import com.yahoo.bard.webservice.data.config.names.TestApiMetricName;
 import com.yahoo.bard.webservice.data.config.names.TestDruidMetricName;
 import com.yahoo.bard.webservice.data.config.names.TestLogicalTableName;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.druid.model.query.AllGranularity;
 import com.yahoo.bard.webservice.druid.model.query.Granularity;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
+import com.yahoo.bard.webservice.table.LogicalTableDictionary;
 import com.yahoo.bard.webservice.table.TableGroup;
 import com.yahoo.bard.webservice.util.Utils;
 
@@ -24,6 +26,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Load the test-specific table configuration.
@@ -111,20 +115,39 @@ public class TestTableLoader extends BaseTableLoader {
         }
         validGrains.add(AllGranularity.INSTANCE);
 
-        loadLogicalTablesWithGranularities(logicalTableTableGroup, validGrains, dictionaries);
+        MetricDictionary metricDictionary = dictionaries.getMetricDictionary();
+        LogicalTableDictionary tableDictionary = dictionaries.getLogicalDictionary();
+        loadLogicalTablesWithGranularities(
+                logicalTableTableGroup,
+                validGrains,
+                tableDictionary,
+                logicalTableTableGroup.keySet().stream()
+                        .collect(Collectors.toMap(Function.identity(), metricDictionary::getScope))
+        );
 
         Map<String, TableGroup> hourlyGroup = new HashMap<>();
         hourlyGroup.put(
                 TestLogicalTableName.HOURLY.asName(),
                 logicalTableTableGroup.get(TestLogicalTableName.HOURLY.asName())
         );
-        loadLogicalTablesWithGranularities(hourlyGroup, Utils.asLinkedHashSet(HOUR), dictionaries);
+        loadLogicalTablesWithGranularities(
+                hourlyGroup,
+                Utils.asLinkedHashSet(HOUR),
+                tableDictionary,
+                hourlyGroup.keySet().stream().collect(Collectors.toMap(Function.identity(), metricDictionary::getScope))
+        );
 
         Map<String, TableGroup> hourlyMonthlyGroup = new HashMap<>();
         hourlyMonthlyGroup.put(
                 TestLogicalTableName.HOURLY_MONTHLY.asName(),
                 logicalTableTableGroup.get(TestLogicalTableName.HOURLY_MONTHLY.asName())
         );
-        loadLogicalTablesWithGranularities(hourlyMonthlyGroup, Utils.asLinkedHashSet(HOUR, MONTH), dictionaries);
+        loadLogicalTablesWithGranularities(
+                hourlyMonthlyGroup,
+                Utils.asLinkedHashSet(HOUR, MONTH),
+                tableDictionary,
+                hourlyMonthlyGroup.keySet().stream()
+                        .collect(Collectors.toMap(Function.identity(), metricDictionary::getScope))
+        );
     }
 }


### PR DESCRIPTION
-- Before, the ApiHavingGenerator relied on the globally scoped metric
dictionary to resolve having metrics. However, that meant that Fili
failed to recognize any metrics in the having clause that appear only
in a metric dictionary of a lower scope (i.e. a metric dictionary scoped
to table name).

-- We fix the bug by introducing a new ApiHavingGenerator that
effectively builds a temporary metric dictionary from the set of
requested metrics, and then using *those* to resolve the having clause.

-- We then use that new generator as the default generator in order to
ensure that the two features (scoped metric dictionaries and having
clauses) actually work together by default.

-- Furthermore, while writing an end-to-end test reproducing the bug, we
discovered that the default table configuration strategy had the same
problem: the tableLoader resolves its metrics from the globally scoped
metric dictionary, not from any lower scope.

-- To address this problem, we introduce some new table generating
functions in the `BaseTableLoader` that effectively allow the customer
to provide a different metric dictionary for use when building each
table. The original table generating methods are kept, because most
people don't need scoped metric dictionaries, and shouldn't have to
wrestle with their complexity when building their application.