### PR TITLE
【Pending】Implement "Left-Union" & "Pure Left-Union" Availabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ pull request if there was one.
       intervals on this availability is determined by a single participating `Availability`, instead of all
       participating `Availabilities` as in `MetricUnionAvailability`. 
     * Added a builder method to `MetricUnionAvailability` and `MetricLeftUnionAvailability` to save on needing to 
-    add additional table classes.
+      add additional table classes.
+    
+- [Implement "pure left-union" Availability](https://github.com/yahoo/fili/pull/736)
+    * A new "pure left-union" `Availability` called **`MetricPureLeftUnionAvailability`** is implemented. For the
+      details of this Availability, please refer to the class description/Javadoc of it
 
 - [Added builder method for MetricUnionAvailability and MetricLeftUnionAvailabi](https://github.com/yahoo/fili/pull/736)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ pull request if there was one.
 
 - [Added builder method for MetricUnionAvailability and MetricLeftUnionAvailabi](https://github.com/yahoo/fili/pull/736)
 
-
 - [Add specs for InsensitiveContainsSearchQuerySpec & RegexSearchQuerySpec](https://github.com/yahoo/fili/pull/732)
     * `RegexSearchQuerySpec` and `InsensitiveContainsSearchQuerySpec` have no dedicated test specs. This PR adds tests
       for them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ pull request if there was one.
 
 ### Added:
 
+- [Implement "left-union" for MetricUnionCompositeTable](https://github.com/yahoo/fili/pull/736)
+    * A new "left-union" `Availability` called **`MetricLeftUnionAvailability`** is implemented.
+      `MetricLeftUnionAvailability` behaves the same as `MetricUnionAvailability` except that the coalesced available
+      intervals on this availability is determined by a single participating `Availability`, instead of all
+      participating `Availabilities` as in `MetricUnionAvailability`. 
+    * `MetricUnionCompositeTable` now have options(2 constructors) of being backed by either `MetricUnionAvailability`
+      or `MetricLeftUnionAvailability`
+
 - [Add specs for InsensitiveContainsSearchQuerySpec & RegexSearchQuerySpec](https://github.com/yahoo/fili/pull/732)
     * `RegexSearchQuerySpec` and `InsensitiveContainsSearchQuerySpec` have no dedicated test specs. This PR adds tests
       for them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ pull request if there was one.
 
 ### Added:
 
-- [Implement "left-union" for MetricUnionCompositeTable](https://github.com/yahoo/fili/pull/736)
+- [Implement "left-union" MetricUnionAvailability](https://github.com/yahoo/fili/pull/736)
     * A new "left-union" `Availability` called **`MetricLeftUnionAvailability`** is implemented.
       `MetricLeftUnionAvailability` behaves the same as `MetricUnionAvailability` except that the coalesced available
       intervals on this availability is determined by a single participating `Availability`, instead of all
       participating `Availabilities` as in `MetricUnionAvailability`. 
-    * `MetricUnionCompositeTable` now have options(2 constructors) of being backed by either `MetricUnionAvailability`
-      or `MetricLeftUnionAvailability`
+    * Added a builder method to `MetricUnionAvailability` and `MetricLeftUnionAvailability` to save on needing to 
+    add additional table classes.
+
+- [Added builder method for MetricUnionAvailability and MetricLeftUnionAvailabi](https://github.com/yahoo/fili/pull/736)
+
 
 - [Add specs for InsensitiveContainsSearchQuerySpec & RegexSearchQuerySpec](https://github.com/yahoo/fili/pull/732)
     * `RegexSearchQuerySpec` and `InsensitiveContainsSearchQuerySpec` have no dedicated test specs. This PR adds tests
@@ -57,6 +60,9 @@ pull request if there was one.
 
 ### Deprecated:
 
+- [Deprecated MetricUnionCompositeTable](https://github.com/yahoo/fili/pull/736)
+    * All it was doing was constructing `MetricUnionAvailability`
+    * Instead added a helper method to build `MetricUnionAvailability` directly.
 
 
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,18 @@ pull request if there was one.
 
 ### Added:
 
-- [Implement "left-union" MetricUnionAvailability](https://github.com/yahoo/fili/pull/736)
-    * A new "left-union" `Availability` called **`MetricLeftUnionAvailability`** is implemented.
-      `MetricLeftUnionAvailability` behaves the same as `MetricUnionAvailability` except that the coalesced available
-      intervals on this availability is determined by a single participating `Availability`, instead of all
-      participating `Availabilities` as in `MetricUnionAvailability`. 
+- [Implement `MetricPureLeftUnionAvailability`](https://github.com/yahoo/fili/pull/736)
+    * `MetricPureLeftUnionAvailability` requires participating `Availabilities` to have the same set of metric columns.
+       The coalesced available intervals on this availability is determined by a subset of participating
+       `Availabilities`, instead of all participating `Availabilities`.
+    * Added a builder method to `MetricPureLeftUnionAvailability` to save on needing to add additional table classes.
+
+- [Implement `MetricLeftUnionAvailability`](https://github.com/yahoo/fili/pull/736)
+    * `MetricLeftUnionAvailability` behaves the same as `MetricUnionAvailability` except that the coalesced available
+      intervals on this availability is determined by a subset of participating `Availabilities`, instead of all
+      participating `Availabilities`. 
     * Added a builder method to `MetricUnionAvailability` and `MetricLeftUnionAvailability` to save on needing to 
       add additional table classes.
-    
-- [Implement "pure left-union" Availability](https://github.com/yahoo/fili/pull/736)
-    * A new "pure left-union" `Availability` called **`MetricPureLeftUnionAvailability`** is implemented. For the
-      details of this Availability, please refer to the class description/Javadoc of it
-
-- [Added builder method for MetricUnionAvailability and MetricLeftUnionAvailabi](https://github.com/yahoo/fili/pull/736)
 
 - [Add specs for InsensitiveContainsSearchQuerySpec & RegexSearchQuerySpec](https://github.com/yahoo/fili/pull/732)
     * `RegexSearchQuerySpec` and `InsensitiveContainsSearchQuerySpec` have no dedicated test specs. This PR adds tests
@@ -60,6 +59,7 @@ pull request if there was one.
     * Some downstream projects generated partial intervals as `ArrayList`, which cannot be cased to
       `SimplifiedIntervalList` in places like `getVolatileIntervalsWithDefault`. The result is a casting exception which
       crashes downstream applications. Casting is replaced with a explicit `SimplifiedIntervalList` object creation.
+
 
 ### Deprecated:
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/DataSourceName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/DataSourceName.java
@@ -7,6 +7,7 @@ import java.util.Comparator;
 /**
  * Marker interface for objects that can be treated as a data source name in druid.
  */
+@FunctionalInterface
 public interface DataSourceName {
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/DataSourceName.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/names/DataSourceName.java
@@ -6,6 +6,8 @@ import java.util.Comparator;
 
 /**
  * Marker interface for objects that can be treated as a data source name in druid.
+ * <p>
+ * This is a {@link java.util.function functional interface} whose functional method is {@link #asName()}.
  */
 @FunctionalInterface
 public interface DataSourceName {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
@@ -109,11 +109,13 @@ public class MetricUnionCompositeTableDefinition extends PhysicalTableDefinition
                     tableMetricNamesMap.keySet(),
                     getLogicalToPhysicalNames(),
                     MetricUnionAvailability.build(
-                            tableMetricNamesMap.keySet(), tableMetricNamesMap.entrySet().stream()
+                            tableMetricNamesMap.keySet(),
+                            tableMetricNamesMap.entrySet().stream()
                                     .collect(Collectors.toMap(
                                             entry -> entry.getKey().getAvailability(),
                                             Map.Entry::getValue
-                                    )))
+                                    ))
+                    )
             );
         } catch (IllegalArgumentException e) {
             String message = String.format(VALIDATION_ERROR_FORMAT, e.getMessage());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
@@ -111,10 +111,12 @@ public class MetricUnionCompositeTableDefinition extends PhysicalTableDefinition
                     MetricUnionAvailability.build(
                             tableMetricNamesMap.keySet(),
                             tableMetricNamesMap.entrySet().stream()
-                                    .collect(Collectors.toMap(
-                                            entry -> entry.getKey().getAvailability(),
-                                            Map.Entry::getValue
-                                    ))
+                                    .collect(
+                                            Collectors.toMap(
+                                                    entry -> entry.getKey().getAvailability(),
+                                                    Map.Entry::getValue
+                                            )
+                                    )
                     )
             );
         } catch (IllegalArgumentException e) {
@@ -209,14 +211,17 @@ public class MetricUnionCompositeTableDefinition extends PhysicalTableDefinition
         // Construct a map of tables to the metrics for that table
         return tables.stream()
                 .collect(
-                        Collectors.collectingAndThen(Collectors.toMap(
-                                Function.identity(),
-                                (ConfigPhysicalTable physicalTable) ->
-                                        Sets.intersection(
-                                                physicalTable.getSchema().getMetricColumnNames(),
-                                                metricNames
-                                        )
-                        ), ImmutableMap::copyOf)
+                        Collectors.collectingAndThen(
+                                Collectors.toMap(
+                                        Function.identity(),
+                                        (ConfigPhysicalTable physicalTable) ->
+                                                Sets.intersection(
+                                                        physicalTable.getSchema().getMetricColumnNames(),
+                                                        metricNames
+                                                )
+                                ),
+                                ImmutableMap::copyOf
+                        )
                 );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
@@ -196,7 +196,7 @@ public class MetricUnionCompositeTableDefinition extends PhysicalTableDefinition
      *
      * @param dictionaries  The ResourceDictionaries from which the tables are to be retrieved
      *
-     * @return A map from <tt>Availability</tt> to set of <tt>MetricColumn</tt>
+     * @return A map from {@code Availability} to set of {@code MetricColumn}
      */
     public Map<ConfigPhysicalTable, Set<String>> getTableToMetricsMap(ResourceDictionaries dictionaries) {
         Set<Column> columns = buildColumns(dictionaries.getDimensionDictionary());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/BaseCompositePhysicalTable.java
@@ -19,7 +19,7 @@ import javax.validation.constraints.NotNull;
 /**
  * An implementation of BasePhysicalTable that contains multiple tables.
  */
-public abstract class BaseCompositePhysicalTable extends BasePhysicalTable {
+public class BaseCompositePhysicalTable extends BasePhysicalTable {
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseCompositePhysicalTable.class);
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
@@ -5,9 +5,9 @@ package com.yahoo.bard.webservice.table;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.table.availability.Availability;
-import com.yahoo.bard.webservice.table.availability.MetricLeftUnionAvailability;
 import com.yahoo.bard.webservice.table.availability.MetricUnionAvailability;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,7 +45,10 @@ import javax.validation.constraints.NotNull;
  * {@link MetricUnionAvailability}.
  *
  * @see MetricUnionAvailability
+ *
+ * @deprecated Build BaseCompositePhysicalTable with {@link MetricUnionAvailability#build(Collection, Map)}
  */
+@Deprecated
 public class MetricUnionCompositeTable extends BaseCompositePhysicalTable {
 
     /**
@@ -74,42 +77,6 @@ public class MetricUnionCompositeTable extends BaseCompositePhysicalTable {
                 physicalTables,
                 logicalToPhysicalColumnNames,
                 new MetricUnionAvailability(
-                        physicalTables.stream().map(ConfigPhysicalTable::getAvailability).collect(Collectors.toSet()),
-                        availabilitiesToMetricNames
-                )
-        );
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param name  Name that represents set of fact table names joined together
-     * @param timeGrain  The time grain of the table. The time grain has to satisfy all grains of the tables
-     * @param columns  The columns for this table
-     * @param physicalTables  A set of PhysicalTables that are put together under this table. The tables shall have
-     * zoned time grains that all satisfy the provided timeGrain
-     * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
-     * @param representativeAvailability  A single source availability that represents the coalesced data availability
-     * of this composite table.
-     * @param availabilitiesToMetricNames  A map of all availabilities to set of metric names
-     */
-    public MetricUnionCompositeTable(
-            @NotNull TableName name,
-            @NotNull ZonedTimeGrain timeGrain,
-            @NotNull Set<Column> columns,
-            @NotNull Set<ConfigPhysicalTable> physicalTables,
-            @NotNull Map<String, String> logicalToPhysicalColumnNames,
-            @NotNull Availability representativeAvailability,
-            @NotNull Map<Availability, Set<String>> availabilitiesToMetricNames
-    ) {
-        super(
-                name,
-                timeGrain,
-                columns,
-                physicalTables,
-                logicalToPhysicalColumnNames,
-                new MetricLeftUnionAvailability(
-                        representativeAvailability,
                         physicalTables.stream().map(ConfigPhysicalTable::getAvailability).collect(Collectors.toSet()),
                         availabilitiesToMetricNames
                 )

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/MetricUnionCompositeTable.java
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.table;
 import com.yahoo.bard.webservice.data.config.names.TableName;
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.table.availability.Availability;
+import com.yahoo.bard.webservice.table.availability.MetricLeftUnionAvailability;
 import com.yahoo.bard.webservice.table.availability.MetricUnionAvailability;
 
 import java.util.Map;
@@ -73,6 +74,42 @@ public class MetricUnionCompositeTable extends BaseCompositePhysicalTable {
                 physicalTables,
                 logicalToPhysicalColumnNames,
                 new MetricUnionAvailability(
+                        physicalTables.stream().map(ConfigPhysicalTable::getAvailability).collect(Collectors.toSet()),
+                        availabilitiesToMetricNames
+                )
+        );
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name  Name that represents set of fact table names joined together
+     * @param timeGrain  The time grain of the table. The time grain has to satisfy all grains of the tables
+     * @param columns  The columns for this table
+     * @param physicalTables  A set of PhysicalTables that are put together under this table. The tables shall have
+     * zoned time grains that all satisfy the provided timeGrain
+     * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
+     * @param representativeAvailability  A single source availability that represents the coalesced data availability
+     * of this composite table.
+     * @param availabilitiesToMetricNames  A map of all availabilities to set of metric names
+     */
+    public MetricUnionCompositeTable(
+            @NotNull TableName name,
+            @NotNull ZonedTimeGrain timeGrain,
+            @NotNull Set<Column> columns,
+            @NotNull Set<ConfigPhysicalTable> physicalTables,
+            @NotNull Map<String, String> logicalToPhysicalColumnNames,
+            @NotNull Availability representativeAvailability,
+            @NotNull Map<Availability, Set<String>> availabilitiesToMetricNames
+    ) {
+        super(
+                name,
+                timeGrain,
+                columns,
+                physicalTables,
+                logicalToPhysicalColumnNames,
+                new MetricLeftUnionAvailability(
+                        representativeAvailability,
                         physicalTables.stream().map(ConfigPhysicalTable::getAvailability).collect(Collectors.toSet()),
                         availabilitiesToMetricNames
                 )

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/Availability.java
@@ -63,7 +63,6 @@ public interface Availability {
     }
 
     /**
-     *
      * Fetch a {@link SimplifiedIntervalList} representing the coalesced available intervals on this availability as
      * filtered by the {@link PhysicalDataSourceConstraint}.
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/BaseCompositeAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/BaseCompositeAvailability.java
@@ -27,7 +27,9 @@ public abstract class BaseCompositeAvailability implements Availability {
     protected BaseCompositeAvailability(Stream<Availability> availabilityStream) {
         sourceAvailabilities = StreamUtils.toUnmodifiableSet(availabilityStream);
         dataSourcesNames = StreamUtils.toUnmodifiableSet(
-                sourceAvailabilities.stream().map(Availability::getDataSourceNames).flatMap(Set::stream)
+                sourceAvailabilities.stream()
+                        .map(Availability::getDataSourceNames)
+                        .flatMap(Set::stream)
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailability.java
@@ -185,6 +185,9 @@ public class MetricLeftUnionAvailability extends MetricUnionAvailability {
     /**
      * Validates to make sure that each representative Availability belongs to a configured table.
      *
+     * @param representativeAvailabilities  The set of representative Availabilities to be checked
+     * @param availabilities  A set that contains Availabilities of all configured tables
+     *
      * @throws IllegalArgumentException if there is at least one representative Availability that does not belong to any
      * configured tables
      */

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailability.java
@@ -1,0 +1,65 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.availability;
+
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
+import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * An implementation of {@code Availability} which describes a union of source availabilities, filtered by required
+ * metrics and then intersected on time available for required columns associated with a single participating
+ * {@code Availability}.
+ * <p>
+ * {@code MetricLeftUnionAvailability} behaves the same as {@code MetricUnionAvailability} except that the coalesced
+ * available intervals on this availability is determined by a single participating {@code Availability}, instead of
+ * all participating {@code Availabilities} as in {@code MetricUnionAvailability}. We call this single
+ * {@code Availability} as "representative" Availability.
+ */
+public class MetricLeftUnionAvailability extends MetricUnionAvailability {
+
+    private final Availability representativeAvailability;
+
+    /**
+     * Constructor.
+     *
+     * @param representativeAvailability  A participating Availability that determines the coalesced available intervals
+     * of this entire MetricLeftUnionAvailability availability
+     * @param availabilities  A set of {@code Availabilities} whose Dimension schemas are (typically) the same and the
+     * Metric columns are unique(i.e. no overlap) on every availability
+     * @param availabilitiesToMetricNames  A map of Availability to its set of metric names that this Availability will
+     * respond with
+     */
+    public MetricLeftUnionAvailability(
+            @NotNull final Availability representativeAvailability,
+            @NotNull Set<Availability> availabilities,
+            @NotNull Map<Availability, Set<String>> availabilitiesToMetricNames
+    ) {
+        super(availabilities, availabilitiesToMetricNames);
+        this.representativeAvailability = representativeAvailability;
+    }
+
+    @Override
+    public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
+        Set<String> dataSourceMetricNames = getAvailabilitiesToMetricNames()
+                .getOrDefault(representativeAvailability, Collections.emptySet());
+
+        if (hasUnconfiguredMetric(constraint, dataSourceMetricNames)) {
+            return new SimplifiedIntervalList();
+        }
+
+        return representativeAvailability.getAvailableIntervals(
+                constraint.withMetricIntersection(dataSourceMetricNames)
+        );
+    }
+
+    @Override
+    public SimplifiedIntervalList getAvailableIntervals() {
+        return representativeAvailability.getAvailableIntervals();
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailability.java
@@ -7,12 +7,12 @@ import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -74,7 +74,7 @@ public class MetricLeftUnionAvailability extends MetricUnionAvailability {
             @NotNull Map<Availability, Set<String>> availabilitiesToMetricNames
     ) {
         super(availabilities, availabilitiesToMetricNames);
-        this.representativeAvailabilities = Collections.unmodifiableSet(representativeAvailabilities);
+        this.representativeAvailabilities = ImmutableSet.copyOf(representativeAvailabilities);
         validateLeftAvailabilities();
     }
 
@@ -142,7 +142,7 @@ public class MetricLeftUnionAvailability extends MetricUnionAvailability {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("representativeAvailabilities", representativeAvailabilities)
+                .add("representativeAvailabilities", getRepresentativeAvailabilities())
                 .toString();
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailability.java
@@ -6,9 +6,15 @@ import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
+import com.google.common.base.MoreObjects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -26,73 +32,135 @@ import javax.validation.constraints.NotNull;
  */
 public class MetricLeftUnionAvailability extends MetricUnionAvailability {
 
-    private final Availability representativeAvailability;
+    private static final Logger LOG = LoggerFactory.getLogger(MetricLeftUnionAvailability.class);
 
-    /**
-     * Constructor.
-     *
-     * @param representativeAvailability  A participating Availability that determines the coalesced available intervals
-     * of this entire MetricLeftUnionAvailability availability
-     * @param availabilities  A set of {@code Availabilities} whose Dimension schemas are (typically) the same and the
-     * Metric columns are unique(i.e. no overlap) on every availability
-     * @param availabilitiesToMetricNames  A map of Availability to its set of metric names that this Availability will
-     * respond with
-     */
-    public MetricLeftUnionAvailability(
-            @NotNull Availability representativeAvailability,
-            @NotNull Set<Availability> availabilities,
-            @NotNull Map<Availability, Set<String>> availabilitiesToMetricNames
-    ) {
-        super(availabilities, availabilitiesToMetricNames);
-        this.representativeAvailability = representativeAvailability;
-    }
-
-    @Override
-    public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
-        Set<String> dataSourceMetricNames = getAvailabilitiesToMetricNames()
-                .getOrDefault(representativeAvailability, Collections.emptySet());
-
-        if (hasUnconfiguredMetric(constraint, dataSourceMetricNames)) {
-            return new SimplifiedIntervalList();
-        }
-
-        Collection<String> representativeColumns = representativeAvailability.getAllAvailableIntervals().keySet();
-
-        Set<String> filteredMetricNames = dataSourceMetricNames.stream()
-                .filter(name -> representativeColumns.contains(name))
-                .collect(Collectors.toSet());
-
-        return representativeAvailability.getAvailableIntervals(
-                constraint.withMetricIntersection(filteredMetricNames)
-        );
-    }
-
-    @Override
-    public SimplifiedIntervalList getAvailableIntervals() {
-        return representativeAvailability.getAvailableIntervals();
-    }
-
+    private final Set<Availability> representativeAvailabilities;
 
     /**
      * Produce a metric left union availability.
      *
-     * @param representativeAvailability  The availability used for aggregate availability checks. (replaces
+     * @param representativeAvailabilities  The availability used for aggregate availability checks. (replaces
      * intersection of all)
      * @param physicalTables  The physical tables to source metrics and dimensions from.
      * @param availabilitiesToMetricNames  The map of availabilities to the metric columns in the union schema.
      *
      * @return A metric union availability decorated with an official aggregate.
      */
-
     public static MetricLeftUnionAvailability build(
-            @NotNull Availability representativeAvailability,
+            @NotNull Set<Availability> representativeAvailabilities,
             @NotNull Collection<ConfigPhysicalTable> physicalTables,
             @NotNull Map<Availability, Set<String>> availabilitiesToMetricNames
     ) {
         return new MetricLeftUnionAvailability(
-                representativeAvailability,
+                representativeAvailabilities,
                 physicalTables.stream().map(ConfigPhysicalTable::getAvailability).collect(Collectors.toSet()),
                 availabilitiesToMetricNames
         );
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param representativeAvailabilities  A set of participating Availabilities that determines the coalesced
+     * available intervals of this entire MetricLeftUnionAvailability
+     * @param availabilities  A set of {@code Availabilities} whose Dimension schemas are (typically) the same and the
+     * Metric columns are unique(i.e. no overlap) on every availability
+     * @param availabilitiesToMetricNames  A map of Availability to its set of metric names that this Availability will
+     * respond with
+     */
+    public MetricLeftUnionAvailability(
+            @NotNull Set<Availability> representativeAvailabilities,
+            @NotNull Set<Availability> availabilities,
+            @NotNull Map<Availability, Set<String>> availabilitiesToMetricNames
+    ) {
+        super(availabilities, availabilitiesToMetricNames);
+        this.representativeAvailabilities = Collections.unmodifiableSet(representativeAvailabilities);
+        validateLeftAvailabilities();
+    }
+
+    @Override
+    public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
+        return getAvailableIntervals(getRepresentativeAvailabilitiesToMetricNames(), constraint);
+    }
+
+    /**
+     * Returns a map of Availability to its set of metric names that this Availability will respond with.
+     *
+     * @return a mapping from Availability to its responsible set of metric names
+     */
+    private Map<Availability, Set<String>> getRepresentativeAvailabilitiesToMetricNames() {
+        return getAvailabilitiesToMetricNames().entrySet().stream()
+                .filter(entry -> getRepresentativeAvailabilities().contains(entry.getKey()))
+                .collect(
+                        Collectors.toMap(
+                                Map.Entry::getKey,
+                                Map.Entry::getValue
+                        )
+                );
+    }
+
+    @Override
+    public SimplifiedIntervalList getAvailableIntervals() {
+        return getRepresentativeAvailabilities().stream()
+                .map(Availability::getAvailableIntervals)
+                .reduce(SimplifiedIntervalList::intersect)
+                .orElse(new SimplifiedIntervalList());
+    }
+
+    /**
+     * Returns an immutable set of representative availabilities.
+     *
+     * @return the immutable set of representative availabilities
+     */
+    public Set<Availability> getRepresentativeAvailabilities() {
+        return representativeAvailabilities;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) { return true; }
+        if (!(o instanceof MetricLeftUnionAvailability)) { return false; }
+        if (!super.equals(o)) { return false; }
+        final MetricLeftUnionAvailability that = (MetricLeftUnionAvailability) o;
+        return Objects.equals(getRepresentativeAvailabilities(), that.getRepresentativeAvailabilities());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), getRepresentativeAvailabilities());
+    }
+
+    /**
+     * Returns a string representation of this Availability.
+     *
+     * The format of the string is
+     * "MetricLeftUnionAvailability{representativeAvailabilities=XXX}", where "XXX" is given by
+     * {@link #getRepresentativeAvailabilities()}.
+     *
+     * @return the string representation of this Availability
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("representativeAvailabilities", representativeAvailabilities)
+                .toString();
+    }
+
+    /**
+     * This method must be called after {@link #representativeAvailabilities} has been initialized.
+     */
+    protected void validateLeftAvailabilities() {
+        Set<Availability> missedOutAvailabilities = getMissedOutAvailabilities();
+        if (!missedOutAvailabilities.isEmpty()) {
+            String message = String.format("'%s' have not been configured in table", missedOutAvailabilities);
+            LOG.error(message);
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    private Set<Availability> getMissedOutAvailabilities() {
+        return getRepresentativeAvailabilities().stream()
+                .filter(availability -> !getRepresentativeAvailabilitiesToMetricNames().containsKey(availability))
+                .collect(Collectors.toSet());
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricPureLeftUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricPureLeftUnionAvailability.java
@@ -1,0 +1,272 @@
+// Copyright 2018 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.availability;
+
+import com.yahoo.bard.webservice.data.config.names.DataSourceName;
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
+import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
+import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * A extension of {@link BaseCompositeAvailability} which describes a union of source availabilities backing the
+ * <b>same datasource schema</b> and intersected on time available for required columns.
+ * <p>
+ * The coalesced available intervals of this {@code Availability} is determined by a subset of participating
+ * {@code Availabilities} which we call "<b>representative Availabilities</b>"
+ * <p>
+ * For example, with three source availabilities with the following same metric(dimension columns also have to be the
+ * same, but we are not showing them here):
+ * <pre>
+ * {@code
+ * Source Availability 1:
+ * +---------------+
+ * |    metric1    |
+ * +---------------+
+ * |  [2017/2018]  |
+ * +---------------+
+ *
+ * Source Availability 2:
+ * +------------------+
+ * |     metric1      |
+ * +------------------+
+ * |  [2016/2017-03]  |
+ * +------------------+
+ *
+ * Source Availability 3:
+ * +-----------------+
+ * |     metric1     |
+ * +-----------------+
+ * |    2019/2020    |
+ * +-----------------+
+ * }
+ * </pre>
+ * If the representative Availabilities are Availabilities 1 {@literal &} 2, then the available intervals for metric 1
+ * required by a constraint is "2017/2017-03". Note that only the intervals from Availabilities 1 {@literal &} 2 are
+ * intersected to obtain the "2017/2017-03" and the Availability 3 is not involved in the intersection operation.
+ * <p>
+ * This class is thread-safe.
+ */
+public class MetricPureLeftUnionAvailability extends BaseCompositeAvailability {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetricPureLeftUnionAvailability.class);
+
+    private final Set<Availability> representativeAvailabilities;
+
+    /**
+     * Produce a metric left union availability.
+     * <p>
+     * This method calls {@link #MetricPureLeftUnionAvailability(Set, Set, Map)}.
+     *
+     * @param representativeAvailabilities  A set of participating Availabilities that determines the coalesced
+     * available intervals of this entire MetricLeftUnionAvailability
+     * @param physicalTables  The physical tables to source availabilities from
+     * @param availabilitiesToColumns  The map of availabilities to the metric columns in the union schema
+     *
+     * @return A metric union availability decorated with an official aggregate.
+     */
+    public static MetricPureLeftUnionAvailability build(
+            @NotNull Set<Availability> representativeAvailabilities,
+            @NotNull Collection<ConfigPhysicalTable> physicalTables,
+            @NotNull Map<Availability, Set<String>> availabilitiesToColumns
+    ) {
+        return new MetricPureLeftUnionAvailability(
+                representativeAvailabilities,
+                physicalTables.stream().map(ConfigPhysicalTable::getAvailability).collect(Collectors.toSet()),
+                availabilitiesToColumns
+        );
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param representativeAvailabilities  A set of participating Availabilities that determines the coalesced
+     * available intervals of this entire MetricLeftUnionAvailability
+     * @param availabilities  A set of {@code Availabilities} whose schemas must be the same
+     * @param availabilitiesToColumns  The map of availabilities to the metric columns in the union schema
+     */
+    public MetricPureLeftUnionAvailability(
+            @NotNull Set<Availability> representativeAvailabilities,
+            @NotNull Set<Availability> availabilities,
+            @NotNull Map<Availability, Set<String>> availabilitiesToColumns
+    ) {
+        super(availabilities.stream());
+        validateColumns(availabilitiesToColumns);
+        this.representativeAvailabilities = ImmutableSet.copyOf(representativeAvailabilities);
+    }
+
+    @Override
+    public Set<DataSourceName> getDataSourceNames() {
+        return getRepresentativeAvailabilities().stream()
+                .map(Availability::getDataSourceNames)
+                .flatMap(Set::stream)
+                .collect(
+                        Collectors.collectingAndThen(
+                                Collectors.toCollection(LinkedHashSet::new),
+                                Collections::unmodifiableSet
+                        )
+                );
+    }
+
+    @Override
+    public Set<DataSourceName> getDataSourceNames(DataSourceConstraint constraint) {
+        return getRepresentativeAvailabilities().stream()
+                .map(availability -> availability.getDataSourceNames(constraint))
+                .flatMap(Set::stream)
+                .collect(
+                        Collectors.collectingAndThen(
+                                Collectors.toCollection(LinkedHashSet::new),
+                                Collections::unmodifiableSet
+                        )
+                );
+    }
+
+    @Override
+    public Map<String, SimplifiedIntervalList> getAllAvailableIntervals() {
+        return getRepresentativeAvailabilities().stream()
+                .map(Availability::getAllAvailableIntervals)
+                .map(Map::entrySet)
+                .flatMap(Set::stream)
+                .collect(
+                        Collectors.collectingAndThen(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        Map.Entry::getValue,
+                                        (value1, value2) -> SimplifiedIntervalList.simplifyIntervals(value1, value2)
+                                ),
+                                Collections::unmodifiableMap
+                        )
+                );
+    }
+
+    @Override
+    public SimplifiedIntervalList getAvailableIntervals() {
+        return getRepresentativeAvailabilities().stream()
+                .map(Availability::getAvailableIntervals)
+                .reduce(SimplifiedIntervalList::intersect)
+                .orElse(new SimplifiedIntervalList());
+    }
+
+    @Override
+    public SimplifiedIntervalList getAvailableIntervals(PhysicalDataSourceConstraint constraint) {
+        return getRepresentativeAvailabilities().stream()
+                .map(availability -> availability.getAvailableIntervals(constraint))
+                .reduce(SimplifiedIntervalList::intersect)
+                .orElse(new SimplifiedIntervalList());
+    }
+
+    /**
+     * Returns the representative Availabilities for this Availability in an immutable set.
+     *
+     * @return immutable representative Availabilities set for this Availability
+     */
+    public Set<Availability> getRepresentativeAvailabilities() {
+        return representativeAvailabilities;
+    }
+
+    /**
+     * Returns a string representation of this Availability.
+     *
+     * The format of the string is
+     * "MetricPureLeftUnionAvailability{representativeAvailabilities=XXX}", where "XXX" is given by
+     * {@link #getRepresentativeAvailabilities()}.
+     *
+     * @return the string representation of this Availability
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("representativeAvailabilities", getRepresentativeAvailabilities())
+                .toString();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof MetricPureLeftUnionAvailability)) {
+            return false;
+        }
+        final MetricPureLeftUnionAvailability that = (MetricPureLeftUnionAvailability) other;
+        return Objects.equals(
+                getRepresentativeAvailabilities(),
+                that.getRepresentativeAvailabilities()
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRepresentativeAvailabilities());
+    }
+
+    /**
+     * Validates columns from multiple datasources.
+     * <p>
+     * The validation makes sure that
+     * <ul>
+     *     <li> no datasource has empty column set
+     *     <li> all datasources have exactly the same column set
+     * </ul>
+     *
+     * @param availabilitiesToColumns The map of availabilities to the metric columns in the union schema.
+     *
+     * @throws IllegalArgumentException if at least one datasource has empty column set or not all datasources have
+     * exactly the same column set
+     */
+    protected static void validateColumns(Map<Availability, Set<String>> availabilitiesToColumns) {
+        if (hasEmptyColSet(availabilitiesToColumns)) {
+            String message = String.format("Empty column set found - '%s'", availabilitiesToColumns);
+            LOG.error(message);
+            throw new IllegalArgumentException(message);
+        }
+
+        if (hasDifferentColSet(availabilitiesToColumns)) {
+            String message = String.format(
+                    "Columns from multiple sources do not match - '%s'",
+                    availabilitiesToColumns
+            );
+            LOG.error(message);
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    /**
+     * Returns true if at least one datasource has empty column set.
+     *
+     * @param availabilitiesToColumns  The map of availabilities to the metric columns in the union schema
+     *
+     * @return true if at least one datasource has empty column set
+     */
+    private static boolean hasEmptyColSet(Map<Availability, Set<String>> availabilitiesToColumns) {
+        return availabilitiesToColumns.values().stream().anyMatch(Set::isEmpty);
+    }
+
+    /**
+     * Returns true if not all datasources have exactly the same column set.
+     *
+     * @param availabilitiesToColumns  The map of availabilities to the metric columns in the union schema
+     *
+     * @return true if not all datasources have exactly the same column set
+     */
+    private static boolean hasDifferentColSet(Map<Availability, Set<String>> availabilitiesToColumns) {
+        return new HashSet<>(availabilitiesToColumns.values()).size() > 1;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -2,16 +2,19 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.table.availability;
 
-import com.google.common.collect.ImmutableSet;
 import com.yahoo.bard.webservice.data.config.names.DataSourceName;
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
+
+import com.google.common.collect.ImmutableSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.AbstractMap;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -184,6 +187,26 @@ public class MetricUnionAvailability extends BaseCompositeAvailability implement
                 )
                 .filter(entry -> !entry.getValue().getMetricNames().isEmpty())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+
+    /**
+     * Produce a metric union availability.
+     *
+     * @param physicalTables  The physical tables to source metrics and dimensions from.
+     * @param availabilitiesToMetricNames  The map of availabilities to the metric columns in the union schema.
+     *
+     * @return A metric union availability decorated with an official aggregate.
+     */
+
+    public static MetricUnionAvailability build(
+            @NotNull Collection<ConfigPhysicalTable> physicalTables,
+            @NotNull Map<Availability, Set<String>> availabilitiesToMetricNames
+    ) {
+        return new MetricUnionAvailability(
+                physicalTables.stream().map(ConfigPhysicalTable::getAvailability).collect(Collectors.toSet()),
+                availabilitiesToMetricNames
+        );
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/MetricUnionAvailability.java
@@ -8,6 +8,7 @@ import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint;
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
 import org.slf4j.Logger;
@@ -16,7 +17,9 @@ import org.slf4j.LoggerFactory;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -140,10 +143,10 @@ public class MetricUnionAvailability extends BaseCompositeAvailability {
 
     @Override
     public String toString() {
-        return String.format("MetricUnionAvailability with data source names: [%s] and Configured metric columns: %s",
-                getDataSourceNamesAsString(),
-                getMetricNames()
-        );
+        return MoreObjects.toStringHelper(this)
+                .add("metricNames", getMetricNames())
+                .add("availabilitiesToMetricNames", getAvailabilitiesToMetricNames())
+                .toString();
     }
 
     @Override
@@ -153,8 +156,14 @@ public class MetricUnionAvailability extends BaseCompositeAvailability {
         }
         if (obj instanceof MetricUnionAvailability) {
             MetricUnionAvailability that = (MetricUnionAvailability) obj;
-            return Objects.equals(metricNames, that.metricNames)
-                    && Objects.equals(availabilitiesToMetricNames, that.availabilitiesToMetricNames);
+            return Objects.equals(
+                    new LinkedHashSet<>(getMetricNames()), // bound to a concrete type for ClassScanner
+                    new LinkedHashSet<>(that.getMetricNames())
+            ) &&
+                    Objects.equals(
+                            new HashMap<>(getAvailabilitiesToMetricNames()),
+                            new HashMap<>(that.getAvailabilitiesToMetricNames())
+                    );
         }
         return false;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
@@ -99,7 +99,8 @@ import javax.ws.rs.core.UriInfo;
  */
 @Path("data")
 @Singleton
-public class DataServlet extends CORSPreflightServlet implements BardConfigResources {
+public class
+DataServlet extends CORSPreflightServlet implements BardConfigResources {
     private static final Logger LOG = LoggerFactory.getLogger(DataServlet.class);
     private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/MetricUnionCompositeTableDefinitionSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/MetricUnionCompositeTableDefinitionSpec.groovy
@@ -14,6 +14,7 @@ import com.yahoo.bard.webservice.data.time.ZonedTimeGrain
 import com.yahoo.bard.webservice.data.time.ZonedTimeGrainSpec
 import com.yahoo.bard.webservice.metadata.DataSourceMetadataService
 import com.yahoo.bard.webservice.table.availability.Availability
+import com.yahoo.bard.webservice.table.availability.MetricUnionAvailability
 
 import spock.lang.Shared
 import spock.lang.Specification
@@ -194,8 +195,15 @@ class MetricUnionCompositeTableDefinitionSpec extends Specification {
         Map<Availability, Set<String>> availabilitiesToMetricNames = tableMap.collectEntries {
             [physicalTableDictionary.get(it.key).availability, new HashSet<String>(it.value)]
         }
-        MetricUnionCompositeTable expectedPhysicalTable = new MetricUnionCompositeTable(name, timeGrain, [dimensionColumn, metricColumn1, metricColumn2] as Set, [table1, table2] as Set, logicalToPhysicalNames, availabilitiesToMetricNames)
 
+        BaseCompositePhysicalTable expectedPhysicalTable = new BaseCompositePhysicalTable(
+                name,
+                timeGrain,
+                [dimensionColumn, metricColumn1, metricColumn2] as Set,
+                [table1, table2] as Set,
+                logicalToPhysicalNames,
+                MetricUnionAvailability.build([table1, table2] as Set, availabilitiesToMetricNames)
+        )
         MetricUnionCompositeTableDefinition metricUnionCompositeTableDefinition = new MetricUnionCompositeTableDefinition(name, timeGrain, [apiMetricName1, apiMetricName2] as Set, dependantTables, [dimensionConfig] as Set)
 
         when:

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/AvailabilityTestingUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/AvailabilityTestingUtils.groovy
@@ -24,6 +24,21 @@ import java.util.stream.Stream
  */
 class AvailabilityTestingUtils extends Specification {
 
+    /**
+     * Returns a list of time intervals by converting a collection of their string representations.
+     * <p>
+     * The String formats are described by {@link org.joda.time.format.ISODateTimeFormat#dateTimeParser()} and
+     * {@link org.joda.time.format.ISOPeriodFormat#standard()}, and may be 'datetime/datetime', 'datetime/period' or
+     * 'period/datetime'.
+     *
+     * @param intervals  The collection of string time-intervals
+     *
+     * @return the list of time interval objects
+     */
+    static List<Interval> parseIntervals(Collection<String> intervals) {
+        intervals.collect {it -> new Interval(it)}
+    }
+
     static class TestAvailability implements Availability {
         final Set<DataSourceName> sourceDataSourceNames
         final Map<String, Set<Interval>> intervals

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricLeftUnionAvailabilitySpec.groovy
@@ -1,0 +1,190 @@
+// Copyright 2018 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.availability
+
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
+import com.yahoo.bard.webservice.data.metric.MetricColumn
+import com.yahoo.bard.webservice.table.Column
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable
+import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint
+import com.yahoo.bard.webservice.util.SimplifiedIntervalList
+import com.yahoo.bard.webservice.web.filters.ApiFilters
+
+import org.joda.time.Interval
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Test for metric left-union availability behavior.
+ */
+class MetricLeftUnionAvailabilitySpec extends Specification {
+    Availability representativeAvailability
+    Availability availability2
+
+    String metric1
+    String metric2
+
+    Column metricColumn1
+    Column metricColumn2
+
+    ConfigPhysicalTable physicalTable1
+    ConfigPhysicalTable physicalTable2
+
+    Set<ConfigPhysicalTable> physicalTables
+
+    MetricLeftUnionAvailability metricLeftUnionAvailability
+
+    ApiFilters apiFilters
+
+    Map<Availability, Set<String>> availabilitiesToMetricNames
+
+    def setup() {
+        representativeAvailability = Mock(Availability)
+        availability2 = Mock(Availability)
+
+        representativeAvailability.dataSourceNames >> ([DataSourceName.of('source1')] as Set)
+        availability2.dataSourceNames >> ([DataSourceName.of('source2')] as Set)
+
+        metric1 = 'metric1'
+        metric2 = 'metric2'
+
+        metricColumn1 = new MetricColumn(metric1)
+        metricColumn2 = new MetricColumn(metric2)
+
+        physicalTable1 = Mock(ConfigPhysicalTable)
+        physicalTable2 = Mock(ConfigPhysicalTable)
+
+        physicalTable1.getAvailability() >> representativeAvailability
+        physicalTable2.getAvailability() >> availability2
+
+        physicalTables = [physicalTable1, physicalTable2] as Set
+
+        apiFilters = new ApiFilters()
+
+        availabilitiesToMetricNames = new HashMap<>()
+    }
+
+    @Unroll
+    def "getAvailableIntervals returns the intersection of requested columns when available intervals have #reason"() {
+        given:
+        representativeAvailability.getAllAvailableIntervals() >> [(metric1): []]
+        availability2.getAllAvailableIntervals() >> [(metric2): []]
+
+        availabilitiesToMetricNames.put(representativeAvailability, [metric1] as Set)
+        availabilitiesToMetricNames.put(availability2, [metric2] as Set)
+
+        representativeAvailability.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList(
+                availableIntervals1.collect{it -> new Interval(it)} as Set
+        )
+        availability2.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList(
+                availableIntervals2.collect{it -> new Interval(it)} as Set
+        )
+
+        metricLeftUnionAvailability = new MetricLeftUnionAvailability(
+                representativeAvailability,
+                physicalTables.availability as Set,
+                availabilitiesToMetricNames
+        )
+
+        DataSourceConstraint dataSourceConstraint = new DataSourceConstraint(
+                [] as Set,
+                [] as Set,
+                [] as Set,
+                [metric1] as Set,
+                [] as Set,
+                [] as Set,
+                [metric1] as Set,
+                apiFilters
+        )
+
+        PhysicalDataSourceConstraint physicalDataSourceConstraint = new PhysicalDataSourceConstraint(dataSourceConstraint, [metric1, metric2] as Set)
+
+        expect:
+        metricLeftUnionAvailability.getAvailableIntervals(physicalDataSourceConstraint) == new SimplifiedIntervalList(
+                availableIntervals1.collect{it -> new Interval(it)} as Set
+        )
+
+        where:
+        availableIntervals1       | availableIntervals2       | reason
+        []                        | []                        | "two empty intervals collections"
+        ['2018-01-01/2018-02-01'] | []                        | "one interval collection being empty"
+        ['2017-01-01/2017-02-01'] | ['2017-01-01/2017-02-01'] | "full overlap (start/end, start/end)"
+        ['2017-01-01/2017-02-01'] | ['2018-01-01/2018-02-01'] | "0 overlap (-10/-1, 0/10)"
+        ['2017-01-01/2017-02-01'] | ['2017-02-01/2017-03-01'] | "0 overlap abutting (-10/0, 0/10)"
+        ['2017-01-01/2017-02-01'] | ['2017-01-15/2017-03-01'] | "partial front overlap (0/10, 5/15)"
+        ['2017-01-01/2017-02-01'] | ['2016-10-01/2017-01-15'] | "partial back overlap (0/10, -5/5)"
+        ['2017-01-01/2017-02-01'] | ['2017-01-15/2017-02-01'] | "full front overlap (0/10, 5/10)"
+        ['2017-01-01/2017-02-01'] | ['2017-01-01/2017-01-15'] | "full back overlap (0/10, 0/5)"
+        ['2017-01-01/2017-02-01'] | ['2017-01-15/2017-01-25'] | "fully contain (0/10, 3/9)"
+    }
+
+    def "getAvailableIntervals returns empty availability if requesting a column on table that is not supported by the underlying data sources"() {
+        given:
+        representativeAvailability.getAllAvailableIntervals() >> [(metric1): ['2018-01-01/2018-02-01']]
+        availability2.getAllAvailableIntervals() >> [(metric2): ['2018-01-01/2018-02-01']]
+
+        availabilitiesToMetricNames.put(representativeAvailability, [metric1] as Set)
+        availabilitiesToMetricNames.put(availability2, [metric2] as Set)
+
+        representativeAvailability.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList(
+                [new Interval('2018-01-01/2018-02-01')]
+        )
+        availability2.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList(
+                [new Interval('2018-01-01/2018-02-01')]
+        )
+
+        metricLeftUnionAvailability = new MetricLeftUnionAvailability(
+                representativeAvailability,
+                physicalTables.availability as Set,
+                availabilitiesToMetricNames
+        )
+
+        DataSourceConstraint dataSourceConstraint = new DataSourceConstraint(
+                [] as Set,
+                [] as Set,
+                [] as Set,
+                [metric1, 'un_configured'] as Set,
+                [] as Set,
+                [] as Set,
+                [metric1, 'un_configured'] as Set,
+                apiFilters
+        )
+
+        PhysicalDataSourceConstraint physicalDataSourceConstraint = new PhysicalDataSourceConstraint(
+                dataSourceConstraint,
+                [metric1, metric2, 'un_configured'] as Set
+        )
+
+        expect:
+        metricLeftUnionAvailability.getAvailableIntervals(physicalDataSourceConstraint) == new SimplifiedIntervalList()
+    }
+
+    def "getAvailableIntervals() returns available intervals of representative availability"() {
+        setup:
+        representativeAvailability.getAllAvailableIntervals() >> [(metric1): []]
+        availability2.getAllAvailableIntervals() >> [(metric2): []]
+
+        availabilitiesToMetricNames.put(representativeAvailability, [metric1] as Set)
+        availabilitiesToMetricNames.put(availability2, [metric2] as Set)
+
+        representativeAvailability.getAvailableIntervals() >> new SimplifiedIntervalList(
+                [new Interval('2018-01-01/2018-02-01')]
+        )
+        availability2.getAvailableIntervals() >> new SimplifiedIntervalList(
+                [new Interval('2018-01-01/2018-02-01')]
+        )
+
+        metricLeftUnionAvailability = new MetricLeftUnionAvailability(
+                representativeAvailability,
+                physicalTables.availability as Set,
+                availabilitiesToMetricNames
+        )
+
+        expect:
+        metricLeftUnionAvailability.getAvailableIntervals() == new SimplifiedIntervalList(
+                [new Interval('2018-01-01/2018-02-01')]
+        )
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricPureLeftUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricPureLeftUnionAvailabilitySpec.groovy
@@ -1,0 +1,373 @@
+// Copyright 2018 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.table.availability
+
+import com.yahoo.bard.webservice.data.config.names.DataSourceName
+import com.yahoo.bard.webservice.data.metric.MetricColumn
+import com.yahoo.bard.webservice.table.Column
+import com.yahoo.bard.webservice.table.ConfigPhysicalTable
+import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
+import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint
+import com.yahoo.bard.webservice.util.SimplifiedIntervalList
+import com.yahoo.bard.webservice.web.filters.ApiFilters
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Test for metric left-union availability behavior.
+ */
+class MetricPureLeftUnionAvailabilitySpec extends Specification {
+    Availability representativeAvailability
+    Availability nonRepresentativeAvailability
+
+    String metric
+
+    Column metricColumn1
+    Column metricColumn2
+
+    ConfigPhysicalTable physicalTable1
+    ConfigPhysicalTable physicalTable2
+
+    Set<ConfigPhysicalTable> physicalTables
+
+    MetricPureLeftUnionAvailability metricPureLeftUnionAvailability
+
+    ApiFilters apiFilters
+
+    Map<Availability, Set<String>> availabilitiesToMetricNames
+
+    def setup() {
+        representativeAvailability = Mock(Availability)
+        nonRepresentativeAvailability = Mock(Availability)
+
+        representativeAvailability.dataSourceNames >> ([DataSourceName.of('source1')] as Set)
+        nonRepresentativeAvailability.dataSourceNames >> ([DataSourceName.of('source2')] as Set)
+
+        metric = 'metric'
+
+        metricColumn1 = new MetricColumn(metric)
+        metricColumn2 = new MetricColumn(metric)
+
+        physicalTable1 = Mock(ConfigPhysicalTable)
+        physicalTable2 = Mock(ConfigPhysicalTable)
+
+        physicalTable1.getAvailability() >> representativeAvailability
+        physicalTable2.getAvailability() >> nonRepresentativeAvailability
+
+        physicalTables = [physicalTable1, physicalTable2] as Set
+
+        apiFilters = new ApiFilters()
+
+        availabilitiesToMetricNames = new HashMap<>()
+
+        availabilitiesToMetricNames.put(representativeAvailability, [metric] as Set)
+        availabilitiesToMetricNames.put(nonRepresentativeAvailability, [metric] as Set)
+
+        metricPureLeftUnionAvailability = new MetricPureLeftUnionAvailability(
+                [representativeAvailability] as Set,
+                physicalTables.availability as Set,
+                availabilitiesToMetricNames
+        )
+    }
+
+    def "Build method and constructor produce the same instance"() {
+        given: "a MetricPureLeftUnionAvailability instance crated by constructor"
+        MetricPureLeftUnionAvailability availabilityByContr = new MetricPureLeftUnionAvailability(
+                [representativeAvailability] as Set,
+                physicalTables.availability as Set,
+                availabilitiesToMetricNames
+        )
+
+        and: "a MetricPureLeftUnionAvailability instance created by builder with same parameter"
+        MetricPureLeftUnionAvailability availabilityByBuild = MetricPureLeftUnionAvailability.build(
+                [representativeAvailability] as Set,
+                physicalTables,
+                availabilitiesToMetricNames
+        )
+
+        expect: "the two instances are equal"
+        availabilityByBuild == availabilityByContr
+    }
+
+    def "Without constraint, Availability returns immutable datasources of representative Availability only"() {
+        when: "datasources are requested"
+        Set<DataSourceName> dataSourceNames = metricPureLeftUnionAvailability.getDataSourceNames()
+
+        then: "datasources are only associated with the representative availability"
+        dataSourceNames == [DataSourceName.of("source1")] as Set
+
+        when: "when we try to mutate the datasources"
+        dataSourceNames.add(DataSourceName.of("hack"))
+
+        then: "error is thrown"
+        Exception exception = thrown()
+        exception instanceof UnsupportedOperationException
+    }
+
+    def "With constraint, Availability returns constrained datasources of representative Availability only"() {
+        given: "a constraint"
+        DataSourceConstraint constraint = Mock(DataSourceConstraint)
+
+        and: "the constraint filters out all datasources in representative availability but keeps a datasource in non-representative availability"
+        representativeAvailability.getDataSourceNames(constraint) >> ([] as Set)
+        nonRepresentativeAvailability.getDataSourceNames(constraint) >> ([DataSourceName.of("source2")] as Set)
+
+        when: "datasources are requested"
+        Set<DataSourceName> dataSourceNames = metricPureLeftUnionAvailability.getDataSourceNames(constraint)
+
+        then: "datasources are only associated with the representative availability"
+        dataSourceNames == [] as Set
+
+        when: "when we try to mutate the datasources"
+        dataSourceNames.add(DataSourceName.of("hack"))
+
+        then: "error is thrown"
+        Exception exception = thrown()
+        exception instanceof UnsupportedOperationException
+    }
+
+    @Unroll
+    def "Availabilities by columns reflects representative availabilities only when rep. and non-rep. availabilities have #intervals"() {
+        setup: "representative availabilities reflects a set of available intervals"
+        representativeAvailability.getAllAvailableIntervals() >> [
+                (metric): SimplifiedIntervalList.simplifyIntervals(
+                        AvailabilityTestingUtils.parseIntervals(representativeIntervals)
+                )
+        ]
+
+        and: "non-representative availabilities reflects another set of available intervals"
+        nonRepresentativeAvailability.getAllAvailableIntervals() >> [
+                (metric): SimplifiedIntervalList.simplifyIntervals(
+                        AvailabilityTestingUtils.parseIntervals(nonRepresentativeIntervals)
+                )
+        ]
+
+        expect: "pure left union availability always reflects the availabilities from the representative availabilities"
+        metricPureLeftUnionAvailability.getAllAvailableIntervals() == [
+                (metric): SimplifiedIntervalList.simplifyIntervals(
+                        AvailabilityTestingUtils.parseIntervals(representativeIntervals)
+                )
+        ]
+
+        where:
+        representativeIntervals   | nonRepresentativeIntervals | intervals
+        []                        | []                         | "both empty intervals"
+        ['2018-01/2018-02']       | []                         | "empty interval in rep. availability"
+        []                        | ['2018-01/2018-02']        | "empty interval in non-rep. availability"
+        ['2017-01/2017-02']       | ['2017-01/2017-02']        | "full overlap (start/end, start/end)"
+        ['2017-01/2017-02']       | ['2018-01/2018-02']        | "0 overlap (-10/-1, 0/10)"
+        ['2017-01/2017-02']       | ['2017-02/2017-03']        | "0 overlap abutting (-10/0, 0/10)"
+        ['2017-01/2017-02']       | ['2017-01/2017-03']        | "partial front overlap (0/10, 5/15)"
+        ['2017-01/2017-03']       | ['2016-10/2017-02']        | "partial back overlap (0/10, -5/5)"
+        ['2017-01/2017-03']       | ['2017-03/2017-03']        | "full front overlap (0/10, 5/10)"
+        ['2017-01/2017-02']       | ['2017-01/2017-01']        | "full back overlap (0/10, 0/5)"
+        ['2017-01/2017-05']       | ['2017-02/2017-03']        | "fully contain (0/10, 3/9)"
+    }
+
+    @Unroll
+    def "Unconstrained availability always reflects the unconstrained representative availabilities"() {
+        setup: "representative availabilities reflects a set of available intervals"
+        representativeAvailability.getAvailableIntervals() >> SimplifiedIntervalList.simplifyIntervals(
+                AvailabilityTestingUtils.parseIntervals(representativeIntervals)
+        )
+
+        and: "non-representative availabilities reflects another set of available intervals"
+        nonRepresentativeAvailability.getAvailableIntervals() >> SimplifiedIntervalList.simplifyIntervals(
+                AvailabilityTestingUtils.parseIntervals(nonRepresentativeIntervals)
+        )
+
+        expect: "pure left union availability always reflects the availabilities from the representative availabilities"
+        metricPureLeftUnionAvailability.getAvailableIntervals() == SimplifiedIntervalList.simplifyIntervals(
+                AvailabilityTestingUtils.parseIntervals(representativeIntervals)
+        )
+
+        where:
+        representativeIntervals   | nonRepresentativeIntervals | intervals
+        []                        | []                         | "both empty intervals"
+        ['2018-01/2018-02']       | []                         | "empty interval in rep. availability"
+        []                        | ['2018-01/2018-02']        | "empty interval in non-rep. availability"
+        ['2017-01/2017-02']       | ['2017-01/2017-02']        | "full overlap (start/end, start/end)"
+        ['2017-01/2017-02']       | ['2018-01/2018-02']        | "0 overlap (-10/-1, 0/10)"
+        ['2017-01/2017-02']       | ['2017-02/2017-03']        | "0 overlap abutting (-10/0, 0/10)"
+        ['2017-01/2017-02']       | ['2017-01/2017-03']        | "partial front overlap (0/10, 5/15)"
+        ['2017-01/2017-03']       | ['2016-10/2017-02']        | "partial back overlap (0/10, -5/5)"
+        ['2017-01/2017-03']       | ['2017-03/2017-03']        | "full front overlap (0/10, 5/10)"
+        ['2017-01/2017-02']       | ['2017-01/2017-01']        | "full back overlap (0/10, 0/5)"
+        ['2017-01/2017-05']       | ['2017-02/2017-03']        | "fully contain (0/10, 3/9)"
+    }
+
+    @Unroll
+    def "Constrained availability always reflects the Constrained representative availabilities"() {
+        given: "a constraint"
+        PhysicalDataSourceConstraint constraint = Mock(PhysicalDataSourceConstraint)
+
+        and: "representative availabilities reflects a set of constrained intervals"
+        representativeAvailability.getAvailableIntervals(constraint) >> SimplifiedIntervalList.simplifyIntervals(
+                AvailabilityTestingUtils.parseIntervals(representativeIntervals)
+        )
+
+        and: "non-representative availabilities reflects another set of constrained intervals"
+        nonRepresentativeAvailability.getAvailableIntervals(constraint) >> SimplifiedIntervalList.simplifyIntervals(
+                AvailabilityTestingUtils.parseIntervals(nonRepresentativeIntervals)
+        )
+
+        expect: "pure left union availability always reflects the availabilities from the representative availabilities"
+        metricPureLeftUnionAvailability.getAvailableIntervals(constraint) == SimplifiedIntervalList.simplifyIntervals(
+                AvailabilityTestingUtils.parseIntervals(representativeIntervals)
+        )
+
+        where:
+        representativeIntervals   | nonRepresentativeIntervals | intervals
+        []                        | []                         | "both empty intervals"
+        ['2018-01/2018-02']       | []                         | "empty interval in rep. availability"
+        []                        | ['2018-01/2018-02']        | "empty interval in non-rep. availability"
+        ['2017-01/2017-02']       | ['2017-01/2017-02']        | "full overlap (start/end, start/end)"
+        ['2017-01/2017-02']       | ['2018-01/2018-02']        | "0 overlap (-10/-1, 0/10)"
+        ['2017-01/2017-02']       | ['2017-02/2017-03']        | "0 overlap abutting (-10/0, 0/10)"
+        ['2017-01/2017-02']       | ['2017-01/2017-03']        | "partial front overlap (0/10, 5/15)"
+        ['2017-01/2017-03']       | ['2016-10/2017-02']        | "partial back overlap (0/10, -5/5)"
+        ['2017-01/2017-03']       | ['2017-03/2017-03']        | "full front overlap (0/10, 5/10)"
+        ['2017-01/2017-02']       | ['2017-01/2017-01']        | "full back overlap (0/10, 0/5)"
+        ['2017-01/2017-05']       | ['2017-02/2017-03']        | "fully contain (0/10, 3/9)"
+    }
+
+    def "Published reference to internal state is immutable"() {
+        given: "a reference to representative availabilities"
+        Set<Availability> availabilities = metricPureLeftUnionAvailability.getRepresentativeAvailabilities()
+
+        when: "we try add a new element to the set"
+        availabilities.add(Mock(Availability))
+
+        then: "error is thworn"
+        Exception exception = thrown()
+        exception instanceof UnsupportedOperationException
+
+        when: "we try to mutate an element to the set"
+        Availability availability = availabilities.iterator().next()
+        availability = null
+
+        then: "internal state is not changed"
+        availabilities == metricPureLeftUnionAvailability.representativeAvailabilities
+    }
+
+    def "toString matches Javadoc description"() {
+        given: "toString spec of representative availability"
+        representativeAvailability.toString() >> "representativeAvailability"
+
+        expect: "Availability prints to have the same format described in toString() Javadoc of this Availability"
+        metricPureLeftUnionAvailability.toString() ==
+                "MetricPureLeftUnionAvailability{representativeAvailabilities=[representativeAvailability]}"
+    }
+
+    @Unroll
+    def "'#columnSet1' and '#columnSet2' trigger error because of #reason"() {
+        given: "toString spec of representative and non-representative availabilities"
+        representativeAvailability.toString() >> "rep."
+        nonRepresentativeAvailability.toString() >> "non-rep."
+
+        and: "expected error message"
+        String errorMessage = reason == "empty column set(s)" ? "Empty column set found - '{rep.=${columnSet1}, non-rep.=${columnSet2}}'"
+                : """Columns from multiple sources do not match - '{rep.=${columnSet1}, non-rep.=${columnSet2}}'"""
+
+        and: "bad column sets are used"
+        availabilitiesToMetricNames = [
+                (representativeAvailability): columnSet1,
+                (nonRepresentativeAvailability): columnSet2
+        ]
+
+        when: "the bad columns are validated"
+        MetricPureLeftUnionAvailability.validateColumns(availabilitiesToMetricNames)
+
+        then: "error is thrown"
+        Exception exception = thrown()
+        exception instanceof IllegalArgumentException
+        exception.message == errorMessage
+
+        when: "the bad columns are passed to constructor"
+        new MetricPureLeftUnionAvailability(
+                [representativeAvailability] as Set,
+                physicalTables.availability as Set,
+                availabilitiesToMetricNames
+        )
+
+        then: "error is also thrown"
+        exception = thrown()
+        exception instanceof IllegalArgumentException
+        exception.message == errorMessage
+
+        where:
+        columnSet1              | columnSet2              | reason
+        [] as Set               | [] as Set               | "empty column set(s)"
+        ["col1"] as Set         | [] as Set               | "empty column set(s)"
+        [] as Set               | ["col2"] as Set         | "empty column set(s)"
+        ["col1", "col2"] as Set | ["col1"] as Set         | "duplicate column sets"
+        ["col1"] as Set         | ["col1", "col2"] as Set | "duplicate column sets"
+        ["col1", "col2"] as Set | ["col3"] as Set         | "duplicate column sets"
+        ["col3"] as Set         | ["col1", "col2"] as Set | "duplicate column sets"
+    }
+
+    @Unroll
+    def "'#columnSet1' and '#columnSet2' do not trigger error"() {
+        when: "valid column sets are used"
+        MetricPureLeftUnionAvailability.validateColumns(
+                [
+                        (representativeAvailability): columnSet1,
+                        (nonRepresentativeAvailability): columnSet2
+                ]
+        )
+
+        then: "no error is thrown"
+        noExceptionThrown()
+
+        where:
+        columnSet1              | columnSet2
+        ["col1"] as Set         | ["col1"] as Set
+        ["col1", "col2"] as Set | ["col1", "col2"] as Set
+    }
+
+    @Unroll
+    def "There #is empty column set(s) among '#columnSet1' and '#columnSet2'"() {
+        expect:
+        MetricPureLeftUnionAvailability.hasEmptyColSet(
+                [
+                        (representativeAvailability): columnSet1,
+                        (nonRepresentativeAvailability): columnSet2
+                ]
+        ) == hasEmpty
+
+        where:
+        columnSet1      | columnSet2      || hasEmpty
+        [] as Set       | [] as Set       || Boolean.TRUE
+        ["col1"] as Set | [] as Set       || Boolean.TRUE
+        [] as Set       | ["col2"] as Set || Boolean.TRUE
+        ["col1"] as Set | ["col1"] as Set || Boolean.FALSE
+
+        is = hasEmpty ? "is(are)" : "is(are) not"
+    }
+
+    @Unroll
+    def "'#columnSet1' and '#columnSet2' #are the same column set"() {
+        expect:
+        MetricPureLeftUnionAvailability.hasDifferentColSet(
+                [
+                        (representativeAvailability): columnSet1,
+                        (nonRepresentativeAvailability): columnSet2
+                ]
+        ) == hasDifferentColSet
+
+        where:
+        columnSet1              | columnSet2              || hasDifferentColSet
+        [] as Set               | [] as Set               || Boolean.FALSE
+        ["col1"] as Set         | [] as Set               || Boolean.TRUE
+        [] as Set               | ["col2"] as Set         || Boolean.TRUE
+        ["col1"] as Set         | ["col1"] as Set         || Boolean.FALSE
+        ["col1", "col2"] as Set | ["col1"] as Set         || Boolean.TRUE
+        ["col1"] as Set         | ["col1", "col2"] as Set || Boolean.TRUE
+        ["col1", "col2"] as Set | ["col3"] as Set         || Boolean.TRUE
+        ["col3"] as Set         | ["col1", "col2"] as Set || Boolean.TRUE
+        ["col1", "col2"] as Set | ["col1", "col2"] as Set || Boolean.FALSE
+
+        are = hasDifferentColSet ? "are not" : "are"
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricPureLeftUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricPureLeftUnionAvailabilitySpec.groovy
@@ -3,13 +3,10 @@
 package com.yahoo.bard.webservice.table.availability
 
 import com.yahoo.bard.webservice.data.config.names.DataSourceName
-import com.yahoo.bard.webservice.data.metric.MetricColumn
-import com.yahoo.bard.webservice.table.Column
 import com.yahoo.bard.webservice.table.ConfigPhysicalTable
 import com.yahoo.bard.webservice.table.resolver.DataSourceConstraint
 import com.yahoo.bard.webservice.table.resolver.PhysicalDataSourceConstraint
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList
-import com.yahoo.bard.webservice.web.filters.ApiFilters
 
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -20,17 +17,9 @@ class MetricPureLeftUnionAvailabilitySpec extends Specification {
 
     String metric
 
-    Column metricColumn1
-    Column metricColumn2
-
-    ConfigPhysicalTable physicalTable1
-    ConfigPhysicalTable physicalTable2
-
     Set<ConfigPhysicalTable> physicalTables
 
     MetricPureLeftUnionAvailability metricPureLeftUnionAvailability
-
-    ApiFilters apiFilters
 
     Map<Availability, Set<String>> availabilitiesToMetricNames
 
@@ -43,23 +32,15 @@ class MetricPureLeftUnionAvailabilitySpec extends Specification {
 
         metric = 'metric'
 
-        metricColumn1 = new MetricColumn(metric)
-        metricColumn2 = new MetricColumn(metric)
+        physicalTables = [
+                Mock(ConfigPhysicalTable) {getAvailability() >> representativeAvailability},
+                Mock(ConfigPhysicalTable) {getAvailability() >> nonRepresentativeAvailability}
+        ] as Set
 
-        physicalTable1 = Mock(ConfigPhysicalTable)
-        physicalTable2 = Mock(ConfigPhysicalTable)
-
-        physicalTable1.getAvailability() >> representativeAvailability
-        physicalTable2.getAvailability() >> nonRepresentativeAvailability
-
-        physicalTables = [physicalTable1, physicalTable2] as Set
-
-        apiFilters = new ApiFilters()
-
-        availabilitiesToMetricNames = new HashMap<>()
-
-        availabilitiesToMetricNames.put(representativeAvailability, [metric] as Set)
-        availabilitiesToMetricNames.put(nonRepresentativeAvailability, [metric] as Set)
+        availabilitiesToMetricNames = [
+                (representativeAvailability): [metric] as Set,
+                (nonRepresentativeAvailability): [metric] as Set
+        ]
 
         metricPureLeftUnionAvailability = new MetricPureLeftUnionAvailability(
                 [representativeAvailability] as Set,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
@@ -99,6 +99,27 @@ class MetricUnionAvailabilitySpec extends Specification {
     }
 
     @Unroll
+    def "#constraintColumns #has unconfigured metric columns in #configuredMetricColumns"() {
+        given: "a constraint specifying constrained columns"
+        DataSourceConstraint constraint = Mock(DataSourceConstraint)
+        constraint.getMetricNames() >> (constraintColumns as Set)
+
+        expect: "unconfigured metric columns are identified"
+        MetricUnionAvailability.hasUnconfiguredMetric(constraint, configuredMetricColumns as Set) == hasUnconfiguredCol
+
+        where:
+        constraintColumns      | configuredMetricColumns || hasUnconfiguredCol
+        []                     | []                      || false
+        ["metric1", "metric2"] | ["metric1", "metric2"]  || false
+        ["metric1", "metric2"] | []                      || true
+        []                     | ["metric1", "metric2"]  || false
+        ["metric1"]            | ["metric1", "metric2"]  || false
+        ["metric1", "metric2"] | ["metric1"]             || true
+
+        has = hasUnconfiguredCol ? "has" : "do not have"
+    }
+
+    @Unroll
     def "isMetricUnique returns true if and only if metric is unique across all data sources in the case of #caseDescription"() {
         expect:
         expected == MetricUnionAvailability.isMetricUnique(

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/MetricUnionAvailabilitySpec.groovy
@@ -66,6 +66,24 @@ class MetricUnionAvailabilitySpec extends Specification {
         availabilitiesToMetricNames = new HashMap<>()
     }
 
+    def "Build method produces the same instance by constructor"() {
+        given:
+        availability1.getAllAvailableIntervals() >> [:]
+        availability2.getAllAvailableIntervals() >> [:]
+
+        availabilitiesToMetricNames.put(availability1, [metric1] as Set)
+        availabilitiesToMetricNames.put(availability2, [metric2] as Set)
+
+        MetricUnionAvailability availabilityByContr = new MetricUnionAvailability(
+                physicalTables.availability as Set,
+                availabilitiesToMetricNames
+        )
+        MetricUnionAvailability availabilityByBuild = MetricUnionAvailability.build(physicalTables, availabilitiesToMetricNames)
+
+        expect:
+        availabilityByBuild == availabilityByContr
+    }
+
     def "Metric columns are initialized by fetching columns from availabilities, not from physical tables"() {
         given:
         availability1.getAllAvailableIntervals() >> [(metric1): []]
@@ -150,8 +168,12 @@ class MetricUnionAvailabilitySpec extends Specification {
         metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, availabilitiesToMetricNames)
 
         then:
-        RuntimeException exception = thrown()
-        exception.message.startsWith("Metric columns must be unique across the metric union data sources, but duplicate was found across the following data sources: source1, source2")
+        Exception exception = thrown()
+        exception instanceof IllegalArgumentException
+        exception.message.startsWith(
+                "Metric columns must be unique across the metric union data sources, " +
+                        "but duplicate was found across the following data sources: source1, source2"
+        )
     }
 
     def "getDataSourceNames returns sources from availabilities not from physical tables"() {
@@ -226,8 +248,8 @@ class MetricUnionAvailabilitySpec extends Specification {
         PhysicalDataSourceConstraint physicalDataSourceConstraint = new PhysicalDataSourceConstraint(dataSourceConstraint, [metric1, metric2, 'ignored2'] as Set)
 
         expect:
-        metricUnionAvailability.constructSubConstraint(physicalDataSourceConstraint).get(availability1).getMetricNames() == [metric1] as Set
-        metricUnionAvailability.constructSubConstraint(physicalDataSourceConstraint).get(availability2).getMetricNames() == [metric2] as Set
+        metricUnionAvailability.constructSubConstraint(availabilitiesToMetricNames, physicalDataSourceConstraint).get(availability1).getMetricNames() == [metric1] as Set
+        metricUnionAvailability.constructSubConstraint(availabilitiesToMetricNames, physicalDataSourceConstraint).get(availability2).getMetricNames() == [metric2] as Set
     }
 
     @Unroll
@@ -263,6 +285,9 @@ class MetricUnionAvailabilitySpec extends Specification {
 
         expect:
         metricUnionAvailability.getAvailableIntervals(physicalDataSourceConstraint) == new SimplifiedIntervalList(
+                availableIntervals.collect{it -> new Interval(it)} as Set
+        )
+        metricUnionAvailability.getAvailableIntervals(availabilitiesToMetricNames, physicalDataSourceConstraint) == new SimplifiedIntervalList(
                 availableIntervals.collect{it -> new Interval(it)} as Set
         )
 
@@ -312,5 +337,52 @@ class MetricUnionAvailabilitySpec extends Specification {
 
         expect:
         metricUnionAvailability.getAvailableIntervals(physicalDataSourceConstraint) == new SimplifiedIntervalList()
+        metricUnionAvailability.getAvailableIntervals(availabilitiesToMetricNames, physicalDataSourceConstraint) == new SimplifiedIntervalList()
+    }
+
+    def "Published references to internal states are immutable"() {
+        given: "a MetricUnionAvailability instance"
+        availability1.getAllAvailableIntervals() >> [(metric1): ['2018-01-01/2018-02-01']]
+        availability2.getAllAvailableIntervals() >> [(metric2): ['2018-01-01/2018-02-01']]
+
+        availabilitiesToMetricNames.put(availability1, [metric1] as Set)
+        availabilitiesToMetricNames.put(availability2, [metric2] as Set)
+
+        availability1.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList(
+                [new Interval('2018-01-01/2018-02-01')]
+        )
+        availability2.getAvailableIntervals(_ as PhysicalDataSourceConstraint) >> new SimplifiedIntervalList(
+                [new Interval('2018-01-01/2018-02-01')]
+        )
+
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, availabilitiesToMetricNames)
+
+        when: "we try to mutate metrics"
+        metricUnionAvailability.getMetricNames().add("someMetric")
+
+        then: "error is thrown"
+        Exception exception = thrown()
+        exception instanceof UnsupportedOperationException
+
+        when: "we try to mutate availability->metircs map"
+        metricUnionAvailability.getAvailabilitiesToMetricNames().put(Mock(Availability), [] as Set)
+
+        then: "error is thrown"
+        exception = thrown()
+        exception instanceof UnsupportedOperationException
+    }
+
+    def "Data sources names in logging messages are comma separated"() {
+        given:
+        availability1.getAllAvailableIntervals() >> [:]
+        availability2.getAllAvailableIntervals() >> [:]
+
+        availabilitiesToMetricNames.put(availability1, [metric1] as Set)
+        availabilitiesToMetricNames.put(availability2, [metric2] as Set)
+
+        metricUnionAvailability = new MetricUnionAvailability(physicalTables.availability as Set, availabilitiesToMetricNames)
+
+        expect:
+        metricUnionAvailability.getDataSourceNamesAsString() == "source1, source2"
     }
 }


### PR DESCRIPTION
**This is not required at this moment, but open for possible future needs**
======================================================

Problem
======
https://github.com/yahoo/fili/issues/734

Solution
======
* A new "left-union" `Availability` called **`MetricLeftUnionAvailability`** is implemented. `MetricLeftUnionAvailability` behaves the same as `MetricUnionAvailability` except that the coalesced available intervals on this availability is determined by a single participating `Availability`, instead of all participating `Availabilities` as in `MetricUnionAvailability`. 
* Added a builder method to `MetricUnionAvailability` and `MetricLeftUnionAvailability` to save on needing to add additional table classes.

Addition
======
* A new "pure left-union" `Availability` called **`MetricPureLeftUnionAvailability`** is implemented. For the details of this Availability, please refer to the class description/Javadoc of it

### Miscellaneous
I found this issue while reading `Availability` interface - https://github.com/yahoo/fili/issues/735. This is not a blocker to this PR but this issue could cause serious runtime bug and needs some care as soon as possible.