### PR TITLE
Legitimate request having interval of 'P1D/current' with 'all' grain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ pull request if there was one.
 
 ### Fixed:
 
+- [Legitimate request having interval of 'P1D/current' with 'all' grain](https://github.com/yahoo/fili/pull/692)
+    * PxD/current should be valid interval with "all" granularity.
+
 - [Correct Druid coordinator URL in Wikipedia example](https://github.com/yahoo/fili/pull/683)
     * Config value for Druid coordinator URL is mis-typed.
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -549,12 +549,16 @@ public abstract class ApiRequestImpl implements ApiRequest {
             String dateText,
             DateTimeFormatter timeFormatter
     ) throws BadApiRequestException {
-        //If granularity is all and dateText is macro, then throw an exception
         TimeMacros macro = TimeMacros.forName(dateText);
         if (macro != null) {
             if (granularity instanceof AllGranularity) {
-                LOG.debug(INVALID_INTERVAL_GRANULARITY.logFormat(macro, dateText));
-                throw new BadApiRequestException(INVALID_INTERVAL_GRANULARITY.format(macro, dateText));
+                //If granularity is all and dateText is a macro of TimeMacros.NEXT, then throw an exception
+                if (TimeMacros.NEXT.equals(macro)) {
+                    LOG.debug(INVALID_INTERVAL_GRANULARITY.logFormat(macro, dateText));
+                    throw new BadApiRequestException(INVALID_INTERVAL_GRANULARITY.format(macro, dateText));
+                } else {
+                    return DateTime.now();
+                }
             }
             return macro.getDateTime(now, (TimeGrain) granularity);
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -552,12 +552,13 @@ public abstract class ApiRequestImpl implements ApiRequest {
         TimeMacros macro = TimeMacros.forName(dateText);
         if (macro != null) {
             if (granularity instanceof AllGranularity) {
-                //If granularity is all and dateText is a macro of TimeMacros.NEXT, then throw an exception
-                if (TimeMacros.NEXT.equals(macro)) {
+                if (TimeMacros.CURRENT.equals(macro)) {
+                    // Granularity is "all" and dateText is a macro of TimeMacros.CURRENT, this valid
+                    return DateTime.now();
+                } else {
+                    // Granularity is "all" and dateText is not a macro of TimeMacros.CURRENT, this not valid
                     LOG.debug(INVALID_INTERVAL_GRANULARITY.logFormat(macro, dateText));
                     throw new BadApiRequestException(INVALID_INTERVAL_GRANULARITY.format(macro, dateText));
-                } else {
-                    return DateTime.now();
                 }
             }
             return macro.getDateTime(now, (TimeGrain) granularity);

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestIntervalsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestIntervalsSpec.groovy
@@ -163,6 +163,33 @@ class DataApiRequestIntervalsSpec extends Specification {
     }
 
     @Unroll
+    def "current/P#numPastDays D with 'all' granularity generates an interval of #numPastDays days for the future" () {
+        when: "parse string interval from request"
+        Set intervals = new TestingDataApiRequestImpl().generateIntervals(
+                String.format("${TimeMacros.CURRENT.getName()}/P%sD", numPastDays),
+                apiRequest.generateGranularity("all", granularityParser), dateTimeFormatter
+        )
+        Interval interval = intervals.first()
+        DateTime parsedStart = DateTime.now()
+        DateTime parsedEnd = parsedStart.plusDays(numPastDays)
+
+        then: "an interval of days in the future is generated"
+        intervals.size() == 1
+        interval.start.year == parsedStart.year
+        interval.start.monthOfYear == parsedStart.monthOfYear
+        interval.start.dayOfYear == parsedStart.dayOfYear
+        interval.end.year == parsedEnd.year
+        interval.end.monthOfYear == parsedEnd.monthOfYear
+        interval.end.dayOfYear == parsedEnd.dayOfYear
+
+        where:
+        numPastDays | _
+        1           | _
+        2           | _
+        3           | _
+    }
+
+    @Unroll
     def "check parsing interval #intervalString parses to #parsedStart/#parsedStop with the use of time periods"() {
 
         given: "An expected interval"


### PR DESCRIPTION
Addresses https://github.com/yahoo/fili/issues/691

The root cause is the fact that `AllGranularity` doesn't support `roundFloor()`(shown in picture below), which is why current code avoid the case of parsing interval under "all" granularity.

A costly and not-necessarily the right option is to have `AllGranularity` implement `TimeGrain`.
But a much better solution would be simply allowing such interval string during parsing, which this PR chooses

```
                              +---------------+
                              |               |
                          +--->  Granularity  <----+
                          |   |               |    |
roundFloor()  +-----+     |   +---------------+    |
                    |     |                        |
                    |     |                        |
                    +-----+-----+         +--------+-------+
                    | TimeGrain |         | AllGranularity |
                    +-----^-----+         +----------------+
                          |
                          |
                 +--------+--------+
                 |ZoneLessTimeGrain|
                 +--------^--------+
                          |
                          |
                          |
                  +-------+--------+
                  |DefaultTimeGrain|
                  +----------------+

```
