### PR TITLE
Implement ContainsSearchQuerySpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ pull request if there was one.
 
 ### Added:
 
+- [Implement ContainsSearchQuerySpec](https://github.com/yahoo/fili/pull/730)
+    * Adds serialization for `ContainsSearchQuerySpec` so that Fili API users can use that through Fili.
+
 - [Add storageStrategy as a field of the DimensionConfig class](https://github.com/yahoo/fili/issues/718)
     * Adds getStorageStrategy as a field of the dimensionConfig class.
     * Passes the storage strategy to the KeyValueStoreDimension Constructor

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/ContainsSearchQuerySpec.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/ContainsSearchQuerySpec.java
@@ -1,0 +1,72 @@
+// Copyright 2018 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.druid.model.query;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Class for specifying the ContainsSearchQuerySpec.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "type", "case_sensitive", "value" })
+public class ContainsSearchQuerySpec extends SearchQuerySpec {
+
+    private final Boolean caseSensitive;
+    private final String value;
+
+    /**
+     * Constructs a new {@code ContainsSearchQuerySpec} with the specified flag on case-sensitive search and value to
+     * search for.
+     * <p>
+     * Both flag and value can be {@code null}.
+     *
+     * @param caseSensitive a flag indicating whether or not the search should be case sensitive
+     * @param value value to search for
+     */
+    public ContainsSearchQuerySpec(final Boolean caseSensitive, final String value) {
+        super(DefaultSearchQueryType.CONTAINS);
+        this.caseSensitive = caseSensitive;
+        this.value = value;
+    }
+
+    /**
+     * Returns true if the search is case sensitive.
+     *
+     * @return the flag indicating whether or not the search should be case sensitive
+     */
+    @JsonProperty(value = "case_sensitive")
+    public Boolean isCaseSensitive() {
+        return caseSensitive;
+    }
+
+    /**
+     * Returns the value to search for in this search query spec.
+     *
+     * @return the searched value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the string representation of this search query spec.
+     * <p>
+     * <b>The string is NOT the JSON representation used for Druid query.</b> The format of the string is
+     * "ContainsSearchQuerySpec{type=XXX, case_sensitive=YYY, value='ZZZ'}", where XXX is given by {@link #getType()},
+     * YYY by {@link #isCaseSensitive()}, and ZZZ by {@link #getValue()} which is also surrounded by a pair of single
+     * quotes. Note that each value is separated by a comma followed by a single space.
+     *
+     * @return the string representation of this search query spec
+     */
+    @Override
+    public String toString() {
+        return String.format(
+                "ContainsSearchQuerySpec{type=%s, case_sensitive=%s, value='%s'}",
+                getType(),
+                isCaseSensitive(),
+                getValue()
+        );
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/DefaultSearchQueryType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/DefaultSearchQueryType.java
@@ -10,6 +10,7 @@ import java.util.Locale;
  * Enum for specifying the type of SearchQuerySpec.
  */
 public enum DefaultSearchQueryType implements SearchQueryType {
+    CONTAINS,
     FRAGMENT,
     INSENSITIVE_CONTAINS,
     REGEX;

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/ContainsSearchQuerySpecSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/ContainsSearchQuerySpecSpec.groovy
@@ -1,0 +1,31 @@
+// Copyright 2018 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.druid.model.query
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ContainsSearchQuerySpecSpec extends Specification {
+
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+
+    @Unroll
+    def "#caseSensitive spec on '#values' values serializes to '#expectedJson'"() {
+        expect:
+        OBJECT_MAPPER.writeValueAsString(new ContainsSearchQuerySpec(isCaseSensitive, value)) == expectedJson
+
+        where:
+        isCaseSensitive | value        || expectedJson
+        true            | "some_value" || '{"type":"contains","case_sensitive":true,"value":"some_value"}'
+        false           | "some_value" || '{"type":"contains","case_sensitive":false,"value":"some_value"}'
+        true            | null         || '{"type":"contains","case_sensitive":true}'
+        false           | null         || '{"type":"contains","case_sensitive":false}'
+        null            | "some_value" || '{"type":"contains","value":"some_value"}'
+        null            | null         || '{"type":"contains"}'
+
+        caseSensitive = isCaseSensitive == null ? "Default" : (isCaseSensitive ? "Case sensitive" : "Case insensitive")
+    }
+
+}


### PR DESCRIPTION
Druid allows 4 `SearchQuerySpec`'s:

* `InsensitiveContainsSearchQuerySpec`
* `FragmentSearchQuerySpec`
* `ContainsSearchQuerySpec`
* `RegexSearchQuerySpec`

Serialization for all of the above are supported in Fili except for `ContainsSearchQuerySpec` at this moment. This PR adds serialization for `ContainsSearchQuerySpec` so that API users can use that through Fili