### PR TITLE
fixing the NoSuchElementException when availability of the underlying table is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ pull request if there was one.
 
 ### Fixed:
 
+- [Fix generate intervals logic when availability is empty](https://github.com/yahoo/fili/pull/698)
+    * Logic to generate intervals when `CURRENT_MACRO_USES_LATEST` flag is turned on has a bug. The code throws `NoSuchElementException` when the table has no availabilities. This PR fixes the bug by checking if the availability of the underlying table is empty.
 - [Correct Druid coordinator URL in Wikipedia example](https://github.com/yahoo/fili/pull/683)
     * Config value for Druid coordinator URL is mis-typed.
     
@@ -156,8 +158,10 @@ Thanks to everyone who contributed to this release!
 
 ### Added:
 
-- [Logical Table Availability](https://github.com/yahoo/fili/pull/697)
-    * Added `logicalTableAvailability` to `TableUtils` which returns the union of availabilities for the logical table.
+- [Latest Time Macro](https://github.com/yahoo/fili/pull/697)
+    * Added `logicalTableAvailability` to `TableUtils` which returns the union of intervals for the logical table.
+    * Added `now` parameter to `generateIntervals` for which time macros will be relatively calculated.
+    * Added `CURRENT_MACRO_USES_LATEST` flag which when turned on uses the first unavailable availability to generate the intervals. 
 
 - [Annotate Functional Interface](https://github.com/yahoo/fili/pull/606)
     * Add `@FunctionalInterface` annotation to all functional interfaces.


### PR DESCRIPTION
Logic to generate intervals when `CURRENT_MACRO_USES_LATEST` flag is turned on has a bug. The code throws `NoSuchElementException` when the table has no availabilities. This PR fixes the bug by checking if the availability of the underlying table is empty.