### PR TITLE
Revert deprecation of getAvailability using physicalDataSourceConstraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -758,6 +758,9 @@ Removals:
 
 ### Deprecated:
 
+- [Revert deprecation of getAvailbleInterval with PhysicalDatasourceConstraint](https://github.com/yahoo/fili/pull/621)
+    * The method is needed in order for availability to function correctly, there is a deeper dive and planning required to actually deprecate it in favor of simpler less confusing design.
+
 - [Remove `PhysicalTable::getTableName` to use `getName` instead](https://github.com/yahoo/fili/pull/263)
     * Having more than 1 method for the same concept (ie. what's the name of this physical table) was confusing and not
       very useful.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
@@ -28,11 +28,7 @@ public interface Availability {
      * @param constraint  The constraint to filter data source names.
      *
      * @return A set of names for data sources backing this availability
-     *
-     * @deprecated in order to enforce general data source constraint. Use
-     * {@link #getDataSourceNames(DataSourceConstraint)} instead
      */
-    @Deprecated
     default Set<DataSourceName> getDataSourceNames(PhysicalDataSourceConstraint constraint) {
         return getDataSourceNames((DataSourceConstraint) constraint);
     }
@@ -75,11 +71,7 @@ public interface Availability {
      * {@link com.yahoo.bard.webservice.table.Schema} and {@link com.yahoo.bard.webservice.web.ApiFilter}s
      *
      * @return A <tt>SimplifiedIntervalList</tt> of intervals available
-     *
-     * @deprecated in order to enforce general data source constraint. Use
-     * {@link #getAvailableIntervals(DataSourceConstraint)} instread
      */
-    @Deprecated
     default SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
         return getAvailableIntervals();
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PartitionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/PartitionAvailability.java
@@ -3,7 +3,6 @@
 package com.yahoo.bard.webservice.table.availability;
 
 import com.yahoo.bard.webservice.data.config.names.DataSourceName;
-import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
 import com.yahoo.bard.webservice.table.resolver.DataSourceFilter;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
@@ -74,7 +73,7 @@ public class PartitionAvailability extends BaseCompositeAvailability implements 
      *
      * @return  A stream of availabilities which participate given the constraint
      */
-    private Stream<Availability> filteredAvailabilities(DataSourceConstraint constraint) {
+    private Stream<Availability> filteredAvailabilities(PhysicalDataSourceConstraint constraint) {
         return availabilityFilters.entrySet().stream()
                 .filter(entry -> entry.getValue().apply(constraint))
                 .map(Map.Entry::getKey);
@@ -87,7 +86,7 @@ public class PartitionAvailability extends BaseCompositeAvailability implements 
      *
      * @return The intervals which are available for the given constraint
      */
-    private SimplifiedIntervalList mergeAvailabilities(DataSourceConstraint constraint) {
+    private SimplifiedIntervalList mergeAvailabilities(PhysicalDataSourceConstraint constraint) {
         return filteredAvailabilities(constraint)
                 .map(availability -> availability.getAvailableIntervals(constraint))
                 .reduce(SimplifiedIntervalList::intersect).orElse(new SimplifiedIntervalList());
@@ -99,7 +98,7 @@ public class PartitionAvailability extends BaseCompositeAvailability implements 
     }
 
     @Override
-    public Set<DataSourceName> getDataSourceNames(DataSourceConstraint constraint) {
+    public Set<DataSourceName> getDataSourceNames(PhysicalDataSourceConstraint constraint) {
         return filteredAvailabilities(constraint)
                 .map(availability -> availability.getDataSourceNames(constraint))
                 .flatMap(Set::stream).collect(Collectors.toSet());

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/PartitionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/PartitionAvailabilitySpec.groovy
@@ -85,8 +85,8 @@ class PartitionAvailabilitySpec extends Specification{
         availability1.getDataSourceNames() >> ([name1] as Set)
         availability2.getDataSourceNames() >> ([name2] as Set)
 
-        availability1.getDataSourceNames(_ as DataSourceConstraint) >> ([name1] as Set)
-        availability2.getDataSourceNames(_ as DataSourceConstraint) >> ([name2] as Set)
+        availability1.getDataSourceNames(_ as PhysicalDataSourceConstraint) >> ([name1] as Set)
+        availability2.getDataSourceNames(_ as PhysicalDataSourceConstraint) >> ([name2] as Set)
 
         DataSourceFilter partition1 = Mock(DataSourceFilter)
         DataSourceFilter partition2 = Mock(DataSourceFilter)
@@ -99,7 +99,7 @@ class PartitionAvailabilitySpec extends Specification{
         partitionAvailability = new PartitionAvailability(partitionMap)
 
         expect:
-        partitionAvailability.getDataSourceNames(Mock(DataSourceConstraint)) == [name1] as Set
+        partitionAvailability.getDataSourceNames(Mock(PhysicalDataSourceConstraint)) == [name1] as Set
     }
 
     @Unroll


### PR DESCRIPTION
The method is needed in order for availability to function correctly, there is a deeper dive and planning required to actually deprecate it in favor of simpler less confusing design.