### PR TITLE
Add getter for LogicalMetricInfo in MetricInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Current
 
 ### Added:
 
+- [Add getter for LogicalMetricInfo in MetricInstance](https://github.com/yahoo/fili/pull/588)
+    * There are 3 instance variables inside `MetricInstance` class, two of which have getters. The one without getter,
+      `LogicalMetricInfo`, should have one, as well, so that subclass can access it without creating a duplicate
+      `LogicalMetricInfo` inside their own.
+
 - [Backwards compatible constructor for KeyValueStoreDimension around storage strategy]()
     * Provide a backwards compatible constructor for existing implementations that don't provide storage strategies.
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/MetricInstance.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/MetricInstance.java
@@ -94,8 +94,13 @@ public class MetricInstance {
                 .collect(Collectors.toList());
     }
 
-    public String getMetricName() {
-        return logicalMetricInfo.getName();
+    /**
+     * Returns the LogicalMetricInfo of this MetricInstance.
+     *
+     * @return the LogicalMetricInfo of this MetricInstance
+     */
+    public LogicalMetricInfo getLogicalMetricInfo() {
+        return logicalMetricInfo;
     }
 
     public List<String> getDependencyMetricNames() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/MetricInstance.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/MetricInstance.java
@@ -94,6 +94,10 @@ public class MetricInstance {
                 .collect(Collectors.toList());
     }
 
+    public String getMetricName() {
+        return logicalMetricInfo.getName();
+    }
+
     /**
      * Returns the LogicalMetricInfo of this MetricInstance.
      *


### PR DESCRIPTION
https://github.com/yahoo/fili/issues/587: There are 3 instance variables inside `MetricInstance` class, two of which have getters. The one without getter, `LogicalMetricInfo`, should have one, as well, so that subclass can access it without creating a duplicate `LogicalMetricInfo` inside their own.