### PR TITLE
Correct exception message & add missing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,20 @@ Current
 
 ### Fixed:
 
+- [Correct exception message & add missing tests](https://github.com/yahoo/fili/pull/649)
+    * According to Javadoc of 
+      
+        * [`java.util.Map#merge(Object, Object, java.util.function.BiFunction)`](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#merge-K-V-java.util.function.BiFunction-) and
+        * [`java.util.stream.Collectors#toMap(Function, Function, BinaryOperator)`](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html#toMap-java.util.function.Function-java.util.function.Function-java.util.function.BinaryOperator-)
+      
+      The input to the `mergingFunction`/`mergeFunction` is a value, not a key. The exception message of
+      `StreamUtils.throwingMerger` is, therefore, misleading.
+      
+      Some Javadoc of the  `StreamUtils` is also corrected.
+      
+      In addition to correcting the exception message, tests to `StreamUtils` are also missing and, hence, have been
+      added, as well.
+      
 - [Fix lookup metadata loader by pulling the RegisteredLookupDimension](https://github.com/yahoo/fili/pull/651)
     * Lookup Metadata Health Check always return true when some Druid registered lookup are absolutely failing to be
       loaded. Instead of checking load status of `RegisteredLookupDimension`, `RegisteredLookupMetadataLoadTask` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,18 +267,7 @@ Current
 ### Fixed:
 
 - [Correct exception message & add missing tests](https://github.com/yahoo/fili/pull/649)
-    * According to Javadoc of 
-      
-        * [`java.util.Map#merge(Object, Object, java.util.function.BiFunction)`](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#merge-K-V-java.util.function.BiFunction-) and
-        * [`java.util.stream.Collectors#toMap(Function, Function, BinaryOperator)`](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html#toMap-java.util.function.Function-java.util.function.Function-java.util.function.BinaryOperator-)
-      
-      The input to the `mergingFunction`/`mergeFunction` is a value, not a key. The exception message of
-      `StreamUtils.throwingMerger` is, therefore, misleading.
-      
-      Some Javadoc of the  `StreamUtils` is also corrected.
-      
-      In addition to correcting the exception message, tests to `StreamUtils` are also missing and, hence, have been
-      added, as well.
+    * Clarified exception message thrown by `StreamUtils.throwingMerger`
       
 - [Fix lookup metadata loader by pulling the RegisteredLookupDimension](https://github.com/yahoo/fili/pull/651)
     * Lookup Metadata Health Check always return true when some Druid registered lookup are absolutely failing to be

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/StreamUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/StreamUtils.java
@@ -2,6 +2,8 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.util;
 
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.TWO_VALUES_OF_THE_SAME_KEY;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -33,7 +35,7 @@ public class StreamUtils {
      * @see Collectors#throwingMerger()
      */
     public static <T> BinaryOperator<T> throwingMerger() {
-        return (u, v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); };
+        return (u, v) -> { throw new IllegalStateException(TWO_VALUES_OF_THE_SAME_KEY.format(u, v)); };
     }
 
     /**
@@ -58,8 +60,10 @@ public class StreamUtils {
     }
 
     /**
-     * Return a collector that creates a LinkedHashMap using the given key and value functions.
+     * Return a collector that creates a {@link java.util.Map} using the given key and value functions.
      * This collector assumes the elements being collected are distinct.
+     * <p>
+     * The concrete type of the {@link java.util.Map} being created is given by a {@link java.util.function.Supplier}.
      *
      * @param <S>  Type of the objects being collected
      * @param <K>  Type of the keys
@@ -67,9 +71,10 @@ public class StreamUtils {
      * @param <M>  The type of Map being collected into
      * @param keyMapper  Mapping function for the key
      * @param valueMapper  Mapping function for the value
-     * @param mapSupplier  A function which returns a new, empty Map into which the results will be inserted
+     * @param mapSupplier  A {@link java.util.function.Supplier} which provides a new, empty {@link java.util.Map} into
+     * which the results will be inserted
      *
-     * @return a collector that creates a LinkedHashMap using the given key and value functions.
+     * @return a collector that creates a {@link java.util.Map} using the given key and value functions
      * @throws IllegalStateException if multiple values are associated with the same key
      * @see Collectors#toMap(Function, Function, BinaryOperator, java.util.function.Supplier)
      */
@@ -107,14 +112,17 @@ public class StreamUtils {
      * @param <K>  Type of the keys
      * @param <M>  The type of Map being collected into
      * @param keyMapper  Mapping function for the key
-     * @param mapSupplier  A function which returns a new, empty Map into which the results will be inserted
+     * @param mapSupplier  A {@link java.util.function.Supplier} which provides a new, empty {@link java.util.Map} into
+     * which the results will be inserted
      *
-     * @return a collector that creates a LinkedHashMap dictionary using the given key function.
+     * @return a {@link java.util.stream.Collector} that creates a dictionary using the given
+     * {@link java.util.function.Function key function} and the given {@link java.util.function.Supplier map supplier}
      * @throws IllegalStateException if multiple values are associated with the same key
      * @see Collectors#toMap(Function, Function, BinaryOperator, java.util.function.Supplier)
      */
     public static <S, K, M extends Map<K, S>> Collector<S, ?, M> toDictionary(
-            Function<? super S, ? extends K> keyMapper, Supplier<M> mapSupplier
+            Function<? super S, ? extends K> keyMapper,
+            Supplier<M> mapSupplier
     ) {
         return Collectors.toMap(keyMapper, Function.identity(), StreamUtils.throwingMerger(), mapSupplier);
     }
@@ -173,7 +181,7 @@ public class StreamUtils {
      * @return the new set containing the additional value
      */
     public static <T> Set<T> append(Set<T> set, T value) {
-        HashSet<T> result = new HashSet<T>(set);
+        HashSet<T> result = new HashSet<>(set);
         result.add(value);
         return result;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -263,7 +263,9 @@ public enum ErrorMessageFormat implements MessageFormatter {
     UNABLE_TO_DELETE_DIR("Unable to delete directory %s."),
     FAIL_TO_WIPTE_LUCENE_INDEX_DIR("Failed to wipte Lucene index at directory: %s"),
 
-    REQUEST_PROCESSING_EXCEPTION("Exception processing request: %s")
+    REQUEST_PROCESSING_EXCEPTION("Exception processing request: %s"),
+
+    TWO_VALUES_OF_THE_SAME_KEY("Values %s and %s are associated with the same key"),
     ;
 
     private final String messageFormat;

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/StreamUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/StreamUtilsSpec.groovy
@@ -1,0 +1,60 @@
+// Copyright 2018 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.util
+
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.TWO_VALUES_OF_THE_SAME_KEY
+
+import spock.lang.Specification
+
+import java.util.function.Predicate
+import java.util.stream.Stream
+
+class StreamUtilsSpec extends Specification {
+    def "When duplicate keys merge, IllegalStateException is thrown"() {
+        when: "a key, which is already associates with a value, is inserted to a map"
+        [dupKey: 1].merge("dupKey", 2, StreamUtils.throwingMerger())
+
+        then: "insert if rejected"
+        IllegalStateException exception = thrown()
+        exception.message == TWO_VALUES_OF_THE_SAME_KEY.format(1, 2)
+    }
+
+    def "Stream collected to unmodifiable set cannot be modified and element first-in ordering is preserved"() {
+        given: "a stream collected to an unmodifiable set"
+        Set<Integer> set = StreamUtils.toUnmodifiableSet(Stream.of(1, 2, 3))
+        Iterator<Integer> iterator = set.iterator()
+
+        expect: "elements are pulled out in-order"
+        iterator.next() == 1
+        iterator.next() == 2
+        iterator.next() == 3
+        !iterator.hasNext()
+
+        when: "we try to modify by adding an element to the set"
+        set.add(4)
+
+        then: "it is rejected"
+        thrown(UnsupportedOperationException)
+    }
+
+    def "Negating a Predicate reverses test result"() {
+        given: "a predicate whose test returns true"
+        Predicate<Object> predicate = Mock(Predicate) {test() >> true}
+
+        when: "we negate that predicate"
+        StreamUtils.not(predicate)
+
+        then: "test returns false"
+        !predicate.test()
+    }
+
+    def "Appending returns set with the appended element"() {
+        expect:
+        StreamUtils.append([1, 2] as Set, 3) == [1, 2, 3] as Set
+    }
+
+    def "Merging returns set containing two sets"() {
+        expect:
+        StreamUtils.setMerge([1, 2, 3] as Set, [4, 5, 6] as Set) == [1, 2, 3, 4, 5, 6] as Set
+    }
+}


### PR DESCRIPTION
According to Javadoc of 

* [`java.util.Map#merge(Object, Object, java.util.function.BiFunction)`](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html#merge-K-V-java.util.function.BiFunction-) and
* [`java.util.stream.Collectors#toMap(Function, Function, BinaryOperator)`](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Collectors.html#toMap-java.util.function.Function-java.util.function.Function-java.util.function.BinaryOperator-)

The **input** to the `mergingFunction`/`mergeFunction` is a value, not a key. The exception message at https://github.com/yahoo/fili/blob/master/fili-core/src/main/java/com/yahoo/bard/webservice/util/StreamUtils.java#L36 is, therefore, misleading.

Some Javadoc of the  `StreamUtils` is also corrected.

In addition, tests to `StreamUtils` are also missing and, hence, have been added, as well.