### PR TITLE
Remove UriInfo from the ExceptionHandlers.

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/exception/DataExceptionHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/exception/DataExceptionHandler.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * Allows a customer to inject custom code for handling Exceptions in Fili's DataServlet.
@@ -29,7 +28,6 @@ public interface DataExceptionHandler {
      * @param apiRequest  A bean containing parsed information about the request, note that
      * this won't exist if an exception was thrown while constructing the request
      * @param containerRequestContext  HTTP request context
-     * @param uriInfo  URiInfo of the request
      * @param writer  A tool for serializing JSON
      */
     void handleThrowable(
@@ -37,7 +35,6 @@ public interface DataExceptionHandler {
         AsyncResponse asyncResponse,
         Optional<DataApiRequest> apiRequest,
         ContainerRequestContext containerRequestContext,
-        UriInfo uriInfo,
         ObjectWriter writer
     );
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliDataExceptionHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliDataExceptionHandler.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * The default implementation of {@link DataExceptionHandler}.
@@ -44,7 +43,6 @@ public class FiliDataExceptionHandler implements DataExceptionHandler {
             AsyncResponse asyncResponse,
             Optional<DataApiRequest> apiRequest,
             ContainerRequestContext containerRequestContext,
-            UriInfo uriInfo,
             ObjectWriter writer
     ) {
         if (e instanceof RequestValidationException) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliDimensionExceptionHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliDimensionExceptionHandler.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * Default implementation of the MetadataExceptionHandler for the DimensionServlet.
@@ -34,7 +33,6 @@ public class FiliDimensionExceptionHandler implements MetadataExceptionHandler {
     public Response handleThrowable(
         Throwable e,
         Optional<? extends ApiRequest> request,
-        UriInfo uriInfo,
         ContainerRequestContext requestContext
     ) {
         if (e instanceof RequestValidationException) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliJobsExceptionHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliJobsExceptionHandler.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * Handles exceptions for the JobsServlet.
@@ -42,7 +41,6 @@ public class FiliJobsExceptionHandler implements MetadataExceptionHandler {
     public Response handleThrowable(
             Throwable e,
             Optional<? extends ApiRequest> request,
-            UriInfo uriInfo,
             ContainerRequestContext requestContext
     ) {
         if (e instanceof RequestValidationException) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliMetricExceptionHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliMetricExceptionHandler.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * Default handler for exceptions in the MetricServlet.
@@ -28,7 +27,6 @@ public class FiliMetricExceptionHandler implements MetadataExceptionHandler {
     public Response handleThrowable(
             Throwable e,
             Optional<? extends ApiRequest> request,
-            UriInfo uriInfo,
             ContainerRequestContext requestContext
     ) {
         if (e instanceof RequestValidationException) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliSlicesExceptionHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliSlicesExceptionHandler.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * Default handler of Slices servlet errors.
@@ -26,7 +25,6 @@ public class FiliSlicesExceptionHandler implements MetadataExceptionHandler {
     public Response handleThrowable(
             Throwable e,
             Optional<? extends ApiRequest> request,
-            UriInfo uriInfo,
             ContainerRequestContext requestContext
     ) {
         if (e instanceof RequestValidationException) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliTablesExceptionHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/exception/FiliTablesExceptionHandler.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * Handles exceptions in the TablesEndpoint.
@@ -29,7 +28,6 @@ public class FiliTablesExceptionHandler implements MetadataExceptionHandler {
     public Response handleThrowable(
             Throwable e,
             Optional<? extends ApiRequest> request,
-            UriInfo uriInfo,
             ContainerRequestContext requestContext
     ) {
         if (e instanceof RequestValidationException) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/exception/MetadataExceptionHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/exception/MetadataExceptionHandler.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 
 /**
  * Like {@link DataExceptionHandler}, but handles the metadata endpoints.
@@ -25,7 +24,6 @@ public interface MetadataExceptionHandler {
      * @param e  The throwable to generate a Response for
      * @param request  The bean containing the parsed request, may be empty if an exception was thrown
      * during request construction
-     * @param uriInfo  The URI of the request
      * @param requestContext  HTTP request context for the request
      *
      * @return The Response to send to the user
@@ -33,7 +31,6 @@ public interface MetadataExceptionHandler {
     Response handleThrowable(
             Throwable e,
             Optional<? extends ApiRequest> request,
-            UriInfo uriInfo,
             ContainerRequestContext requestContext
     );
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
@@ -457,7 +457,6 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
                 asyncResponse,
                 Optional.ofNullable(apiRequest),
                 containerRequestContext,
-                uriInfo,
                 writer
             );
             // Generally, it's expected that implementations of `ExceptionHandler` will resume

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -157,7 +157,6 @@ public class DimensionsServlet extends EndpointServlet {
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     requestContext
             );
         } finally {
@@ -217,7 +216,6 @@ public class DimensionsServlet extends EndpointServlet {
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {
@@ -326,7 +324,6 @@ public class DimensionsServlet extends EndpointServlet {
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
@@ -197,7 +197,6 @@ public class JobsServlet extends EndpointServlet {
             observableResponse = Observable.just(exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     containerRequestContext
             ));
         } finally {
@@ -249,7 +248,6 @@ public class JobsServlet extends EndpointServlet {
             observableResponse = Observable.just(exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     containerRequestContext
             ));
         } finally {
@@ -329,7 +327,6 @@ public class JobsServlet extends EndpointServlet {
             observableResponse = Observable.just(exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     containerRequestContext
             ));
         } finally {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
@@ -151,7 +151,6 @@ public class MetricsServlet extends EndpointServlet {
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {
@@ -210,7 +209,6 @@ public class MetricsServlet extends EndpointServlet {
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
@@ -146,7 +146,6 @@ public class SlicesServlet extends EndpointServlet {
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {
@@ -214,7 +213,6 @@ public class SlicesServlet extends EndpointServlet {
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(apiRequest),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
@@ -206,7 +206,6 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(tablesApiRequestImpl),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {
@@ -271,7 +270,6 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(tablesApiRequestImpl),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {
@@ -360,7 +358,6 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(tablesApiRequest),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {
@@ -420,7 +417,6 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             return exceptionHandler.handleThrowable(
                     t,
                     Optional.ofNullable(tablesApiRequestImpl),
-                    uriInfo,
                     containerRequestContext
             );
         } finally {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliDataExceptionHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliDataExceptionHandlerSpec.groovy
@@ -39,7 +39,7 @@ class FiliDataExceptionHandlerSpec extends Specification {
         and: "A mock AsyncResponse to resume"
 
         when: "We handle the exception"
-        dataExceptionHandler.handleThrowable(exception, response, Optional.empty(), null, null, writer)
+        dataExceptionHandler.handleThrowable(exception, response, Optional.empty(), null,  writer)
 
         then: "The response is resumed"
         1 * response.resume(_) >> {
@@ -56,7 +56,7 @@ class FiliDataExceptionHandlerSpec extends Specification {
         NoMatchFoundException exception = new NoMatchFoundException("NoMatch")
 
         when:
-        dataExceptionHandler.handleThrowable(exception, response, Optional.empty(), null, null, writer)
+        dataExceptionHandler.handleThrowable(exception, response, Optional.empty(), null,  writer)
 
         then:
         1 * response.resume(_) >> {
@@ -71,7 +71,7 @@ class FiliDataExceptionHandlerSpec extends Specification {
         TimeoutException exception = new TimeoutException("Timeout")
 
         when:
-        dataExceptionHandler.handleThrowable(exception, response, Optional.empty(), null, null, writer)
+        dataExceptionHandler.handleThrowable(exception, response, Optional.empty(), null,  writer)
 
         then:
         1 * response.resume(_) >> {
@@ -86,7 +86,7 @@ class FiliDataExceptionHandlerSpec extends Specification {
         Throwable throwable = new Throwable("Throw")
 
         when:
-        dataExceptionHandler.handleThrowable(throwable, response, Optional.empty(), null, null, writer)
+        dataExceptionHandler.handleThrowable(throwable, response, Optional.empty(), null,  writer)
 
         then:
         1 * response.resume(_) >> {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliDimensionExceptionHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliDimensionExceptionHandlerSpec.groovy
@@ -43,7 +43,7 @@ class FiliDimensionExceptionHandlerSpec extends Specification {
         RequestValidationException exception = new RequestValidationException(status, "Error", "Error")
 
         when:
-        Response response = dimensionExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = dimensionExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == status.statusCode
@@ -58,7 +58,7 @@ class FiliDimensionExceptionHandlerSpec extends Specification {
         RowLimitReachedException exception = new RowLimitReachedException("RowLimit")
 
         when:
-        Response response = dimensionExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = dimensionExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == ResponseCode.INSUFFICIENT_STORAGE.statusCode
@@ -70,7 +70,7 @@ class FiliDimensionExceptionHandlerSpec extends Specification {
         JsonProcessingException exception = new JsonProcessingException("JsonError")
 
         when:
-        Response response = dimensionExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = dimensionExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == Response.Status.INTERNAL_SERVER_ERROR.statusCode
@@ -82,7 +82,7 @@ class FiliDimensionExceptionHandlerSpec extends Specification {
         Throwable throwable = new Throwable("Throw")
 
         when:
-        Response response = dimensionExceptionHandler.handleThrowable(throwable, request, null, null)
+        Response response = dimensionExceptionHandler.handleThrowable(throwable, request, null)
 
         then:
         response.status == Response.Status.BAD_REQUEST.statusCode

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliJobsExceptionHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliJobsExceptionHandlerSpec.groovy
@@ -42,7 +42,7 @@ class FiliJobsExceptionHandlerSpec extends Specification {
         RequestValidationException exception = new RequestValidationException(status, "Error", "Error")
 
         when:
-        Response response = jobsExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = jobsExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == status.statusCode
@@ -57,7 +57,7 @@ class FiliJobsExceptionHandlerSpec extends Specification {
         Throwable throwable = new Throwable("Throw")
 
         when:
-        Response response = jobsExceptionHandler.handleThrowable(throwable, request, null, null)
+        Response response = jobsExceptionHandler.handleThrowable(throwable, request, null)
 
         then:
         response.status == Response.Status.INTERNAL_SERVER_ERROR.statusCode

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliMetricExceptionHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliMetricExceptionHandlerSpec.groovy
@@ -49,7 +49,7 @@ class FiliMetricExceptionHandlerSpec extends Specification {
         RequestValidationException exception = new RequestValidationException(status, "Error", "Error")
 
         when:
-        Response response = metricsExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = metricsExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == status.statusCode
@@ -64,7 +64,7 @@ class FiliMetricExceptionHandlerSpec extends Specification {
         IOException exception = new IOException("IOException")
 
         when:
-        Response response = metricsExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = metricsExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == Response.Status.INTERNAL_SERVER_ERROR.statusCode
@@ -76,7 +76,7 @@ class FiliMetricExceptionHandlerSpec extends Specification {
         Throwable throwable = new Throwable("Throw")
 
         when:
-        Response response = metricsExceptionHandler.handleThrowable(throwable, request, null, null)
+        Response response = metricsExceptionHandler.handleThrowable(throwable, request, null)
 
         then:
         response.status == Response.Status.BAD_REQUEST.statusCode

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliSlicesExceptionHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliSlicesExceptionHandlerSpec.groovy
@@ -22,7 +22,7 @@ class FiliSlicesExceptionHandlerSpec extends Specification {
         RequestValidationException exception = new RequestValidationException(status, "Error", "Error")
 
         when:
-        Response response = slicesExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = slicesExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == status.statusCode
@@ -37,7 +37,7 @@ class FiliSlicesExceptionHandlerSpec extends Specification {
         IOException exception = new IOException("IOException")
 
         when:
-        Response response = slicesExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = slicesExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == Response.Status.INTERNAL_SERVER_ERROR.statusCode
@@ -49,7 +49,7 @@ class FiliSlicesExceptionHandlerSpec extends Specification {
         Throwable throwable = new Throwable("Throw")
 
         when:
-        Response response = slicesExceptionHandler.handleThrowable(throwable, request, null, null)
+        Response response = slicesExceptionHandler.handleThrowable(throwable, request, null)
 
         then:
         response.status == Response.Status.INTERNAL_SERVER_ERROR.statusCode

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliTablesExceptionHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/exception/FiliTablesExceptionHandlerSpec.groovy
@@ -47,7 +47,7 @@ class FiliTablesExceptionHandlerSpec extends Specification {
         RequestValidationException exception = new RequestValidationException(status, "Error", "Error")
 
         when:
-        Response response = tablesExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = tablesExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == status.statusCode
@@ -62,7 +62,7 @@ class FiliTablesExceptionHandlerSpec extends Specification {
         JsonProcessingException exception = new JsonProcessingException("JsonError")
 
         when:
-        Response response = tablesExceptionHandler.handleThrowable(exception, request, null, null)
+        Response response = tablesExceptionHandler.handleThrowable(exception, request, null)
 
         then:
         response.status == Response.Status.INTERNAL_SERVER_ERROR.statusCode
@@ -74,7 +74,7 @@ class FiliTablesExceptionHandlerSpec extends Specification {
         Throwable throwable = new Throwable("Throw")
 
         when:
-        Response response = tablesExceptionHandler.handleThrowable(throwable, request, null, null)
+        Response response = tablesExceptionHandler.handleThrowable(throwable, request, null)
 
         then:
         response.status == Response.Status.BAD_REQUEST.statusCode


### PR DESCRIPTION
-- The `UriInfo` is included in the `ContainerRequestContext`, so it
doesn't need to be explicitly passed to an `ExceptionHandler`.

-- Technically, we should probably do the deprecation dance, but this
has been out for less than a day, so the impact is going to be
non-existent.