### PR TITLE
Fix handling of partially-matched LogicalTable lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,11 @@ Current
 
 ### Fixed:
 
+- [Fix handling of partially-matched LogicalTable lookup](https://github.com/yahoo/fili/pull/601)
+    * While searching for a mathing `LogicalTable`, instead of look up by key `TableIdentifier` only, we scan table name
+      first and give an error it it doesn't exist in dictionary. Then look up by key `TableIdentifier` and give the
+      second error if we don't find the identifier.
+
 - [Scoped metric dictionaries and the having clause now work together by default](https://github.com/yahoo/fili/pull/580)
     * Add a new ApiHavingGenerator that builds a temporary metric dictionary from the set of requested metrics(not from globally scoped metric dictionary), and then using those to resolve the having clause.
     * Add a table generating functions in BaseTableLoader that effectively allow the customer to provide a different metric dictionary at lower scope(not from the globally scoped metric dictionary) for use when building each table.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/LogicalTableDictionary.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/LogicalTableDictionary.java
@@ -5,6 +5,8 @@ package com.yahoo.bard.webservice.table;
 import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 
+import org.joda.time.ReadablePeriod;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,6 +45,33 @@ public class LogicalTableDictionary extends LinkedHashMap<TableIdentifier, Logic
         return values()
                 .stream()
                 .filter(it -> it.getDimensions().contains(dimension))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a list of logical table names in this LogicalTableDictionary.
+     *
+     * @return  The list of logical table names in this LogicalTableDictionary
+     */
+    public List<String> getNames() {
+        return this.keySet().stream()
+                .map(TableIdentifier::getKey)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a list of configured granularities of a logical table.
+     *
+     * @param logicalTableName  The name of the logical table
+     *
+     * @return a list of configured granularities of the logical table
+     */
+    public List<ReadablePeriod> getGranularities(String logicalTableName) {
+        return this.keySet().stream()
+                .filter(tableIdentifier -> tableIdentifier.getKey().equals(logicalTableName) &&
+                        tableIdentifier.getValue().isPresent()
+                )
+                .map(tableIdentifier -> tableIdentifier.getValue().get())
                 .collect(Collectors.toList());
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/LogicalTableDictionary.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/LogicalTableDictionary.java
@@ -5,8 +5,6 @@ package com.yahoo.bard.webservice.table;
 import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 
-import org.joda.time.ReadablePeriod;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -56,22 +54,6 @@ public class LogicalTableDictionary extends LinkedHashMap<TableIdentifier, Logic
     public List<String> getNames() {
         return this.keySet().stream()
                 .map(TableIdentifier::getKey)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Returns a list of configured granularities of a logical table.
-     *
-     * @param logicalTableName  The name of the logical table
-     *
-     * @return a list of configured granularities of the logical table
-     */
-    public List<ReadablePeriod> getGranularities(String logicalTableName) {
-        return this.keySet().stream()
-                .filter(tableIdentifier -> tableIdentifier.getKey().equals(logicalTableName) &&
-                        tableIdentifier.getValue().isPresent()
-                )
-                .map(tableIdentifier -> tableIdentifier.getValue().get())
                 .collect(Collectors.toList());
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -10,6 +10,7 @@ import com.yahoo.bard.webservice.MessageFormatter;
 public enum ErrorMessageFormat implements MessageFormatter {
 
     TABLE_UNDEFINED("Table name '%s' does not exist."),
+    GRANULARITY_NOT_SUPPORTED("Time grain '%s' is not supported. '%s' supports '%s'"),
     TABLE_ALIGNMENT_UNDEFINED("Table '%s' cannot be aligned to a request with intervals: %s."),
     TABLE_SCHEMA_UNDEFINED(
             "Table '%s' is incompatible with the dimensions '%s', metrics '%s' and granularity '%s' requested.",
@@ -30,6 +31,13 @@ public enum ErrorMessageFormat implements MessageFormatter {
     GRANULARITY_MERGE("'%s' time zone cannot be applied to time grain '%s'"),
 
     INVALID_GRANULARITY("Granularity %s is of an unexpected type %s."),
+
+    /**
+     * An error message indicating that a type of granularity is not configured/supported in a table.
+     *
+     * @deprecated Use a more details error message {@link #GRANULARITY_NOT_SUPPORTED}.
+     */
+    @Deprecated
     TABLE_GRANULARITY_MISMATCH("Invalid pair of granularity '%s' and table '%s'."),
 
     TIME_ALIGNMENT("'%s' does not align with granularity '%s'.%s"),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -10,7 +10,7 @@ import com.yahoo.bard.webservice.MessageFormatter;
 public enum ErrorMessageFormat implements MessageFormatter {
 
     TABLE_UNDEFINED("Table name '%s' does not exist."),
-    GRANULARITY_NOT_SUPPORTED("Time grain '%s' is not supported. '%s' supports '%s'"),
+    GRANULARITY_NOT_SUPPORTED("Time grain '%s' is not supported"),
     TABLE_ALIGNMENT_UNDEFINED("Table '%s' cannot be aligned to a request with intervals: %s."),
     TABLE_SCHEMA_UNDEFINED(
             "Table '%s' is incompatible with the dimensions '%s', metrics '%s' and granularity '%s' requested.",

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -54,8 +54,6 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.joda.time.PeriodType;
-import org.joda.time.ReadablePeriod;
 import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -667,17 +665,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
         LogicalTable table = logicalTableDictionary.get(new TableIdentifier(tableName, granularity));
         // No matching granularity is found for this table
         if (table == null) {
-            List<ReadablePeriod> granularities = logicalTableDictionary.getGranularities(tableName);
-            String message = ErrorMessageFormat.GRANULARITY_NOT_SUPPORTED.format(
-                    granularity.getName(),
-                    tableName,
-                    logicalTableDictionary.getGranularities(tableName).isEmpty()
-                            ? "no granularities"
-                            : granularities.stream()
-                            .map(ReadablePeriod::getPeriodType)
-                            .map(PeriodType::getName)
-                            .collect(Collectors.joining(", "))
-            );
+            String message = ErrorMessageFormat.GRANULARITY_NOT_SUPPORTED.format(granularity.getName(), tableName);
             LOG.error(message);
             throw new IllegalArgumentException(message);
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -13,7 +13,6 @@ import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_DIRECTION_IN
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_METRICS_NOT_IN_QUERY_FORMAT;
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_METRICS_NOT_SORTABLE_FORMAT;
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_METRICS_UNDEFINED;
-import static com.yahoo.bard.webservice.web.ErrorMessageFormat.TABLE_UNDEFINED;
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.TOP_N_UNSORTED;
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.UNSUPPORTED_FILTERED_METRIC_CATEGORY;
 
@@ -37,7 +36,6 @@ import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier;
 import com.yahoo.bard.webservice.logging.RequestLog;
 import com.yahoo.bard.webservice.logging.TimedPhase;
 import com.yahoo.bard.webservice.table.LogicalTable;
-import com.yahoo.bard.webservice.table.TableIdentifier;
 import com.yahoo.bard.webservice.util.StreamUtils;
 import com.yahoo.bard.webservice.web.ApiFilter;
 import com.yahoo.bard.webservice.web.ApiHaving;
@@ -184,14 +182,7 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
         // Time grain must be from allowed interval keywords
         this.granularity = generateGranularity(granularity, timeZone, granularityParser);
 
-        TableIdentifier tableId = new TableIdentifier(tableName, this.granularity);
-
-        // Logical table must be in the logical table dictionary
-        this.table = bardConfigResources.getLogicalTableDictionary().get(tableId);
-        if (this.table == null) {
-            LOG.debug(TABLE_UNDEFINED.logFormat(tableName));
-            throw new BadApiRequestException(TABLE_UNDEFINED.format(tableName));
-        }
+        this.table = generateTable(tableName, this.granularity, bardConfigResources.getLogicalTableDictionary());
 
         DateTimeFormatter dateTimeFormatter = generateDateTimeFormatter(timeZone);
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/TablesApiRequestImplSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/TablesApiRequestImplSpec.groovy
@@ -124,10 +124,10 @@ class TablesApiRequestImplSpec extends Specification {
         e.getMessage().matches(reason)
 
         where:
-        name     | grain     | dictionary      | exception              | reason
-        "pets"   | "day"     | emptyDictionary | BadApiRequestException | ".*Logical Table Dictionary is empty.*"
-        "beasts" | "day"     | fullDictionary  | BadApiRequestException | ".*Table name.*does not exist.*"
-        "pets"   | "century" | fullDictionary  | BadApiRequestException | ".*not a valid granularity.*"
-        "pets"   | "hour"    | fullDictionary  | BadApiRequestException | "Invalid pair of granularity .* and table.*"
+        name     | grain     | dictionary      | exception                | reason
+        "pets"   | "day"     | emptyDictionary | BadApiRequestException   | ErrorMessageFormat.EMPTY_DICTIONARY.logFormat("Logical Table")
+        "beasts" | "day"     | fullDictionary  | BadApiRequestException   | ErrorMessageFormat.TABLE_UNDEFINED.logFormat("beasts")
+        "pets"   | "century" | fullDictionary  | BadApiRequestException   | ErrorMessageFormat.UNKNOWN_GRANULARITY.logFormat("century")
+        "pets"   | "hour"    | fullDictionary  | IllegalArgumentException | ErrorMessageFormat.GRANULARITY_NOT_SUPPORTED.format("hour", "pets", ".*")
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/TablesApiRequestImplSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/TablesApiRequestImplSpec.groovy
@@ -128,6 +128,6 @@ class TablesApiRequestImplSpec extends Specification {
         "pets"   | "day"     | emptyDictionary | BadApiRequestException   | ErrorMessageFormat.EMPTY_DICTIONARY.logFormat("Logical Table")
         "beasts" | "day"     | fullDictionary  | BadApiRequestException   | ErrorMessageFormat.TABLE_UNDEFINED.logFormat("beasts")
         "pets"   | "century" | fullDictionary  | BadApiRequestException   | ErrorMessageFormat.UNKNOWN_GRANULARITY.logFormat("century")
-        "pets"   | "hour"    | fullDictionary  | IllegalArgumentException | ErrorMessageFormat.GRANULARITY_NOT_SUPPORTED.format("hour", "pets", ".*")
+        "pets"   | "hour"    | fullDictionary  | IllegalArgumentException | ErrorMessageFormat.GRANULARITY_NOT_SUPPORTED.format("hour", "pets")
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/ApiRequestImplSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/ApiRequestImplSpec.groovy
@@ -2,8 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.apirequest
 
-import static com.yahoo.bard.webservice.web.ErrorMessageFormat.TABLE_GRANULARITY_MISMATCH
-
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
 import com.yahoo.bard.webservice.data.metric.MetricDictionary
 import com.yahoo.bard.webservice.druid.model.query.Granularity
@@ -28,6 +26,7 @@ class ApiRequestImplSpec extends Specification {
         String tableName = "tableName"
         Granularity granularity = Mock(Granularity)
         LogicalTableDictionary logicalTableDictionary = Mock(LogicalTableDictionary)
+        logicalTableDictionary.getNames() >> [tableName]
         TableIdentifier tableIdentifier = new TableIdentifier(tableName, granularity)
         LogicalTable logicalTable = Mock(LogicalTable)
         logicalTableDictionary.get(tableIdentifier) >> logicalTable
@@ -41,6 +40,7 @@ class ApiRequestImplSpec extends Specification {
         String tableName = "tableName"
         Granularity granularity = Mock(Granularity)
         LogicalTableDictionary logicalTableDictionary = Mock(LogicalTableDictionary)
+        logicalTableDictionary.getNames() >> []
         TableIdentifier tableIdentifier = new TableIdentifier(tableName, granularity)
         LogicalTable logicalTable = Mock(LogicalTable)
         logicalTableDictionary.get(tableIdentifier) >> logicalTable
@@ -52,7 +52,7 @@ class ApiRequestImplSpec extends Specification {
 
         then: "we get a BadApiRequestException"
         BadApiRequestException exception = thrown()
-        exception.message == TABLE_GRANULARITY_MISMATCH.logFormat(granularity, nonExistingTableName)
+        exception.message == ErrorMessageFormat.TABLE_UNDEFINED.logFormat(nonExistingTableName)
     }
 
     def "generateLogicalMetrics() returns existing LogicalMetrics"() {


### PR DESCRIPTION
Address issue https://github.com/yahoo/fili/issues/323

The misleading message mentioned in https://github.com/yahoo/fili/issues/323 happens because at https://github.com/yahoo/fili/blob/master/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java#L190 , a `tableId` has a valid table name but has an **invalid** time grain. This makes `get()` return `null`. The correct behavior is by scanning table name and give an error it it doesn't exist in dictionary. Then look up by key `TableIdentifier` and give the second error if we don't find the identifier.