### PR TITLE
Handle empty expected string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ pull request if there was one.
 
 ### Fixed:
 
+- [Fix GroovyTestUtils json parsing](https://github.com/yahoo/fili/pull/760)
+    * Properly handles json parsing failures and non-JSON expected strings.
+
 - [Fix generate intervals logic when availability is empty](https://github.com/yahoo/fili/pull/702)
     * Logic to generate intervals when `CURRENT_MACRO_USES_LATEST` flag is turned on has a bug. The code throws `NoSuchElementException` when the table has no availabilities. This PR fixes the bug by checking if the availability of the underlying table is empty.
 - [Correct Druid coordinator URL in Wikipedia example](https://github.com/yahoo/fili/pull/683)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/GroovyTestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/util/GroovyTestUtils.groovy
@@ -6,6 +6,7 @@ import static com.yahoo.bard.webservice.util.JsonSortStrategy.SORT_MAPS
 
 import com.yahoo.bard.webservice.application.ObjectMappersSuite
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 
@@ -33,6 +34,11 @@ abstract class GroovyTestUtils extends Specification {
      * @see <a href="http://json.org/">JSON.org</a>
      */
     static boolean compareJson(String actual, String expected, JsonSortStrategy sortStrategy = SORT_MAPS) {
+        if (actual.equals(expected)) {
+            // Objects match, all is well
+            return true
+        }
+
         try {
             // Parse the JSON strings into objects
             //Use two separate slurpers because slurper optimizations mean that the two parsed maps will share
@@ -119,7 +125,7 @@ abstract class GroovyTestUtils extends Specification {
 
             // Use power assert against strings to get comparisons
             assert actualText == expectedText
-        } catch (JsonException e) {
+        } catch (JsonProcessingException | JsonException e) {
             LOG.warn("Unable to parse JSON", e)
 
             // Compare the inputs to get a sense of what went wrong


### PR DESCRIPTION
One of my tests is expecting a bad return code before Druid is called.  Since the expected query is empty, the GroovyTestUtils incorrectly fails by trying to parse the empty string.

If the actual an expected are the same, the compare should be true without having to parse as JSON.

Also found the JSON parsing failed with a Jackson exception, not a Groovy exception.  Now handles both kinds.