### PR TITLE
Annotate Functional Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Current
 
 ### Added:
 
+- [Annotate Functional Interface](https://github.com/yahoo/fili/pull/606)
+    * Add `@FunctionalInterface` annotation to all functional interfaces.
+
 - [Implement LookupLoadTask](https://github.com/yahoo/fili/pull/620)
     * Add capability for Fili to check load statuses of Druid lookups.
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/async/jobs/jobrows/JobRowBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/async/jobs/jobrows/JobRowBuilder.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.UriInfo;
  * Interface for building JobRows (i.e. metadata about an asynchronous job) from Bard requests. Provides an injection
  * point that allows customers to build custom job metadata.
  */
+@FunctionalInterface
 public interface JobRowBuilder {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/async/workflows/AsynchronousWorkflowsBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/async/workflows/AsynchronousWorkflowsBuilder.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
  * A SAM that sets up the workflow for shipping query results back to the user, and saving query results for later
  * querying if necessary.
  */
+@FunctionalInterface
 public interface AsynchronousWorkflowsBuilder {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/DimensionLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/DimensionLoader.java
@@ -7,6 +7,7 @@ import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 /**
  * Defines the core interactions for loading dimensions into a dimension dictionary.
  */
+@FunctionalInterface
 public interface DimensionLoader {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/DimensionName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/DimensionName.java
@@ -5,12 +5,13 @@ package com.yahoo.bard.webservice.data.config.names;
 /**
  * Defines the logical name of a Dimension as used in the api query.
  */
+@FunctionalInterface
 public interface DimensionName {
 
-  /**
-   * The logical name of this dimension as used in the api query.
-   *
-   * @return Dimension Name
-   */
-  String asName();
+    /**
+     * The logical name of this dimension as used in the api query.
+     *
+     * @return Dimension Name
+     */
+    String asName();
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/FieldName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/FieldName.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.data.config.names;
 /**
  * Marker interface for enums that can be treated as a metric or dimension field name for Druid Query fields.
  */
+@FunctionalInterface
 public interface FieldName {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/TableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/TableLoader.java
@@ -8,6 +8,7 @@ import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
  * Defines the core interactions to load logical tables, physical tables, and table groups into the resource
  * dictionaries.
  */
+@FunctionalInterface
 public interface TableLoader {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/filterbuilders/DruidFilterBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/filterbuilders/DruidFilterBuilder.java
@@ -13,6 +13,7 @@ import java.util.Set;
 /**
  * Builds druid query model objects from ApiFilters.
  */
+@FunctionalInterface
 public interface DruidFilterBuilder {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/ColumnMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/ColumnMapper.java
@@ -8,6 +8,7 @@ package com.yahoo.bard.webservice.data.metric.mappers;
  * @deprecated with-like functionality no longer needed because delayed construction is being used instead
  */
 @Deprecated
+@FunctionalInterface
 public interface ColumnMapper {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/VolatileIntervalsFunction.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/volatility/VolatileIntervalsFunction.java
@@ -10,6 +10,7 @@ import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
  * use case for this is data which is being ingested via real time ingestion, and thus which will be replaced later by
  * new historical segments.
  */
+@FunctionalInterface
 public interface VolatileIntervalsFunction {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/SuccessCallback.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/SuccessCallback.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 /**
  * Callback from the async HTTP client on success.
  */
+@FunctionalInterface
 public interface SuccessCallback {
     /**
      * Invoke the success callback code.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/HasDruidName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/HasDruidName.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.druid.model;
 /**
  * A marker interface for things which have a druid name.
  */
+@FunctionalInterface
 public interface HasDruidName {
     /**
      * Get the Druid name.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/QueryType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/QueryType.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Types of queries supported by this application.
  */
+@FunctionalInterface
 public interface QueryType {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/postaggregation/PostAggregationType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/postaggregation/PostAggregationType.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.druid.model.postaggregation;
 /**
  * An interface for post aggregation types.
  */
+@FunctionalInterface
 public interface PostAggregationType {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogFormatter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogFormatter.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.logging;
 /**
  * Interface for log formatter that are meant to facilitate log exploration and data extraction.
  */
+@FunctionalInterface
 public interface LogFormatter {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/QuerySigningService.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/QuerySigningService.java
@@ -11,6 +11,7 @@ import java.util.Optional;
  *
  * @param <T>  the type that corresponds to the id of the set of segments referenced by a druid query.
  */
+@FunctionalInterface
 public interface QuerySigningService<T> {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/IsTableAligned.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/IsTableAligned.java
@@ -9,6 +9,7 @@ import java.util.function.Predicate;
 /**
  * A predicate to determine whether a table aligns with a criteria.
  */
+@FunctionalInterface
 public interface IsTableAligned extends Predicate<PhysicalTable> {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalTableResolver.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/PhysicalTableResolver.java
@@ -10,6 +10,7 @@ import java.util.Collection;
  * Physical table resolver selects the best physical table that satisfied a query (if any) from a supply of candidate
  * physical tables.
  */
+@FunctionalInterface
 public interface PhysicalTableResolver {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/MacroCalculationStrategies.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/MacroCalculationStrategies.java
@@ -9,6 +9,7 @@ import org.joda.time.DateTime;
 /**
  * Interface implemented by macros to get the dateTime based on granularity.
  */
+@FunctionalInterface
 public interface MacroCalculationStrategies {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/RateLimiter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/RateLimiter.java
@@ -9,6 +9,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 /**
  * An object containing the logic to keep track of and limit the amount of requests being made to the webservice.
  */
+@FunctionalInterface
 public interface RateLimiter {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseFormatResolver.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseFormatResolver.java
@@ -11,6 +11,7 @@ import javax.ws.rs.container.ContainerRequestContext;
  * takes the format name string from URI and a ContainerRequestContext object from which the header Accept field is
  * accessible.
  */
+@FunctionalInterface
 public interface ResponseFormatResolver extends BiFunction<String, ContainerRequestContext, String> {
     /**
      * Resolve desirable format from URI and ContainerRequestContext.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseStream.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseStream.java
@@ -7,6 +7,7 @@ import javax.ws.rs.core.StreamingOutput;
 /**
  * An interface for classes that transform response data to a format representation (e.g. JSON, CSV and others).
  */
+@FunctionalInterface
 public interface ResponseStream {
     /**
      * Gets a resource method that can be used to stream this response as an entity.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseWriter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseWriter.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
  * The interface for objects that write fully-processed ResultSets back to the user. This allows customers to fully
  * customize how they choose to serialize the results from Fili based on the request.
  */
+@FunctionalInterface
 public interface ResponseWriter {
     /**
      * Serializes the ResultSet (pulled from the ResponseData) and any desired metadata and adds it to the specified

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseWriterSelector.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseWriterSelector.java
@@ -13,6 +13,7 @@ import java.util.Optional;
  * sole purpose is to take a `DataApiRequest` and return the `ResponseWriter` that should be used
  * to write the response.
  */
+@FunctionalInterface
 public interface ResponseWriterSelector {
     /**
      * Select ResponseWriter given certain type of format from DataApiRequest.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/workflow/RequestWorkflowProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/workflow/RequestWorkflowProvider.java
@@ -7,6 +7,7 @@ import com.yahoo.bard.webservice.web.handlers.DataRequestHandler;
 /**
  * Request workflow provider builds a request processing chain for handing druid data requests.
  */
+@FunctionalInterface
 public interface RequestWorkflowProvider {
 
     /**

--- a/fili-navi/src/main/java/com/yahoo/bard/webservice/data/dimension/Tag.java
+++ b/fili-navi/src/main/java/com/yahoo/bard/webservice/data/dimension/Tag.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 /**
  * Interface for tags used for tagging dimension fields to add additional properties implicitly specified by its name.
  */
+@FunctionalInterface
 public interface Tag {
 
     /**


### PR DESCRIPTION
Add `@FunctionalInterface` annotation to all functional interfaces.

It is not mandatory to use it, but it is best practice to use it with functional interface to avoid addition of extra methods accidentally. If the interface is annotated with `@FunctionalInterface` annotation and we try to have more than one abstract method, it throws compiler error.

The major benefit of functional interface is that we can use lambda expressions to instantiate them and avoid using bulky anonymous class implementation. Since there is only one abstract function in the functional interfaces, there is no confusion in applying the lambda expression to the method. 
