### PR TITLE
Correct Druid coordinator URL in Wikipedia example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ pull request if there was one.
 
 ### Fixed:
 
+- [Correct Druid coordinator URL in Wikipedia example](https://github.com/yahoo/fili/pull/683)
+    * Config value for Druid coordinator URL is mis-typed.
 
 
 ### Known Issues:

--- a/fili-wikipedia-example/src/main/resources/applicationConfig.properties
+++ b/fili-wikipedia-example/src/main/resources/applicationConfig.properties
@@ -11,7 +11,7 @@ bard__resource_binder=com.yahoo.wiki.webservice.application.WikiBinderFactory
 
 bard__non_ui_druid_broker=http://localhost:8082/druid/v2
 bard__ui_druid_broker=http://localhost:8082/druid/v2
-bard__druid_coord=http://localhost:8081/druid/v2
+bard__druid_coord=http://localhost:8081/druid/coordinator/v1
 
 # Use memory for the default dimension backing store
 bard__dimension_backend=memory


### PR DESCRIPTION
Addresses issue https://github.com/yahoo/fili/issues/679

I've manually tested it