### PR TITLE
Enhance generic example

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/MetricInstance.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/MetricInstance.java
@@ -8,6 +8,7 @@ import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.LogicalMetricInfo;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -92,6 +93,18 @@ public class MetricInstance {
         this.dependencyMetricNames = Arrays.stream(dependencyFields)
                 .map(FieldName::asName)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Construct a MetricInstance from FieldNames.
+     *
+     * @param logicalMetricInfo  Logical metric info provider
+     * @param maker  The Metric Maker that creates the actual Logical Metric
+     */
+    public MetricInstance(LogicalMetricInfo logicalMetricInfo, MetricMaker maker) {
+        this.logicalMetricInfo = logicalMetricInfo;
+        this.maker = maker;
+        this.dependencyMetricNames = Collections.emptyList();
     }
 
     public String getMetricName() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/Utils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/Utils.java
@@ -2,6 +2,9 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.util;
 
+import com.yahoo.bard.webservice.data.config.metric.MetricInstance;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -19,6 +22,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -183,5 +187,15 @@ public class Utils {
      */
     public static <T, U, V> ImmutablePair<T, V> withRight(ImmutablePair<T, U> pair, V right) {
         return new ImmutablePair<>(pair.getLeft(), right);
+    }
+
+    /**
+     * Create metrics from instance descriptors and store in the metric dictionary.
+     *
+     * @param metricDictionary  The dictionary to store metrics in
+     * @param metrics  The list of metric descriptors
+     */
+    public static void addToMetricDictionary(MetricDictionary metricDictionary, List<MetricInstance> metrics) {
+        metrics.stream().map(MetricInstance::make).forEach(metricDictionary::add);
     }
 }

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DataSourceConfiguration.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DataSourceConfiguration.java
@@ -11,9 +11,9 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Holds the minimum necessary configuration necessary to set up fili to
- * make requests to druid. This defines all metrics, dimensions, and *one*
- * valid time grain of a datasource.
+ * Holds the minimum necessary configuration to set up fili to
+ * make requests to druid. This defines all metrics, dimensions, *one*
+ * valid time grain, and data segments of a datasource.
  * Note the restriction to one time grain, a druid datasource could have
  * more than one, but it *should* have just a single grain.
  */
@@ -56,9 +56,9 @@ public interface DataSourceConfiguration {
     TimeGrain getValidTimeGrain();
 
     /**
-     * Gets a list of segment metadata for a datasource in Druid.
+     * Gets a list of {@link io.druid.timeline.DataSegment data segments} for a datasource in Druid.
      *
-     * @return the list of datasegments reported by druid.
+     * @return the list of data segments reported by druid.
      */
-    List<DataSegment> getDataSegmentMetadata();
+    List<DataSegment> getDataSegments();
 }

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
@@ -45,7 +45,7 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
     /**
      * Constructs a DruidNavigator to load datasources from druid.
      *
-     * @param druidWebService The DruidWebService to be used when talking to druid.
+     * @param druidWebService The DruidWebService to be used when talking to druid
      * @param mapper The instance of ObjectMapper.
      */
     public DruidNavigator(DruidWebService druidWebService, ObjectMapper mapper) {
@@ -145,7 +145,7 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
                 loadTimeGrains(table, dataSegment);
                 loadDataSegment(table, dataSegment);
             });
-            LOG.debug("Loaded table " + table.getName());
+            LOG.debug("Loaded table {}", table.getName());
         }, url);
     }
 
@@ -162,8 +162,7 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
         } catch (JsonProcessingException e) {
             LOG.warn(
                     "Failed while building segment metadata for {}. While this isn't an error, it's unusual behavior",
-                    table.getName(),
-                    e
+                    table.getName()
             );
         }
     }
