### PR TITLE
Inject customizable extraction functions to RegisteredLookupDimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ pull request if there was one.
 
 ### Changed:
 
+- [Inject customizable extraction functions to RegisteredLookupDimension](https://github.com/yahoo/fili/pull/724)
+    * Change injecting registered lookup names to injecting registered lookup extraction function for lookup dimension
+      so that downstream projects can configure all fields of registered lookup extraction function.
+
 - [Abort request when too many Druid filters are generated](https://github.com/yahoo/fili/pull/690)
     * In order to avoid Druid queries with too much filters on high-cardinality dimension, Fili sets a upper limit
       on the number of filters and aborts requests if the limit is exceeded.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ pull request if there was one.
 ### Changed:
 
 - [Inject customizable extraction functions to RegisteredLookupDimension](https://github.com/yahoo/fili/pull/724)
-    * Change injecting registered lookup names to injecting registered lookup extraction function for lookup dimension
-      so that downstream projects can configure all fields of registered lookup extraction function.
+    * Instead of injecting registered lookup names, we inject registered lookup extraction functions for lookup
+      dimension so that downstream projects can configure all fields of registered lookup extraction functions.
 
 - [Abort request when too many Druid filters are generated](https://github.com/yahoo/fili/pull/690)
     * In order to avoid Druid queries with too much filters on high-cardinality dimension, Fili sets a upper limit

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/DefaultRegisteredLookupDimensionConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/DefaultRegisteredLookupDimensionConfig.java
@@ -6,8 +6,11 @@ import com.yahoo.bard.webservice.data.config.names.DimensionName;
 import com.yahoo.bard.webservice.data.dimension.DimensionField;
 import com.yahoo.bard.webservice.data.dimension.KeyValueStore;
 import com.yahoo.bard.webservice.data.dimension.SearchProvider;
+import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.ExtractionFunction;
 
 import javax.validation.constraints.NotNull;
+
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -15,91 +18,98 @@ import java.util.List;
  * A Default Registered Lookup Dimension holds all of the information needed to construct a Registered Lookup Dimension.
  */
 public class DefaultRegisteredLookupDimensionConfig extends DefaultKeyValueStoreDimensionConfig
-    implements RegisteredLookupDimensionConfig {
-  private final List<String> lookups;
+        implements RegisteredLookupDimensionConfig {
 
-  /**
-   * Construct a RegisteredLookupDefaultDimensionConfig instance from dimension name , dimension fields and
-   * default dimension fields.
-   *
-   * @param apiName  The API Name is the external, end-user-facing name for the dimension.
-   * @param physicalName  The internal, physical name for the dimension.
-   * @param description  A description of the dimension and its meaning.
-   * @param longName  The Long Name is the external, end-user-facing long  name for the dimension.
-   * @param category  The Category is the external, end-user-facing category for the dimension.
-   * @param fields  The set of fields for this dimension.
-   * @param defaultDimensionFields  The default set of fields for this dimension to be shown in the response.
-   * @param keyValueStore  The key value store holding dimension row data.
-   * @param searchProvider  The search provider for field value lookups on this dimension.
-   * @param lookups  A list of lookups used to configure the Lookup dimension.
-   */
-  public DefaultRegisteredLookupDimensionConfig(
-      @NotNull DimensionName apiName,
-      String physicalName,
-      String description,
-      String longName,
-      String category,
-      @NotNull LinkedHashSet<DimensionField> fields,
-      @NotNull LinkedHashSet<DimensionField> defaultDimensionFields,
-      @NotNull KeyValueStore keyValueStore,
-      @NotNull SearchProvider searchProvider,
-      @NotNull List<String> lookups
-  ) {
-    super (
-        apiName,
-        physicalName,
-        description,
-        longName,
-        category,
-        fields,
-        defaultDimensionFields,
-        keyValueStore,
-        searchProvider
-    );
-    this.lookups = lookups;
-  }
+    private final List<ExtractionFunction> registeredLookupExtractionFns;
 
-  /**
-   * Construct a RegisteredLookupDefaultDimensionConfig instance from Dimension Name ,
-   * and only using default dimension fields.
-   *
-   * @param apiName  The API Name is the external, end-user-facing name for the dimension.
-   * @param physicalName  The internal, physical name for the dimension.
-   * @param description  A description of the dimension and its meaning.
-   * @param longName  The Long Name is the external, end-user-facing long  name for the dimension.
-   * @param category  The Category is the external, end-user-facing category for the dimension.
-   * @param fields The set of fields for this dimension, this set of field will also be used for the default fields.
-   * @param keyValueStore  The key value store holding dimension row data.
-   * @param searchProvider  The search provider for field value lookups on this dimension.
-   * @param lookups  A list of lookups used to configure the Lookup dimension.
-   */
-  public DefaultRegisteredLookupDimensionConfig(
-      @NotNull DimensionName apiName,
-      String physicalName,
-      String description,
-      String longName,
-      String category,
-      @NotNull LinkedHashSet<DimensionField> fields,
-      @NotNull KeyValueStore keyValueStore,
-      @NotNull  SearchProvider searchProvider,
-      @NotNull List<String> lookups
-  ) {
-    this (
-        apiName,
-        physicalName,
-        description,
-        longName,
-        category,
-        fields,
-        fields,
-        keyValueStore,
-        searchProvider,
-        lookups
-    );
-  }
+    /**
+     * Construct a new {@code RegisteredLookupDefaultDimensionConfig} with the specified a dimension's metadata, the
+     * dimension join facilities for that dimension({@link KeyValueStore} and {@link SearchProvider}), and a list of
+     * registered lookup extraction function of that dimension.
+     *
+     * @param apiName  An external and end-user-facing Webservice API name for the dimension
+     * @param physicalName  The dimension name as shown in Druid
+     * @param description  A description of the dimension and its meaning.
+     * @param longName  An external and end-uder-facing name for the dimension, this could be used as UI name for the
+     * this dimension
+     * @param category  The group name for a set of similar dimensions
+     * @param fields  A set of dimension fields for this dimension
+     * @param defaultDimensionFields  The default set of fields for this dimension to be shown in the response
+     * @param keyValueStore  The key value store holding dimension row data used for dimension join
+     * @param searchProvider  A dimension join facility for searching through dimension metadata
+     * @param registeredLookupExtractionFns  A list of registered lookup extraction functions used to perform lookups
+     */
+    public DefaultRegisteredLookupDimensionConfig(
+            @NotNull DimensionName apiName,
+            String physicalName,
+            String description,
+            String longName,
+            String category,
+            @NotNull LinkedHashSet<DimensionField> fields,
+            @NotNull LinkedHashSet<DimensionField> defaultDimensionFields,
+            @NotNull KeyValueStore keyValueStore,
+            @NotNull SearchProvider searchProvider,
+            @NotNull List<ExtractionFunction> registeredLookupExtractionFns
+    ) {
+        super(
+                apiName,
+                physicalName,
+                description,
+                longName,
+                category,
+                fields,
+                defaultDimensionFields,
+                keyValueStore,
+                searchProvider
+        );
+        this.registeredLookupExtractionFns = Collections.unmodifiableList(registeredLookupExtractionFns);
+    }
 
-  @Override
-  public List<String> getLookups() {
-    return lookups;
-  }
+    /**
+     * Construct a new {@code RegisteredLookupDefaultDimensionConfig} with the specified a dimension's metadata, the
+     * dimension join facilities for that dimension({@link KeyValueStore} and {@link SearchProvider}), and a list of
+     * registered lookup extraction function of that dimension.
+     * <p>
+     * This constructor initializes so that all dimension fields and default dimension fields are the same.
+     *
+     * @param apiName  An external and end-user-facing Webservice API name for the dimension
+     * @param physicalName  The dimension name as shown in Druid
+     * @param description  A description of the dimension and its meaning.
+     * @param longName  An external and end-uder-facing name for the dimension, this could be used as UI name for the
+     * this dimension
+     * @param category  The group name for a set of similar dimensions
+     * @param fields  A set of dimension fields for this dimension
+     * @param keyValueStore  The key value store holding dimension row data used for dimension join
+     * @param searchProvider  A dimension join facility for searching through dimension metadata
+     * @param registeredLookupExtractionFns  A list of registered lookup extraction functions used to perform lookups
+     */
+    public DefaultRegisteredLookupDimensionConfig(
+            @NotNull DimensionName apiName,
+            String physicalName,
+            String description,
+            String longName,
+            String category,
+            @NotNull LinkedHashSet<DimensionField> fields,
+            @NotNull KeyValueStore keyValueStore,
+            @NotNull SearchProvider searchProvider,
+            @NotNull List<ExtractionFunction> registeredLookupExtractionFns
+    ) {
+        this(
+                apiName,
+                physicalName,
+                description,
+                longName,
+                category,
+                fields,
+                fields,
+                keyValueStore,
+                searchProvider,
+                registeredLookupExtractionFns
+        );
+    }
+
+    @Override
+    public List<ExtractionFunction> getRegisteredLookupExtractionFns() {
+        return registeredLookupExtractionFns;
+    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/RegisteredLookupDimensionConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/RegisteredLookupDimensionConfig.java
@@ -18,9 +18,9 @@ public interface RegisteredLookupDimensionConfig extends DimensionConfig {
     }
 
     /**
-     * Returns a list of extraction function for the lookup dimension values.
+     * Returns a list of extraction functions for the lookup dimension values.
      *
-     * @return the list of extraction function for the lookup dimension values
+     * @return the list of extraction functions for the lookup dimension values
      */
     List<ExtractionFunction> getRegisteredLookupExtractionFns();
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/RegisteredLookupDimensionConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/dimension/RegisteredLookupDimensionConfig.java
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.data.config.dimension;
 
 import com.yahoo.bard.webservice.data.dimension.impl.RegisteredLookupDimension;
+import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.ExtractionFunction;
 
 import java.util.List;
 
@@ -17,9 +18,9 @@ public interface RegisteredLookupDimensionConfig extends DimensionConfig {
     }
 
     /**
-     * Returns a list of lookups used to configure the Lookup dimension.
+     * Returns a list of extraction function for the lookup dimension values.
      *
-     * @return List of lookups
+     * @return the list of extraction function for the lookup dimension values
      */
-    List<String> getLookups();
+    List<ExtractionFunction> getRegisteredLookupExtractionFns();
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/Dimension.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/Dimension.java
@@ -57,16 +57,16 @@ public interface Dimension {
     DateTime getLastUpdated();
 
     /**
-     * Getter for dimension fields.
+     * Returns all dimension fields of this dimension.
      *
-     * @return Set of dimension fields
+     * @return all dimension fields of this dimension
      */
     LinkedHashSet<DimensionField> getDimensionFields();
 
     /**
-     * Getter for default dimension fields.
+     * Returns the default dimension fields to be shown in the response.
      *
-     * @return Set of dimension fields
+     * @return the default dimension fields to be shown in the response
      */
     LinkedHashSet<DimensionField> getDefaultDimensionFields();
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/RegisteredLookupDimension.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/RegisteredLookupDimension.java
@@ -5,7 +5,6 @@ package com.yahoo.bard.webservice.data.dimension.impl;
 import com.yahoo.bard.webservice.data.config.dimension.RegisteredLookupDimensionConfig;
 import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.CascadeExtractionFunction;
 import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.ExtractionFunction;
-import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.RegisteredLookupExtractionFunction;
 import com.yahoo.bard.webservice.druid.serializers.LookupDimensionToDimensionSpec;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -16,30 +15,48 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
 /**
- * RegisteredLookupDimension creates a registered look up dimension based on the lookup chain.
+ * A dimension whose dimension value is mapped by a registered lookup extraction function or a chain of such functions
+ * by Druid.
  */
 @JsonSerialize(using = LookupDimensionToDimensionSpec.class)
 public class RegisteredLookupDimension extends KeyValueStoreDimension implements ExtractionFunctionDimension {
 
-    private final List<String> lookups;
+    private final List<ExtractionFunction> registeredLookupExtractionFns;
 
     /**
-     * Constructor.
+     * Constructs a new {@code RegisteredLookupDimension} with a specified dimension config object.
      *
      * @param registeredLookupDimensionConfig Configuration holder for this dimension
      */
     public RegisteredLookupDimension(@NotNull RegisteredLookupDimensionConfig registeredLookupDimensionConfig) {
         super(registeredLookupDimensionConfig);
-        this.lookups = Collections.unmodifiableList(registeredLookupDimensionConfig.getLookups());
+        this.registeredLookupExtractionFns = Collections.unmodifiableList(
+                registeredLookupDimensionConfig.getRegisteredLookupExtractionFns()
+        );
     }
 
-    public List<String> getLookups() {
-        return lookups;
+    @Override
+    @JsonIgnore
+    public Optional<ExtractionFunction> getExtractionFunction() {
+        List<ExtractionFunction> extractionFunctions = getRegisteredLookupExtractionFns();
+        return Optional.ofNullable(
+                extractionFunctions.size() > 1 ?
+                        new CascadeExtractionFunction(extractionFunctions) :
+                        extractionFunctions.size() == 1 ? extractionFunctions.get(0) : null
+        );
+    }
+
+    /**
+     * Returns an immutable list of registered lookup extraction functions used by this dimension.
+     *
+     * @return the immutable list of registered lookup extraction functions used by this dimension
+     */
+    public List<ExtractionFunction> getRegisteredLookupExtractionFns() {
+        return registeredLookupExtractionFns;
     }
 
     @Override
@@ -54,46 +71,31 @@ public class RegisteredLookupDimension extends KeyValueStoreDimension implements
         RegisteredLookupDimension that = (RegisteredLookupDimension) o;
 
         return
-            super.equals(that) &&
-            Objects.equals(lookups, that.lookups);
+                super.equals(that) &&
+                        Objects.equals(getExtractionFunction(), that.getExtractionFunction());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), lookups);
-    }
-
-    @Override
-    public String toString() {
-        return super.getApiName() + ":" +
-               super.getCategory() + ":" +
-                lookups;
+        return Objects.hash(super.hashCode(), getExtractionFunction());
     }
 
     /**
-     * Build an extraction function model object.
+     * Returns a string representation of this dimension.
+     * <p>
+     * The format of the string is "RegisteredLookupDimension{apiName=XXX, registeredLookupExtractionFns=YYY", where
+     * XXX is the Webservice API name of this dimension, and YYY the list of registered lookup extraction functions of
+     * this dimension. Note that there is a single space separating the two values after each comma. The API name is
+     * surrounded by a pair of single quotes.
      *
-     * @return  Take the internal namespaces and construct a model object for the extraction functions.
+     * @return the string representation of this dimension
      */
     @Override
-    @JsonIgnore
-    public Optional<ExtractionFunction> getExtractionFunction() {
-
-        List<ExtractionFunction> extractionFunctions = getLookups().stream()
-                .map(
-                        lookup -> new RegisteredLookupExtractionFunction(
-                                lookup,
-                                false,
-                                "Unknown " + lookup,
-                                false,
-                                true
-                        )
-                ).collect(Collectors.toList());
-
-        return Optional.ofNullable(
-                extractionFunctions.size() > 1 ?
-                        new CascadeExtractionFunction(extractionFunctions) :
-                        extractionFunctions.size() == 1 ? extractionFunctions.get(0) : null
+    public String toString() {
+        return String.format(
+                "RegisteredLookupDimension{apiName='%s', registeredLookupExtractionFns=%s}",
+                getApiName(),
+                getRegisteredLookupExtractionFns()
         );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/RegisteredLookupDimension.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/RegisteredLookupDimension.java
@@ -70,9 +70,7 @@ public class RegisteredLookupDimension extends KeyValueStoreDimension implements
 
         RegisteredLookupDimension that = (RegisteredLookupDimension) o;
 
-        return
-                super.equals(that) &&
-                        Objects.equals(getExtractionFunction(), that.getExtractionFunction());
+        return super.equals(that) && Objects.equals(getExtractionFunction(), that.getExtractionFunction());
     }
 
     @Override
@@ -83,7 +81,7 @@ public class RegisteredLookupDimension extends KeyValueStoreDimension implements
     /**
      * Returns a string representation of this dimension.
      * <p>
-     * The format of the string is "RegisteredLookupDimension{apiName=XXX, registeredLookupExtractionFns=YYY", where
+     * The format of the string is "RegisteredLookupDimension{apiName=XXX, registeredLookupExtractionFns=YYY}", where
      * XXX is the Webservice API name of this dimension, and YYY the list of registered lookup extraction functions of
      * this dimension. Note that there is a single space separating the two values after each comma. The API name is
      * surrounded by a pair of single quotes.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/dimension/extractionfunction/RegisteredLookupExtractionFunction.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/dimension/extractionfunction/RegisteredLookupExtractionFunction.java
@@ -8,6 +8,7 @@ import java.util.Objects;
  * RegisteredLookup ExtractionFunction that maps dimension values to some corresponding pre-defined values in druid.
  */
 public class RegisteredLookupExtractionFunction extends ExtractionFunction {
+
     private final String lookup;
     private final Boolean retainMissingValue;
     private final String replaceMissingValueWith;
@@ -15,16 +16,19 @@ public class RegisteredLookupExtractionFunction extends ExtractionFunction {
     private final Boolean optimize;
 
     /**
-     * Constructor.
+     * Constructs a new {@code RegisteredLookupExtractionFunction} with the specified function attributes.
      *
-     * @param lookup  lookup's name specified by the user
-     * @param retainMissingValue  when true: returns original dimension value if mapping is not found, also note that
-     * replaceMissingValueWith must be null or empty string, when false: missing values are treated as missing
-     * @param replaceMissingValueWith  replaces dimension values not found in mapping with this value and
-     * retainMissingValue must be false if this value is not null or is not empty string
-     * @param injective  set to true to apply some optimization given that mapping is one-to-one,
-     * may cause undefined behavior if retainMissingValue is false and injective is true
-     * @param optimize  set to false to turn off rewriting extraction filter as selector filters
+     * @param lookup  Name of the lookup
+     * @param retainMissingValue  A flag indicating whether or not the original dimension value is returned if lookup
+     * mapping is not found for a dimension value. It is illegal to set retainMissingValue = true and also specify a
+     * replaceMissingValueWith
+     * @param replaceMissingValueWith  The default lookup value if lookup mapping is not found for a dimension value.
+     * Setting this to "" has the same effect as setting it to null or omitting the property. It is illegal to set
+     * retainMissingValue = true and also specify a replaceMissingValueWith
+     * @param injective  A flag indicating whether or not to apply some optimization for aggregation query involving
+     * lookups given that mapping is one-to-one, may cause undefined behavior if retainMissingValue is false and
+     * injective is true
+     * @param optimize  A flag indicating whether or not to allow optimization of lookup based extraction filter
      */
     public RegisteredLookupExtractionFunction(
             String lookup,
@@ -42,31 +46,65 @@ public class RegisteredLookupExtractionFunction extends ExtractionFunction {
     }
 
     /**
-     * Convenience Constructor,
-     * defaults: retainMissingValue=false, replaceMissingValueWith=null, injective=false, optimize=true.
+     * Constructs a new {@code RegisteredLookupExtractionFunction} with the specified lookup name.
+     * <p>
+     * This constructor initializes the following dimension specs to their default values
+     * <ul>
+     *     <li> retainMissingValue=false
+     *     <li> replaceMissingValueWith="Unknown {@code <lookup>}"
+     *     <li> injective=false
+     *     <li> optimize=true
+     * </ul>
      *
      * @param lookup  lookup property specified by the user
      */
     public RegisteredLookupExtractionFunction(String lookup) {
-        this(lookup, false, null, false, true);
+        this(lookup, false, String.format("Unknown %s", lookup), false, true);
     }
 
+    /**
+     * Returns the name of this lookup.
+     *
+     * @return the name of this lookup
+     */
     public String getLookup() {
         return lookup;
     }
 
+    /**
+     * Returns the flag indicating whether or not the original dimension value is returned if lookup mapping is not
+     * found for a dimension value.
+     *
+     * @return the flag indicating whether or not the original dimension value is returned if lookup mapping is not
+     * found for a dimension value
+     */
     public Boolean getRetainMissingValue() {
         return retainMissingValue;
     }
 
+    /**
+     * Returns the default lookup value if lookup mapping is not found for a dimension value.
+     *
+     * @return the default lookup value if lookup mapping is not found for a dimension value
+     */
     public String getReplaceMissingValueWith() {
         return replaceMissingValueWith;
     }
 
+    /**
+     * Returns the flag indicating whether or not to apply some optimization for aggregation query involving lookups.
+     *
+     * @return the flag indicating whether or not to apply some optimization for aggregation query involving lookups
+     */
     public Boolean getInjective() {
         return injective;
     }
 
+    /**
+     * Returns the flag indicating whether or not to allow optimization of lookup based extraction filter.
+     *
+     * @return the flag indicating whether or not to allow optimization of lookup based extraction filter
+     */
     public Boolean getOptimize() {
         return optimize;
     }
@@ -117,5 +155,30 @@ public class RegisteredLookupExtractionFunction extends ExtractionFunction {
                 Objects.equals(replaceMissingValueWith, other.replaceMissingValueWith) &&
                 Objects.equals(injective, other.injective) &&
                 Objects.equals(optimize, other.optimize);
+    }
+
+    /**
+     * Returns a string representation of this extraction function.
+     * <p>
+     * The format of the string is "RegisteredLookupExtractionFunction{type=A, lookup='B', retainMissingValue=C,
+     * replaceMissingValueWith='D', injective=E, optimize=F}", where values (A - E) are given by {@link #getType()},
+     * {@link #getLookup()}, {@link #getRetainMissingValue()}, {@link #getReplaceMissingValueWith()},
+     * {@link #getInjective()}, {@link #getOptimize()}, respectively. Note that there is a single space separating each
+     * value after a comma. The lookup name and the default lookup value are surrounded by pairs of single quotes.
+     *
+     * @return the string representation of this extraction function
+     */
+    @Override
+    public String toString() {
+        return String.format(
+                "RegisteredLookupExtractionFunction{type=%s, lookup='%s', retainMissingValue=%s, " +
+                        "replaceMissingValueWith='%s', injective=%s, optimize=%s}",
+                getType(),
+                getLookup(),
+                getRetainMissingValue(),
+                getReplaceMissingValueWith(),
+                getInjective(),
+                getOptimize()
+        );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/RegisteredLookupMetadataLoadTask.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/RegisteredLookupMetadataLoadTask.java
@@ -11,6 +11,7 @@ import com.yahoo.bard.webservice.druid.client.DruidWebService;
 import com.yahoo.bard.webservice.druid.client.FailureCallback;
 import com.yahoo.bard.webservice.druid.client.HttpErrorCallback;
 import com.yahoo.bard.webservice.druid.client.SuccessCallback;
+import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.RegisteredLookupExtractionFunction;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -165,8 +166,11 @@ public class RegisteredLookupMetadataLoadTask extends LoadTask<Boolean> {
                     dimensionDictionary.findAll().stream()
                             .filter(dimension -> dimension instanceof RegisteredLookupDimension)
                             .map(dimension -> (RegisteredLookupDimension) dimension)
-                            .map(RegisteredLookupDimension::getLookups)
+                            .map(RegisteredLookupDimension::getRegisteredLookupExtractionFns)
                             .flatMap(List::stream)
+                            .map(extractionFunction ->
+                                    ((RegisteredLookupExtractionFunction) extractionFunction).getLookup()
+                            )
                             .peek(namespace -> LOG.trace("Checking lookup metadata status for {}", namespace))
                             .filter(lookup -> !lookupStatuses.containsKey(lookup) || !lookupStatuses.get(lookup))
                             .collect(Collectors.toSet())

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/RegisteredLookupMetadataLoadTaskSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/metadata/RegisteredLookupMetadataLoadTaskSpec.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.metadata
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.data.dimension.impl.RegisteredLookupDimension
 import com.yahoo.bard.webservice.druid.client.DruidWebService
+import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.RegisteredLookupExtractionFunction
 import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
 
 import spock.lang.Specification
@@ -34,7 +35,10 @@ class RegisteredLookupMetadataLoadTaskSpec extends Specification {
         }
 
         and: "Given a load task that looks at lookups existing in Druid"
-        dimension.getLookups() >> ["loadedLookup", "pendingLookup"]
+        dimension.getRegisteredLookupExtractionFns() >> [
+                new RegisteredLookupExtractionFunction("loadedLookup"),
+                new RegisteredLookupExtractionFunction("pendingLookup")
+        ]
 
         RegisteredLookupMetadataLoadTask lookupLoadTask = new RegisteredLookupMetadataLoadTask(
                 druidClient,
@@ -64,7 +68,10 @@ class RegisteredLookupMetadataLoadTaskSpec extends Specification {
         }
 
         and: "Given a load task that looks at lookups existing in Druid"
-        dimension.getLookups() >> ["loadedLookup", "pendingLookup"]
+        dimension.getRegisteredLookupExtractionFns() >> [
+                new RegisteredLookupExtractionFunction("loadedLookup"),
+                new RegisteredLookupExtractionFunction("pendingLookup")
+        ]
 
         RegisteredLookupMetadataLoadTask lookupLoadTask = new RegisteredLookupMetadataLoadTask(
                 druidClient,
@@ -131,7 +138,9 @@ class RegisteredLookupMetadataLoadTaskSpec extends Specification {
         }
 
         and: "Load task is asking for a lookup that's not configured in Druid"
-        dimension.getLookups() >> ["LookupNotInDruid"]
+        dimension.getRegisteredLookupExtractionFns() >> [
+                new RegisteredLookupExtractionFunction("LookupNotInDruid")
+        ]
         RegisteredLookupMetadataLoadTask lookupLoadTask = new RegisteredLookupMetadataLoadTask(
                 druidClient,
                 new DimensionDictionary([dimension] as Set)

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/dimension/TestRegisteredLookupDimensionConfig.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/dimension/TestRegisteredLookupDimensionConfig.java
@@ -6,7 +6,9 @@ import com.yahoo.bard.webservice.data.config.names.TestApiDimensionName;
 import com.yahoo.bard.webservice.data.dimension.DimensionField;
 import com.yahoo.bard.webservice.data.dimension.KeyValueStore;
 import com.yahoo.bard.webservice.data.dimension.SearchProvider;
+import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.ExtractionFunction;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -18,15 +20,19 @@ import javax.validation.constraints.NotNull;
  */
 public class TestRegisteredLookupDimensionConfig extends TestDimensionConfig
         implements RegisteredLookupDimensionConfig {
-    private List<String> lookups;
+
+    private final List<ExtractionFunction> registeredLookupExtractionFns;
 
     /**
      * Constructor.
      *
      * @param dimensionConfig Configuration properties for dimensions
-     * @param lookups List of lookups used for Lookup
+     * @param registeredLookupExtractionFns  A list of registered lookup extraction functions used to perform lookups.
      */
-    public TestRegisteredLookupDimensionConfig(@NotNull DimensionConfig dimensionConfig, List<String> lookups) {
+    public TestRegisteredLookupDimensionConfig(
+            @NotNull DimensionConfig dimensionConfig,
+            List<ExtractionFunction> registeredLookupExtractionFns
+    ) {
         this(
                 TestApiDimensionName.valueOf(dimensionConfig.getApiName().toUpperCase(Locale.ENGLISH)),
                 dimensionConfig.getPhysicalName(),
@@ -34,7 +40,7 @@ public class TestRegisteredLookupDimensionConfig extends TestDimensionConfig
                 dimensionConfig.getSearchProvider(),
                 dimensionConfig.getFields(),
                 dimensionConfig.getDefaultDimensionFields(),
-                lookups
+                registeredLookupExtractionFns
         );
     }
 
@@ -47,7 +53,7 @@ public class TestRegisteredLookupDimensionConfig extends TestDimensionConfig
      * @param searchProvider  SearchProvider for the dimension
      * @param fields  Fields of the dimension
      * @param defaultFields  Default fields of the dimension
-     * @param lookups List of lookups
+     * @param registeredLookupExtractionFns  A list of registered lookup extraction functions used to perform lookups.
      */
     public TestRegisteredLookupDimensionConfig(
             TestApiDimensionName apiName,
@@ -56,62 +62,108 @@ public class TestRegisteredLookupDimensionConfig extends TestDimensionConfig
             SearchProvider searchProvider,
             LinkedHashSet<DimensionField> fields,
             LinkedHashSet<DimensionField> defaultFields,
-            List<String> lookups
+            List<ExtractionFunction> registeredLookupExtractionFns
     ) {
         super(apiName, physicalName, keyValueStore, searchProvider, fields, defaultFields);
-        this.lookups = lookups;
+        this.registeredLookupExtractionFns = Collections.unmodifiableList(registeredLookupExtractionFns);
     }
 
     @Override
-    public List<String> getLookups() {
-        return this.lookups;
+    public List<ExtractionFunction> getRegisteredLookupExtractionFns() {
+        return this.registeredLookupExtractionFns;
     }
 
     //CHECKSTYLE:OFF
     @Override
     public TestRegisteredLookupDimensionConfig withApiName(TestApiDimensionName apiName) {
-        return new TestRegisteredLookupDimensionConfig(apiName, getPhysicalName(), getKeyValueStore(), getSearchProvider(), getFields(), getDefaultDimensionFields(),
-                lookups
+        return new TestRegisteredLookupDimensionConfig(
+                apiName,
+                getPhysicalName(),
+                getKeyValueStore(),
+                getSearchProvider(),
+                getFields(),
+                getDefaultDimensionFields(),
+                getRegisteredLookupExtractionFns()
         );
     }
 
     @Override
     public TestRegisteredLookupDimensionConfig withPhysicalName(String physicalName) {
-        return new TestRegisteredLookupDimensionConfig(getApiNameEnum(), physicalName, getKeyValueStore(), getSearchProvider(), getFields(), getDefaultDimensionFields(),
-                lookups
+        return new TestRegisteredLookupDimensionConfig(
+                getApiNameEnum(),
+                physicalName,
+                getKeyValueStore(),
+                getSearchProvider(),
+                getFields(),
+                getDefaultDimensionFields(),
+                getRegisteredLookupExtractionFns()
         );
     }
 
     @Override
     public TestRegisteredLookupDimensionConfig withKeyValueStore(KeyValueStore keyValueStore) {
-        return new TestRegisteredLookupDimensionConfig(getApiNameEnum(), getPhysicalName(), keyValueStore, getSearchProvider(), getFields(), getDefaultDimensionFields(),
-                lookups
+        return new TestRegisteredLookupDimensionConfig(
+                getApiNameEnum(),
+                getPhysicalName(),
+                keyValueStore,
+                getSearchProvider(),
+                getFields(),
+                getDefaultDimensionFields(),
+                getRegisteredLookupExtractionFns()
         );
     }
 
     @Override
     public TestRegisteredLookupDimensionConfig withSearchProvider(SearchProvider searchProvider) {
-        return new TestRegisteredLookupDimensionConfig(getApiNameEnum(), getPhysicalName(), getKeyValueStore(), searchProvider, getFields(), getDefaultDimensionFields(),
-                lookups
+        return new TestRegisteredLookupDimensionConfig(
+                getApiNameEnum(),
+                getPhysicalName(),
+                getKeyValueStore(),
+                searchProvider,
+                getFields(),
+                getDefaultDimensionFields(),
+                getRegisteredLookupExtractionFns()
         );
     }
 
     @Override
     public TestRegisteredLookupDimensionConfig withFields(LinkedHashSet<DimensionField> fields) {
-        return new TestRegisteredLookupDimensionConfig(getApiNameEnum(), getPhysicalName(), getKeyValueStore(), getSearchProvider(), fields, getDefaultDimensionFields(),
-                lookups
+        return new TestRegisteredLookupDimensionConfig(
+                getApiNameEnum(),
+                getPhysicalName(),
+                getKeyValueStore(),
+                getSearchProvider(),
+                fields,
+                getDefaultDimensionFields(),
+                getRegisteredLookupExtractionFns()
         );
     }
 
     @Override
     public TestRegisteredLookupDimensionConfig withDefaultFields(LinkedHashSet<DimensionField> defaultFields) {
-        return new TestRegisteredLookupDimensionConfig(getApiNameEnum(), getPhysicalName(), getKeyValueStore(), getSearchProvider(), getFields(), defaultFields,
-                lookups
+        return new TestRegisteredLookupDimensionConfig(
+                getApiNameEnum(),
+                getPhysicalName(),
+                getKeyValueStore(),
+                getSearchProvider(),
+                getFields(),
+                defaultFields,
+                getRegisteredLookupExtractionFns()
         );
     }
 
-    public TestRegisteredLookupDimensionConfig withNamespaces(List<String> namespaces) {
-        return new TestRegisteredLookupDimensionConfig(getApiNameEnum(), getPhysicalName(), getKeyValueStore(), getSearchProvider(), getFields(), getDefaultDimensionFields(), namespaces);
+    public TestRegisteredLookupDimensionConfig withRegisteredLookupExtractionFns(
+            List<ExtractionFunction> registeredLookupExtractionFns
+    ) {
+        return new TestRegisteredLookupDimensionConfig(
+                getApiNameEnum(),
+                getPhysicalName(),
+                getKeyValueStore(),
+                getSearchProvider(),
+                getFields(),
+                getDefaultDimensionFields(),
+                registeredLookupExtractionFns
+        );
     }
     //CHECKSTYLE:ON
 }

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/dimension/TestRegisteredLookupDimensions.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/config/dimension/TestRegisteredLookupDimensions.java
@@ -3,6 +3,8 @@
 package com.yahoo.bard.webservice.data.config.dimension;
 
 import com.yahoo.bard.webservice.data.config.names.TestApiDimensionName;
+import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.ExtractionFunction;
+import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.RegisteredLookupExtractionFunction;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,12 +43,16 @@ public class TestRegisteredLookupDimensions extends TestDimensions {
      *
      * @return list of lookups for the look up
      */
-    private List<String> dimensionLookups(String dimensionName) {
+    private List<ExtractionFunction> dimensionLookups(String dimensionName) {
         switch (dimensionName) {
             case "BREED":
-                return Arrays.asList("BREED__SPECIES", "BREED__OTHER", "BREED__COLOR");
+                return Arrays.asList(
+                        new RegisteredLookupExtractionFunction("BREED__SPECIES"),
+                        new RegisteredLookupExtractionFunction("BREED__OTHER"),
+                        new RegisteredLookupExtractionFunction("BREED__COLOR")
+                );
             case "SPECIES":
-                return Arrays.asList("SPECIES__BREED");
+                return Collections.singletonList(new RegisteredLookupExtractionFunction("SPECIES__BREED"));
             default:
                 return Collections.emptyList();
         }


### PR DESCRIPTION
Addresses issue https://github.com/yahoo/fili/issues/723

Problem
======

We have a business requirement to return different default value for different registered lookup. To be more specific, here is an example of serialized registered lookup extraction function

```json
{
    "type" : "registeredLookup",
    "lookup" : "<lookup name>",
    "retainMissingValue" : false,
    "replaceMissingValueWith" : "<default lookup value>",
    "injective" : false,
    "optimize" : true
}
```

API supports lookups with user-defined lookup name as in `"lookup" : "<lookup name>"`. It is, however, not possible for downstream projects to specify the rest of attributes. We need a different default lookup value as in ` "replaceMissingValueWith" : "<default lookup value>"` for each lookup extraction function.

Solution
======

The cause of this issue is in `DefaultRegisteredLookupDimensionConfig`, we only pass in a list of lookup names. If, instead, we pass in a list of `RegisteredLookupExtractionFunction`, the downstream projects could freely define all of the attributes for a registered lookup extraction function and then configure them in. 

This PR essentially changes `List<String> lookups` to `List<ExtractionFunction> registeredLookupExtractionFns` in `DefaultRegisteredLookupDimensionConfig`.

@michael-mclawhorn This might have impact on https://github.com/yahoo/fili/pull/719