### PR TITLE
Enable checkstyle to detect incorrect package header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Current
 -------
 
 ### Added:
+
+- [Enable checkstyle to detect incorrect package header](https://github.com/yahoo/fili/pull/594)
+    * Fili was able to pass the build with wrong package headers in some source files. This needs to be fixed, and it's
+      fixed in this PR by adding PackageDeclaration checkstyle rule.
+    * In addition, checkstyle version has been bumped to the latest one(Nov, 2017), which is now able to detect more
+      styling errors.
+
 - [Add loaded strategy onto tables full view endpoint](https://github.com/yahoo/fili/pull/589)
     * Add dimension storage strategy to table full view endpoint
 

--- a/checkstyle-style.xml
+++ b/checkstyle-style.xml
@@ -13,10 +13,8 @@
             <property name="severity" value="error" />
         </module>
 
-	    <!-- Make the @SuppressWarnings annotations available to Checkstyle -->
-	    <module name="SuppressWarningsHolder" />
-
-        <module name="FileContentsHolder" />
+	<!-- Make the @SuppressWarnings annotations available to Checkstyle -->
+	<module name="SuppressWarningsHolder" />
 
         <module name="ConstantName">
             <property name="severity" value="error" />
@@ -90,6 +88,11 @@
             <property name="severity" value="error" />
             <metadata name="net.sf.eclipsecs.core.comment"
                 value="Need braces for all code blocks." />
+        </module>
+
+        <module name="PackageDeclaration">
+            <property name="severity" value="error"/>
+            <property name="matchDirectoryStructure" value="true"/>
         </module>
 
         <module name="WhitespaceAround">
@@ -263,6 +266,8 @@
             <property name="tokens" value="VARIABLE_DEF"/>
         </module>
 
+        <module name="SuppressionCommentFilter"/>
+
     </module>
 
     <module name="RegexpSingleline">
@@ -292,8 +297,6 @@
         <property name="lineSeparator" value="lf" />
         <metadata name="net.sf.eclipsecs.core.comment" value="Enforce newline at end of file." />
     </module>
-
-    <module name="SuppressionCommentFilter"/>
 
     <module name="RegexpMultiline">
         <metadata name="net.sf.eclipsecs.core.comment" value="Excessive white space" />

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/PaginationMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/PaginationMapper.java
@@ -46,8 +46,6 @@ public class PaginationMapper extends ResultSetMapper {
      * @param resultSet  The result set to be cut down.
      *
      * @return The page of results desired.
-     *
-     * @throws com.yahoo.bard.webservice.web.PageNotFoundException if the page requested is past the last page of data.
      */
     @Override
     public ResultSet map(ResultSet resultSet) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/DataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/DataRequestHandler.java
@@ -29,8 +29,8 @@ public interface DataRequestHandler {
      */
     boolean handleRequest(
             RequestContext context,
-            final DataApiRequest request,
-            final DruidAggregationQuery<?> druidQuery,
-            final ResponseProcessor response
+            DataApiRequest request,
+            DruidAggregationQuery<?> druidQuery,
+            ResponseProcessor response
     );
 }

--- a/fili-sql/src/test/java/com/yahoo/bard/webservice/database/WikitickerEntry.java
+++ b/fili-sql/src/test/java/com/yahoo/bard/webservice/database/WikitickerEntry.java
@@ -366,6 +366,5 @@ public class WikitickerEntry implements Serializable {
     public void setAdditionalProperty(String name, String value) {
         this.additionalProperties.put(name, value);
     }
-
 }
 //CHECKSTYLE:ON

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <checkstyle.skip>false</checkstyle.skip>
         <checkstyle.config.location>checkstyle-style.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>checkstyle-suppressions.xml</checkstyle.suppressions.location>
-        <checkstyle.version>6.14.1</checkstyle.version>
+        <checkstyle.version>8.5</checkstyle.version>
         <checkstyle.resourceIncludes>**/*.properties*</checkstyle.resourceIncludes>
 
         <dependency.locations.enabled>false</dependency.locations.enabled>
@@ -527,6 +527,14 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
+                    <dependencies>
+                        <!-- override default checkstyle version -->
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>${checkstyle.version}</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>validate</id>


### PR DESCRIPTION
@michael-mclawhorn and I noticed a while ago that Fili was able to pass the build with wrong package headers in some source files. This needs to be fixed, and it's fixed in this PR by adding `PackageDeclaration` checkstyle rule.

In addition, checkstyle version has been bumped to the latest one(Nov, 2017), which is now able to detect more styling errors.