### PR TITLE
Adds a factory for building `ResponseProcessor`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ Current
 
 ### Changed:
 
+- [ResponseProcessor is now injectable.](https://github.com/yahoo/fili/pull/663)
+    * To add a custom `ResponseProcessor`, implement `ResponseProcessorFactory`, override 
+        `AbstractBinderFactory::buildResponseProcessorFactory` to return your custom `ResponseProcessorFactory.class`. 
+
 - [Add config to ignore partial/volatile intervals and cache everything in cache V2](https://github.com/yahoo/fili/pull/645)
     * In cache V2, user should be able to decide whether partial data or volatile data should be cached or not. This PR
       adds a config that allows the user to do this.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -73,8 +73,8 @@ import com.yahoo.bard.webservice.druid.util.FieldConverters;
 import com.yahoo.bard.webservice.druid.util.SketchFieldConverter;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataLoadTask;
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
-import com.yahoo.bard.webservice.metadata.RegisteredLookupMetadataLoadTask;
 import com.yahoo.bard.webservice.metadata.QuerySigningService;
+import com.yahoo.bard.webservice.metadata.RegisteredLookupMetadataLoadTask;
 import com.yahoo.bard.webservice.metadata.RequestedIntervalsFunction;
 import com.yahoo.bard.webservice.metadata.SegmentIntervalsHashIdGenerator;
 import com.yahoo.bard.webservice.table.LogicalTableDictionary;
@@ -85,9 +85,6 @@ import com.yahoo.bard.webservice.util.DefaultingDictionary;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 import com.yahoo.bard.webservice.web.CsvResponseWriter;
 import com.yahoo.bard.webservice.web.DataApiRequest;
-import com.yahoo.bard.webservice.web.apirequest.DataApiRequestFactory;
-import com.yahoo.bard.webservice.web.apirequest.DefaultDataApiRequestFactory;
-import com.yahoo.bard.webservice.web.ratelimit.DefaultRateLimiter;
 import com.yahoo.bard.webservice.web.DefaultResponseFormatResolver;
 import com.yahoo.bard.webservice.web.DimensionApiRequestMapper;
 import com.yahoo.bard.webservice.web.DimensionsApiRequest;
@@ -106,11 +103,16 @@ import com.yahoo.bard.webservice.web.ResponseFormatResolver;
 import com.yahoo.bard.webservice.web.ResponseWriter;
 import com.yahoo.bard.webservice.web.SlicesApiRequest;
 import com.yahoo.bard.webservice.web.TablesApiRequest;
+import com.yahoo.bard.webservice.web.apirequest.DataApiRequestFactory;
+import com.yahoo.bard.webservice.web.apirequest.DefaultDataApiRequestFactory;
 import com.yahoo.bard.webservice.web.apirequest.DefaultHavingApiGenerator;
 import com.yahoo.bard.webservice.web.apirequest.HavingGenerator;
 import com.yahoo.bard.webservice.web.apirequest.PerRequestDictionaryHavingGenerator;
 import com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow;
 import com.yahoo.bard.webservice.web.handlers.workflow.RequestWorkflowProvider;
+import com.yahoo.bard.webservice.web.ratelimit.DefaultRateLimiter;
+import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessorFactory;
+import com.yahoo.bard.webservice.web.responseprocessors.ResultSetResponseProcessorFactory;
 import com.yahoo.bard.webservice.web.util.QueryWeightUtil;
 
 import com.codahale.metrics.Gauge;
@@ -338,6 +340,8 @@ public abstract class AbstractBinderFactory implements BinderFactory {
                 bind(buildResponseWriter(getMappers())).to(ResponseWriter.class);
 
                 bind(buildResponseFormatResolver()).to(ResponseFormatResolver.class);
+
+                bind(buildResponseProcessorFactory()).to(ResponseProcessorFactory.class);
 
                 bind(buildRateLimiter()).to(RateLimiter.class);
 
@@ -1198,6 +1202,19 @@ public abstract class AbstractBinderFactory implements BinderFactory {
      */
     protected ResponseFormatResolver buildResponseFormatResolver() {
         return new DefaultResponseFormatResolver();
+    }
+
+    /**
+     * Returns the class to bind to {@link ResponseProcessorFactory}.
+     * <p>
+     * The ResponseProcessorFactory allows us to inject a custom {@link
+     * com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor} despite the fact that these processors depend
+     * on objects that are built uniquely for each request.
+     *
+     * @return A class that implements {@link ResponseProcessorFactory}.
+     */
+    protected Class<? extends ResponseProcessorFactory> buildResponseProcessorFactory() {
+        return ResultSetResponseProcessorFactory.class;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResponseProcessorFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResponseProcessorFactory.java
@@ -1,0 +1,37 @@
+// Copyright 2018 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.responseprocessors;
+
+import com.yahoo.bard.webservice.application.ObjectMappersSuite;
+import com.yahoo.bard.webservice.data.DruidResponseParser;
+import com.yahoo.bard.webservice.data.HttpResponseMaker;
+import com.yahoo.bard.webservice.web.DataApiRequest;
+import com.yahoo.bard.webservice.web.PreResponse;
+
+import rx.subjects.Subject;
+
+/**
+ * A {@link ResponseProcessor} relies on things that are directly constructed at request time (i.e. the
+ * {@link DataApiRequest}). Therefore, we can't inject a `ResponseProcessor` directly. We can however inject a factory.
+ */
+public interface ResponseProcessorFactory {
+
+    /**
+     * Constructs a custom ResponseProcessor.
+     *
+     * @param apiRequest  The current request
+     * @param responseEmitter  Generates the response to be processed
+     * @param druidResponseParser  Transforms a druid response into a {@link ResultSet}
+     * @param objectMappers  Dictates how to format
+     * @param httpResponseMaker  Crafts an HTTP response to be sent back to the user from a ResultSet or error message
+     *
+     * @return An object that handles parsing and post-processing of Druid requests
+     */
+    ResponseProcessor build(
+            DataApiRequest apiRequest,
+            Subject<PreResponse, PreResponse> responseEmitter,
+            DruidResponseParser druidResponseParser,
+            ObjectMappersSuite objectMappers,
+            HttpResponseMaker httpResponseMaker
+    );
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/responseprocessors/ResultSetResponseProcessorFactory.java
@@ -1,0 +1,34 @@
+// Copyright 2018 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.responseprocessors;
+
+import com.yahoo.bard.webservice.application.ObjectMappersSuite;
+import com.yahoo.bard.webservice.data.DruidResponseParser;
+import com.yahoo.bard.webservice.data.HttpResponseMaker;
+import com.yahoo.bard.webservice.web.DataApiRequest;
+import com.yahoo.bard.webservice.web.PreResponse;
+
+import rx.subjects.Subject;
+
+/**
+ * Builds the default Druid response processor: {@link ResultSetResponseProcessor}.
+ */
+public class ResultSetResponseProcessorFactory implements ResponseProcessorFactory {
+
+    @Override
+    public ResponseProcessor build(
+            DataApiRequest apiRequest,
+            Subject<PreResponse, PreResponse> responseEmitter,
+            DruidResponseParser druidResponseParser,
+            ObjectMappersSuite objectMappers,
+            HttpResponseMaker httpResponseMaker
+    ) {
+        return new ResultSetResponseProcessor(
+                apiRequest,
+                responseEmitter,
+                druidResponseParser,
+                objectMappers,
+                httpResponseMaker
+        );
+    }
+}


### PR DESCRIPTION
-- We would like to do a little bit of Druid error analysis to extract
some more illuminating error codes out of some of Druid's 500's. The
error callback is controlled by the `ResponseProcessor`.

-- Unfortunately, the `ResponseProcessor` can't be injected directly
because it depends on the `DataApiRequest`, which is built directly in
each request. So instead we wrap the creation of `ResponseProcessor` in
a factory that can be injected.