@@ -219,8 +218,8 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
      * @param segmentJson The JsonNode containing a time interval.
      */
     private void loadTimeGrains(TableConfig tableConfig, JsonNode segmentJson) {
-        JsonNode timeInterval = segmentJson.get("interval");
-        String[] utcTimes = timeInterval.asText().split("/");
+        String timeInterval = segmentJson.get("interval").asText();
+        String[] utcTimes = timeInterval.split("/");
         Optional<TimeGrain> timeGrain = Optional.empty();
         try {
             if (utcTimes.length == 2) {
@@ -234,32 +233,34 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
         }
 
         if (!timeGrain.isPresent()) {
-            LOG.warn("Couldn't detect timegrain for {}, defaulting to DAY TimeGrain.", timeInterval.asText());
+            LOG.warn("Couldn't detect timegrain for {}, defaulting to DAY TimeGrain.", timeInterval);
         }
         tableConfig.setTimeGrain(timeGrain.orElse(DefaultTimeGrain.DAY));
     }
 
     /**
-     * Send a blocking request to druid. All queries are finished before continuing.
+     * Send a non-blocking request to Druid.
      *
-     * @param successCallback  The callback to be done if the query succeeds.
-     * @param url  The url to send the query to.
+     * @param successCallback  The callback to be done if the query succeeds
+     * @param url  The url to send the query to
      *
      * @return future response for the druid query
      */
     private Future<Response> queryDruid(SuccessCallback successCallback, String url) {
-        LOG.debug("Fetching " + url);
+        LOG.debug("Fetching {}", url);
         return druidWebService.getJsonObject(
                 rootNode -> {
-                    LOG.debug("Succesfully fetched " + url);
+                    LOG.debug("Succesfully fetched {}", url);
                     successCallback.invoke(rootNode);
                 },
                 (statusCode, reasonPhrase, responseBody) -> {
                     LOG.error("HTTPError {} - {} for {}", statusCode, reasonPhrase, url);
-                    throw new RuntimeException("HTTPError " + statusCode + " occurred while contacting druid");
+                    throw new RuntimeException(
+                            String.format("HTTPError %s occurred while contacting Druid", statusCode)
+                    );
                 },
                 (throwable) -> {
-                    LOG.error("Error thrown while fetching " + url + ". " + throwable.getMessage());
+                    LOG.error("Error thrown while fetching {}. {}", url, throwable.getMessage());
                     throw new RuntimeException(throwable);
                 },
                 url

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/DruidNavigator.java
@@ -162,7 +162,8 @@ public class DruidNavigator implements Supplier<List<? extends DataSourceConfigu
         } catch (JsonProcessingException e) {
             LOG.warn(
                     "Failed while building segment metadata for {}. While this isn't an error, it's unusual behavior",
-                    table.getName()
+                    table.getName(),
+                    e
             );
         }
     }

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/TableConfig.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/auto/TableConfig.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * TableConfig to hold all metrics, dimensions, timegrains, and the name of a datasource.
+ * TableConfig to hold all metrics, dimensions, valid time grain, and the name of a datasource.
  */
 public class TableConfig implements DataSourceConfiguration {
     private final String tableName;
@@ -54,7 +54,7 @@ public class TableConfig implements DataSourceConfiguration {
     }
 
     /**
-     * Add a {@link TimeGrain} to the datasource.
+     * Sets {@link TimeGrain} of the datasource.
      *
      * @param timeGrain  Valid Timegrain to hold in the TableConfig.
      */
@@ -65,7 +65,7 @@ public class TableConfig implements DataSourceConfiguration {
     /**
      * Add a {@link DataSegment} to the existing known datasegments for this table.
      *
-     * @param dataSegment  The {@link DataSegment} metadata given by Druid.
+     * @param dataSegment  The {@link DataSegment} given by Druid.
      */
     public void addDataSegment(DataSegment dataSegment) {
         dataSegments.add(dataSegment);
@@ -122,7 +122,7 @@ public class TableConfig implements DataSourceConfiguration {
     }
 
     @Override
-    public List<DataSegment> getDataSegmentMetadata() {
-        return dataSegments;
+    public List<DataSegment> getDataSegments() {
+        return Collections.unmodifiableList(dataSegments);
     }
 }

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/GenericDimensionConfigs.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/GenericDimensionConfigs.java
@@ -59,7 +59,7 @@ public class GenericDimensionConfigs {
     }
 
     /**
-     * Get all dimension configurations.
+     * Get all dimension configurations of all data sources.
      *
      * @return set of dimension configurations
      */
@@ -76,9 +76,24 @@ public class GenericDimensionConfigs {
      * @param dataSourceConfiguration  The datasource configuration's dimensions to load
      *
      * @return the dimension configurations for this datasource
+     *
+     * @deprecated only the name(a String) of DataSourceConfiguration can resolve its set of DimensionConfigs. There is
+     * no need to pass a heavier DataSourceConfiguration object. Use {@link #getDimensionConfigs(String)} instead.
      */
+    @Deprecated
     public Set<DimensionConfig> getDimensionConfigs(DataSourceConfiguration dataSourceConfiguration) {
         return dataSourceToDimensionConfigs.getOrDefault(dataSourceConfiguration.getName(), Collections.emptySet());
+    }
+
+    /**
+     * Returns all dimension configurations of a particular data source.
+     *
+     * @param dataSourceName  Name of the data source
+     *
+     * @return all dimension configurations of the particular data source
+     */
+    public Set<DimensionConfig> getDimensionConfigs(String dataSourceName) {
+        return dataSourceToDimensionConfigs.getOrDefault(dataSourceName, Collections.emptySet());
     }
 
     /**

--- a/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/GenericTableLoader.java
+++ b/fili-generic-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/GenericTableLoader.java
@@ -38,15 +38,15 @@ import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 /**
- * Load the table configuration for any druid setup.
+ * Load the table configuration for any Druid setup.
  */
 public class GenericTableLoader extends BaseTableLoader {
-    private final Map<String, Set<Granularity>> dataSourceToValidGrains = new HashMap<>();
+    private final Map<String, Set<Granularity>> dataSourceToValidGrains;
     // Set up the metrics
-    private final Map<String, Set<FieldName>> dataSourceToDruidMetricNames = new HashMap<>();
-    private final Map<String, Set<ApiMetricName>> dataSourceToApiMetricNames = new HashMap<>();
+    private final Map<String, Set<FieldName>> dataSourceToDruidMetricNames;
+    private final Map<String, Set<ApiMetricName>> dataSourceToApiMetricNames;
     // Set up the table definitions
-    private final Map<String, Set<PhysicalTableDefinition>> dataSourceToTableDefinitions = new HashMap<>();
+    private final Map<String, Set<PhysicalTableDefinition>> dataSourceToTableDefinitions;
     private final Supplier<List<? extends DataSourceConfiguration>> configLoader;
 
     /**
@@ -62,6 +62,10 @@ public class GenericTableLoader extends BaseTableLoader {
             DataSourceMetadataService metadataService
     ) {
         super(metadataService);
+        dataSourceToValidGrains = new HashMap<>();
+        dataSourceToDruidMetricNames = new HashMap<>();
+        dataSourceToApiMetricNames = new HashMap<>();
+        dataSourceToTableDefinitions = new HashMap<>();
         this.configLoader = configLoader;
         configureTables(genericDimensionConfigs, metadataService);
     }
@@ -69,8 +73,8 @@ public class GenericTableLoader extends BaseTableLoader {
     /**
      * Set up the tables for this table loader.
      *
-     * @param genericDimensionConfigs  The dimensions to load into test tables.
-     * @param metadataService  The metadata service to plays the datasources in.
+     * @param genericDimensionConfigs  The dimensions to load into the tables
+     * @param metadataService  Container that holds and updates data source data segments
      */
     private void configureTables(
             GenericDimensionConfigs genericDimensionConfigs,
@@ -83,7 +87,7 @@ public class GenericTableLoader extends BaseTableLoader {
                     new DataSourceMetadata(
                             dataSourceConfiguration.getName(),
                             Collections.emptyMap(),
-                            dataSourceConfiguration.getDataSegmentMetadata()
+                            dataSourceConfiguration.getDataSegments()
                     )
             );
 
@@ -100,7 +104,7 @@ public class GenericTableLoader extends BaseTableLoader {
                     getPhysicalTableDefinitions(
                             dataSourceConfiguration,
                             dataSourceConfiguration.getValidTimeGrain(),
-                            genericDimensionConfigs.getDimensionConfigs(dataSourceConfiguration)
+                            genericDimensionConfigs.getDimensionConfigs(dataSourceConfiguration.getName())
                     )
             );
 
@@ -164,11 +168,6 @@ public class GenericTableLoader extends BaseTableLoader {
         );
     }
 
-    /**
-     * Load each logical table from the datasources given.
-     *
-     * @param dictionaries  ResourceDictionaries to load with each table.
-     */
     @Override
     public void loadTableDictionary(ResourceDictionaries dictionaries) {
         configLoader.get()

--- a/fili-generic-example/src/test/java/com/yahoo/wiki/webservice/data/config/auto/StaticWikiConfigLoader.java
+++ b/fili-generic-example/src/test/java/com/yahoo/wiki/webservice/data/config/auto/StaticWikiConfigLoader.java
@@ -44,7 +44,7 @@ public class StaticWikiConfigLoader implements Supplier<List<? extends DataSourc
             }
 
             @Override
-            public List<DataSegment> getDataSegmentMetadata() {
+            public List<DataSegment> getDataSegments() {
                 return Collections.emptyList();
             }
 

--- a/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/metric/WikiMetricLoader.java
+++ b/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/metric/WikiMetricLoader.java
@@ -6,7 +6,9 @@ import com.yahoo.bard.webservice.data.config.metric.MetricInstance;
 import com.yahoo.bard.webservice.data.config.metric.MetricLoader;
 import com.yahoo.bard.webservice.data.config.metric.makers.CountMaker;
 import com.yahoo.bard.webservice.data.config.metric.makers.DoubleSumMaker;
+import com.yahoo.bard.webservice.data.metric.LogicalMetricInfo;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
+import com.yahoo.bard.webservice.util.Utils;
 import com.yahoo.wiki.webservice.data.config.names.WikiApiMetricName;
 import com.yahoo.wiki.webservice.data.config.names.WikiDruidMetricName;
 
@@ -66,24 +68,25 @@ public class WikiMetricLoader implements MetricLoader {
         buildMetricMakers(metricDictionary);
 
         // Metrics that directly aggregate druid fields
-        List<MetricInstance> metrics;
-        metrics = Arrays.asList(
-                new MetricInstance(WikiApiMetricName.COUNT, countMaker),
-                new MetricInstance(WikiApiMetricName.ADDED, doubleSumMaker, WikiDruidMetricName.ADDED),
-                new MetricInstance(WikiApiMetricName.DELETED, doubleSumMaker, WikiDruidMetricName.DELETED),
-                new MetricInstance(WikiApiMetricName.DELTA, doubleSumMaker, WikiDruidMetricName.DELTA)
+        List<MetricInstance> metrics = Arrays.asList(
+                new MetricInstance(new LogicalMetricInfo(WikiApiMetricName.COUNT.asName()), countMaker),
+                new MetricInstance(
+                        new LogicalMetricInfo(WikiApiMetricName.ADDED.asName()),
+                        doubleSumMaker,
+                        WikiDruidMetricName.ADDED
+                ),
+                new MetricInstance(
+                        new LogicalMetricInfo(WikiApiMetricName.DELETED.asName()),
+                        doubleSumMaker,
+                        WikiDruidMetricName.DELETED),
+                new MetricInstance(
+                        new LogicalMetricInfo(WikiApiMetricName.DELTA.asName()),
+                        doubleSumMaker,
+                        WikiDruidMetricName.DELTA
+                )
         );
-        LOG.debug("About to load direct aggregation metrics. Metric dictionary keys: {}", metricDictionary.keySet());
-        addToMetricDictionary(metricDictionary, metrics);
-    }
 
-    /**
-     * Create metrics from instance descriptors and store in the metric dictionary.
-     *
-     * @param metricDictionary  The dictionary to store metrics in
-     * @param metrics  The list of metric descriptors
-     */
-    private void addToMetricDictionary(MetricDictionary metricDictionary, List<MetricInstance> metrics) {
-        metrics.stream().map(MetricInstance::make).forEach(metricDictionary::add);
+        Utils.addToMetricDictionary(metricDictionary, metrics);
+        LOG.debug("About to load direct aggregation metrics. Metric dictionary keys: {}", metricDictionary.keySet());
     }
 }


### PR DESCRIPTION
The generic app was written in 2016, whereas lots of API changes/new features/deprecates have been introduced in 2017. `fili-generic-example` needs to adopt these enhancements to better serve our customers in the new 2018.
  
  
  
  