### PR TITLE
Allow the customer to control the test logging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ pull request if there was one.
 
 ### Added:
 
+-- [An injection point for customizing the WebLoggingFilter to use during tests](https://github.com/yahoo/fili/pull/749)
+    * Extend `JerseyTestBinder` and override `getLoggingFilter`.
+
 - [An injection point for customizing Exception handling]https://github.com/yahoo/fili/pull/742)
     * Customers can provide their own logic for handling top level Exceptions in
       the `DataServlet` by implementing `DataExceptionHandler`, and any other

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/application/JerseyTestBinder.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/application/JerseyTestBinder.java
@@ -27,6 +27,7 @@ import com.yahoo.bard.webservice.metadata.TestDataSourceMetadataService;
 import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService;
 import com.yahoo.bard.webservice.web.FilteredSketchMetricsHelper;
 import com.yahoo.bard.webservice.web.MetricsFilterSetBuilder;
+import com.yahoo.bard.webservice.web.filters.BardLoggingFilter;
 import com.yahoo.bard.webservice.web.filters.TestLogWrapperFilter;
 
 import com.codahale.metrics.jersey2.InstrumentedResourceMethodApplicationListener;
@@ -136,7 +137,7 @@ public class JerseyTestBinder {
         // Order matters. First check if BardLoggingFilter is requested
         boolean skipWrapper = false;
         for (Class<?> cls : resourceClasses) {
-            if (cls.getSimpleName().equals("BardLoggingFilter")) {
+            if (cls.getSimpleName().equals(BardLoggingFilter.class.getSimpleName())) {
                 skipWrapper = true;
             }
         }
@@ -146,7 +147,7 @@ public class JerseyTestBinder {
         if (skipWrapper) {
             this.config.registerClasses(resourceClasses);
         } else {
-            this.config.register(TestLogWrapperFilter.class, 1);
+            this.config.register(getLoggingFilter(), 1);
             // Now register the requested classes
             for (Class<?> cls : resourceClasses) {
                 this.config.register(cls, 5);
@@ -172,6 +173,16 @@ public class JerseyTestBinder {
         if (doStart) {
             start();
         }
+    }
+
+    /**
+     * Allows a customer to customize which logging filter to use during testing if the `BardLoggingFilter` is not
+     * explicitly specified.
+     *
+     * @return The Class the customer is using as a LoggingFilter
+     */
+    protected Class<?> getLoggingFilter() {
+        return TestLogWrapperFilter.class;
     }
 
     /**


### PR DESCRIPTION
-- Currently we're using `TestLogWrapperFilter` to log requests
unless the `BardLoggingFilter` is requested. Some customers may
have a custom filter they'd like to use in their tests. They may even be
doing architecturally questionably things in that filter that they can't
test while two logging filters are present and both trying to dump the
RequestLog.

-- This allows a customer to specify a different LoggingFilter than the
BardLoggingFilter or TestLogWrapperFilter in a custom extension of the
JerseyTestBinder.
