### PR TITLE
Add support for "case_sensitive" attribute in FragmentSearchQuerySpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ pull request if there was one.
 
 ### Added:
 
+- [Add support for "case_sensitive" attribute in FragmentSearchQuerySpec](https://github.com/yahoo/fili/pull/727)
+    * Enable `FragmentSearchQuerySpec` to accept an argument for `case_sensitive` so that API users can configure this
+      attribute for JSON serialization through Fili.
+
 - [Add storageStrategy as a field of the DimensionConfig class](https://github.com/yahoo/fili/issues/718)
     * Adds getStorageStrategy as a field of the dimensionConfig class.
     * Passes the storage strategy to the KeyValueStoreDimension Constructor

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/FragmentSearchQuerySpec.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/FragmentSearchQuerySpec.java
@@ -3,6 +3,8 @@
 package com.yahoo.bard.webservice.druid.model.query;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -12,21 +14,76 @@ import java.util.List;
 /**
  * Class for specifying the FragmentSearchQuerySpec for DruidSearchQuery.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "type", "case_sensitive", "values" })
 public class FragmentSearchQuerySpec extends SearchQuerySpec {
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+
+    private final Boolean caseSensitive;
     private final List<String> values;
 
     /**
-     * Constructor.
+     * Constructs a new {@code FragmentSearchQuerySpec} with the specified fragments to search for.
+     * <p>
+     * This constructor initializes "case_sensitive" attribute to {@code null} and the attribute will not be included in
+     * JSON serialization. The fragments can be {@code null}.
      *
-     * @param values  Fragments to search for
+     * @param values fragments to search for
      */
     public FragmentSearchQuerySpec(Collection<String> values) {
-        super(DefaultSearchQueryType.FRAGMENT);
-        this.values = Collections.unmodifiableList(new ArrayList<>(values));
+        this(null, values);
     }
 
+    /**
+     * Constructs a new {@code FragmentSearchQuerySpec} with the specified flag on case-sensitive search and fragments
+     * to search for.
+     * <p>
+     * Both flag and fragments can be {@code null}.
+     *
+     * @param caseSensitive a flag indicating whether or not the search should be case sensitive
+     * @param values fragments to search for
+     */
+    public FragmentSearchQuerySpec(final Boolean caseSensitive, Collection<String> values) {
+        super(DefaultSearchQueryType.FRAGMENT);
+        this.caseSensitive = caseSensitive;
+        this.values = values == null ? null : Collections.unmodifiableList(new ArrayList<>(values));
+    }
+
+    /**
+     * Returns true if the search is case sensitive.
+     *
+     * @return the flag indicating whether or not the search should be case sensitive
+     */
+    @JsonProperty(value = "case_sensitive")
+    public Boolean isCaseSensitive() {
+        return caseSensitive;
+    }
+
+    /**
+     * Returns the fragments to search for in the search query spec.
+     *
+     * @return the searched fragments
+     */
     public List<String> getValues() {
         return values;
+    }
+
+    /**
+     * Returns the string representation of this search query spec.
+     * <p>
+     * <b>The string is NOT the JSON representation used for Druid query.</b> The format of the string is
+     * "FragmentSearchQuerySpec{type=XXX, case_sensitive=YYY, values=ZZZ}", where XXX is given by {@link #getType()},
+     * YYY by {@link #isCaseSensitive()}, and ZZZ by {@link #getValues()}. Note that each value is
+     * separated by a comma followed by a single space. Values are not quoted.
+     *
+     * @return the string representation of this search query spec
+     */
+    @Override
+    public String toString() {
+        return String.format(
+                "FragmentSearchQuerySpec{type=%s, case_sensitive=%s, values=%s}",
+                getType(),
+                isCaseSensitive(),
+                getValues()
+        );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/InsensitiveContainsSearchQuerySpec.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/InsensitiveContainsSearchQuerySpec.java
@@ -14,7 +14,7 @@ public class InsensitiveContainsSearchQuerySpec extends SearchQuerySpec {
     /**
      * Constructor.
      *
-     * @param value  Values to search for case-insensitively
+     * @param value  Value to search for case-insensitively
      */
     public InsensitiveContainsSearchQuerySpec(String value) {
         super(DefaultSearchQueryType.INSENSITIVE_CONTAINS);

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/FragmentSearchQuerySpecSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/FragmentSearchQuerySpecSpec.groovy
@@ -1,0 +1,30 @@
+// Copyright 2018 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.druid.model.query
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class FragmentSearchQuerySpecSpec extends Specification {
+
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+
+    @Unroll
+    def "#caseSensitive spec on '#values' values serializes to '#expectedJson'"() {
+        expect:
+        OBJECT_MAPPER.writeValueAsString(new FragmentSearchQuerySpec(isCaseSensitive, values)) == expectedJson
+
+        where:
+        isCaseSensitive | values                     || expectedJson
+        true            | ["fragment1", "fragment2"] || '{"type":"fragment","case_sensitive":true,"values":["fragment1","fragment2"]}'
+        false           | ["fragment1", "fragment2"] || '{"type":"fragment","case_sensitive":false,"values":["fragment1","fragment2"]}'
+        true            | null                       || '{"type":"fragment","case_sensitive":true}'
+        false           | null                       || '{"type":"fragment","case_sensitive":false}'
+        null            | ["fragment1", "fragment2"] || '{"type":"fragment","values":["fragment1","fragment2"]}'
+        null            | null                       || '{"type":"fragment"}'
+
+        caseSensitive = isCaseSensitive == null ? "Default" : (isCaseSensitive ? "Case sensitive" : "Case insensitive")
+    }
+}


### PR DESCRIPTION
[`FragmentSearchQuerySpec` has an attributed called `case_sensitive`](http://druid.io/docs/latest/querying/searchqueryspec.html#fragmentsearchqueryspec) that has not been configurable in Druid yet. This PR adds it so that API users can configure it through Fili.

In addition, there is not test spec specifically for `FragmentSearchQuerySpec`. This PR adds the tests for it as well.