### PR TITLE
Ignore empty post-aggs serialization

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/AbstractDruidAggregationQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/AbstractDruidAggregationQuery.java
@@ -33,7 +33,7 @@ public abstract class AbstractDruidAggregationQuery<Q extends AbstractDruidAggre
     // At least one is needed
     protected final Collection<Aggregation> aggregations;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     protected final Collection<PostAggregation> postAggregations;
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuery.java
@@ -77,7 +77,6 @@ import java.util.List;
  *        "type": "longSum"
  *      }
  *    ],
- *    "postAggregations": [],
  *    "intervals": [
  *      "2014-09-01T00:00:00.000Z/2014-09-30T00:00:00.000Z"
  *    ],

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/RequestHandlerUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/RequestHandlerUtils.java
@@ -88,7 +88,6 @@ public class RequestHandlerUtils {
      *         "aggregations" : [
      *             { "name" : "pageViews", "fieldName" : "other_page_views", "type" : "longSum" }
      *         ],
-     *         "postAggregations" : [ ],
      *         "intervals" : [ "2014-06-01T00:00:00.000Z/2014-06-01T00:00:00.000Z" ],
      *         "granularity" : { "type" : "period", "period" : "P1W" }
      *     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/NonNumericMetricSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/NonNumericMetricSpec.groovy
@@ -72,7 +72,6 @@ class NonNumericMetricSpec extends BaseDataServletComponentSpec {
                         "type": "min"
                     }
                 ],
-                "postAggregations": [],
                 "context": {}
             }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/GroupByQuerySpec.groovy
@@ -152,6 +152,19 @@ class GroupByQuerySpec extends Specification {
         vars.postAggregations = vars.postAggregations ?: "[]"
         vars.intervals = vars.intervals ?: "[]"
 
+        vars.postAggregations == "[]" ?
+        """
+        {
+            "queryType":"$vars.queryType",
+            "dataSource":$vars.dataSource,
+            "granularity":$vars.granularity,
+            "dimensions":$vars.dimensions,
+            $vars.filter
+            "aggregations":$vars.aggregations,
+            "intervals":$vars.intervals,
+            "context":$vars.context
+        }
+        """ :
         """
         {
             "queryType":"$vars.queryType",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/LookbackQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/LookbackQuerySpec.groovy
@@ -149,11 +149,22 @@ class LookbackQuerySpec extends Specification {
         vars.context = vars.context ?
                 /{"queryId":"dummy100",$vars.context}/ :
                 /{"queryId": "dummy100"}/
-        vars.postAggregations = vars.postAggregations ?: "[]"
         vars.lookbackOffsets = vars.lookbackOffsets ?: [""" "P-1D" """]
         String lookback = /"lookbackPrefixes": $vars.lookbackPrefixes,/
+        vars.postAggregations = vars.postAggregations ?: "[]"
         vars.lookbackPrefixes = vars.lookbackPrefixes != null ? lookback : ""
 
+        vars.postAggregations == [] ?
+        """
+            {
+                "queryType":"$vars.queryType",
+                "dataSource":$vars.dataSource,
+                "context":$vars.context,
+                $vars.lookbackPrefixes
+                
+                "lookbackOffsets":$vars.lookbackOffsets
+            }
+        """.replaceAll(/\s/, "") :
         """
             {
                 "queryType":"$vars.queryType",
@@ -163,7 +174,7 @@ class LookbackQuerySpec extends Specification {
                 "postAggregations":$vars.postAggregations,
                 "lookbackOffsets":$vars.lookbackOffsets
             }
-        """
+        """.replaceAll(/\s/, "")
     }
 
     def "check Lookback query with Timeseries datasource serialization"() {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TimeSeriesQuerySpec.groovy
@@ -88,7 +88,6 @@ class TimeSeriesQuerySpec extends Specification {
             $vars.filter
             "context":$vars.context,
             "aggregations":$vars.aggregations,
-            "postAggregations":$vars.postAggregations,
             "intervals":$vars.intervals
         }
         """

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TopNQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/TopNQuerySpec.groovy
@@ -100,7 +100,6 @@ class TopNQuerySpec extends Specification {
                 "granularity":$vars.granularity,
                 $vars.filter
                 "aggregations":$vars.aggregations,
-                "postAggregations":$vars.postAggregations,
                 "intervals":$vars.intervals,
                 "context":$vars.context
             }""").replaceAll(/\s/, "")

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/VolatilityTableSelectionSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/table/availability/VolatilityTableSelectionSpec.groovy
@@ -79,8 +79,7 @@ class VolatilityTableSelectionSpec extends BaseDataServletComponentSpec {
                             "fieldName": "limbs",
                             "type": "longSum"
                         }
-                ],
-                "postAggregations": []
+                ]
             }
         """
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/RequestUtils.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/RequestUtils.groovy
@@ -118,7 +118,6 @@ class RequestUtils {
             },
             "dimensions": [],
             "aggregations": [],
-            "postAggregations": [],
             "intervals": [],
             "granularity": {
               "type": "period",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDimensionShowClauseDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDimensionShowClauseDataServletSpec.groovy
@@ -46,7 +46,6 @@ abstract class BaseDimensionShowClauseDataServletSpec extends BaseDataServletCom
             "aggregations": [
                 { "name": "width", "fieldName": "width", "type": "longSum" }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/CsvEndpointDataServletMultiDimensionsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/CsvEndpointDataServletMultiDimensionsSpec.groovy
@@ -72,7 +72,6 @@ class CsvEndpointDataServletMultiDimensionsSpec extends BaseDataServletComponent
                     "type": "longSum"
                 }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/CsvEndpointDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/CsvEndpointDataServletSpec.groovy
@@ -60,7 +60,6 @@ class CsvEndpointDataServletSpec extends BaseDataServletComponentSpec {
             "aggregations": [
                 { "name": "width", "fieldName": "width", "type": "longSum" }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DataPaginationSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DataPaginationSpec.groovy
@@ -63,7 +63,6 @@ class DataPaginationSpec extends BaseDataServletComponentSpec {
               "aggregations": [
                     { "name": "height", "fieldName": "height", "type": "longSum" }
               ],
-              "postAggregations": [],
               "context": {}
             }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DataServletContextsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DataServletContextsSpec.groovy
@@ -45,7 +45,6 @@ class DataServletContextsSpec extends Specification {
                     "fieldName" : "height",
                     "type" : "longSum"
                 } ],
-                "postAggregations" : [ ],
                 "intervals" : [ "2014-09-01T00:00:00.000Z/2014-09-08T00:00:00.000Z" ],
                 "granularity": ${BaseDataServletComponentSpec.getTimeGrainString("week")},
                 "context": {}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DataServletTimezoneSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DataServletTimezoneSpec.groovy
@@ -51,7 +51,6 @@ class DataServletTimezoneSpec extends Specification {
                     "fieldName" : "limbs",
                     "type" : "longSum"
                 } ],
-                "postAggregations" : [ ],
                 "intervals" : [ "%s" ],
                 "granularity" : {
                     "type" : "period",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DateTimeSortAscOrderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DateTimeSortAscOrderSpec.groovy
@@ -56,7 +56,6 @@ class DateTimeSortAscOrderSpec extends BaseDataServletComponentSpec {
                         "type": "longSum"
                     }
                 ],
-                "postAggregations": [],
                 "intervals": ["2014-06-02T00:00:00.000Z/2014-06-30T00:00:00.000Z"],
                  "limitSpec": {
                 "columns": [

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DateTimeSortDescOrderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DateTimeSortDescOrderSpec.groovy
@@ -56,7 +56,6 @@ class DateTimeSortDescOrderSpec extends BaseDataServletComponentSpec {
                         "type": "longSum"
                     }
                 ],
-                "postAggregations": [],
                 "intervals": ["2014-06-02T00:00:00.000Z/2014-06-30T00:00:00.000Z"],
                  "limitSpec": {
                 "columns": [

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DebugDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DebugDataServletSpec.groovy
@@ -89,7 +89,6 @@ class DebugDataServletSpec extends Specification {
                 "intervals": [
                   "2014-06-02T00:00:00.000Z/2014-06-03T00:00:00.000Z"
                 ],
-                "postAggregations": [],
                 "queryType": "groupBy",
                 "context": {}
               },

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DruidLimitSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DruidLimitSpec.groovy
@@ -58,7 +58,6 @@ class DruidLimitSpec extends BaseDataServletComponentSpec {
                         "type": "longSum"
                     }
                 ],
-                "postAggregations": [],
                 "intervals": ["2014-06-02T00:00:00.000Z/2014-06-30T00:00:00.000Z"],
                 "limitSpec": {
                     "type": "default",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DruidOrderBySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DruidOrderBySpec.groovy
@@ -57,7 +57,6 @@ class DruidOrderBySpec extends BaseDataServletComponentSpec {
                         "type": "longSum"
                     }
                 ],
-                "postAggregations": [],
                 "intervals": ["2014-06-02T00:00:00.000Z/2014-06-30T00:00:00.000Z"],
                 "limitSpec": {
                     "type": "default",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DruidOrderByWithLimitSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DruidOrderByWithLimitSpec.groovy
@@ -57,7 +57,6 @@ class DruidOrderByWithLimitSpec extends BaseDataServletComponentSpec {
                         "type": "longSum"
                     }
                 ],
-                "postAggregations": [],
                 "intervals": ["2014-06-02T00:00:00.000Z/2014-06-30T00:00:00.000Z"],
                 "limitSpec": {
                     "type": "default",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
@@ -84,7 +84,6 @@ class ErrorDataServletSpec extends Specification {
         "fieldName" : "depth",
         "type" : "longSum"
     } ],
-    "postAggregations" : [],
     "intervals" : [ "2014-09-01T00:00:00.000Z/2014-09-08T00:00:00.000Z" ],
     "granularity": ${BaseDataServletComponentSpec.getTimeGrainString("week")},
     "context" : {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/LookupDimensionGroupingDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/LookupDimensionGroupingDataServletSpec.groovy
@@ -99,7 +99,6 @@ class LookupDimensionGroupingDataServletSpec extends BaseDataServletComponentSpe
             ],
             "granularity": { "period": "P1D", "timeZone": "UTC", "type": "period" },
             "intervals": ["2014-05-01T00:00:00.000Z/2014-05-02T00:00:00.000Z"],
-            "postAggregations": [],
             "queryType": "groupBy"
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/LookupDimensionGroupingFilteringDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/LookupDimensionGroupingFilteringDataServletSpec.groovy
@@ -230,7 +230,6 @@ class LookupDimensionGroupingFilteringDataServletSpec extends BaseDataServletCom
                 "timeZone": "UTC",
                 "type": "period" },
                 "intervals": ["2014-05-01T00:00:00.000Z/2014-05-02T00:00:00.000Z"],
-                "postAggregations": [],
                 "queryType": "groupBy"
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/MultipleDimensionSingleSimpleMetricDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/MultipleDimensionSingleSimpleMetricDataServletSpec.groovy
@@ -97,7 +97,6 @@ class MultipleDimensionSingleSimpleMetricDataServletSpec extends BaseDataServlet
               "aggregations": [
                     { "name": "width", "fieldName": "width", "type": "longSum" }
               ],
-              "postAggregations": [],
               "context": {}
             }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/MultipleMetricHavingDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/MultipleMetricHavingDataServletSpec.groovy
@@ -89,7 +89,6 @@ class MultipleMetricHavingDataServletSpec extends BaseDataServletComponentSpec {
             "intervals": [
                 "2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"
             ],
-            "postAggregations": [],
             "queryType": "groupBy",
             "context": {}
         }"""

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NestedDisjunctionHavingDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NestedDisjunctionHavingDataServletSpec.groovy
@@ -106,7 +106,6 @@ class NestedDisjunctionHavingDataServletSpec extends BaseDataServletComponentSpe
             "intervals": [
                 "2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"
             ],
-            "postAggregations": [],
             "queryType": "groupBy",
             "context": {}
         }"""

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionMultipleSimpleMetricDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionMultipleSimpleMetricDataServletSpec.groovy
@@ -39,7 +39,6 @@ class NoDimensionMultipleSimpleMetricDataServletSpec extends BaseDataServletComp
                   "fieldName" : "width",
                   "type" : "longSum"
               } ],
-              "postAggregations" : [],
               "intervals" : [ "2014-06-02T00:00:00.000Z/2014-06-04T00:00:00.000Z" ],
               "granularity": ${getTimeGrainString()},
               "context": {}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionNoTrailingSlashFilterDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionNoTrailingSlashFilterDataServletSpec.groovy
@@ -36,7 +36,6 @@ class NoDimensionNoTrailingSlashFilterDataServletSpec extends BaseDataServletCom
             "aggregations": [
                 { "name": "width", "fieldName": "width", "type": "longSum" }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionTrailingSlashFilterDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionTrailingSlashFilterDataServletSpec.groovy
@@ -36,7 +36,6 @@ class NoDimensionTrailingSlashFilterDataServletSpec extends BaseDataServletCompo
             "aggregations": [
                 { "name": "width", "fieldName": "width", "type": "longSum" }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoRowsDimensionDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoRowsDimensionDataServletSpec.groovy
@@ -60,7 +60,6 @@ class NoRowsDimensionDataServletSpec extends BaseDataServletComponentSpec {
             "aggregations": [
                 { "name": "width", "fieldName": "width", "type": "longSum" }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NullDimensionIDDruidResponseDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NullDimensionIDDruidResponseDataServletSpec.groovy
@@ -69,7 +69,6 @@ class NullDimensionIDDruidResponseDataServletSpec extends BaseDataServletCompone
               "aggregations": [
                     { "name": "width", "fieldName": "width", "type": "longSum" }
               ],
-              "postAggregations": [],
               "context": {}
             }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/RowNumSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/RowNumSpec.groovy
@@ -51,7 +51,6 @@ class RowNumSpec extends BaseDataServletComponentSpec {
                         "type": "longSum"
                     }
                 ],
-                "postAggregations": [],
                 "intervals": ["2014-06-02T00:00:00.000Z/2014-06-30T00:00:00.000Z"],
                 "limitSpec": {
                     "type": "default",

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ScopedMetricHavingDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ScopedMetricHavingDataServletSpec.groovy
@@ -69,7 +69,6 @@ class ScopedMetricHavingDataServletSpec extends BaseDataServletComponentSpec {
                 "intervals": [
                     "2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"
                 ],
-                "postAggregations": [],
                 "queryType": "groupBy",
                 "context": {}
         }"""

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SingleDimensionNoRowsFilterDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SingleDimensionNoRowsFilterDataServletSpec.groovy
@@ -102,7 +102,6 @@ class SingleDimensionNoRowsFilterDataServletSpec extends BaseDataServletComponen
             "aggregations": [
                 { "name": "width", "fieldName": "width", "type": "longSum" }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SingleDimensionSimpleFilterDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SingleDimensionSimpleFilterDataServletSpec.groovy
@@ -76,7 +76,6 @@ class SingleDimensionSimpleFilterDataServletSpec extends BaseDataServletComponen
             "aggregations": [
                 { "name": "width", "fieldName": "width", "type": "longSum" }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SingleDimensionSingleSimpleMetricDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SingleDimensionSingleSimpleMetricDataServletSpec.groovy
@@ -75,7 +75,6 @@ class SingleDimensionSingleSimpleMetricDataServletSpec extends BaseDataServletCo
               "aggregations": [
                     { "name": "width", "fieldName": "width", "type": "longSum" }
               ],
-              "postAggregations": [],
               "context": {}
             }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SingleMetricHavingDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SingleMetricHavingDataServletSpec.groovy
@@ -69,7 +69,6 @@ class SingleMetricHavingDataServletSpec extends BaseDataServletComponentSpec {
                 "intervals": [
                     "2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"
                 ],
-                "postAggregations": [],
                 "queryType": "groupBy",
                 "context": {}
         }"""

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SketchWholeNumSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/SketchWholeNumSpec.groovy
@@ -63,7 +63,6 @@ class SketchWholeNumSpec extends BaseDataServletComponentSpec {
             "intervals": [
                 "2014-06-02T00:00:00.000Z/2014-06-30T00:00:00.000Z"
         ],
-            "postAggregations": [],
             "queryType": "groupBy",
             "context": {}
         }"""

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TimeSeriesWithHavingDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TimeSeriesWithHavingDataServletSpec.groovy
@@ -73,7 +73,6 @@ class TimeSeriesWithHavingDataServletSpec extends BaseDataServletComponentSpec {
                     { "name": "width", "fieldName": "width", "type": "longSum" },
                     { "name": "height", "fieldName": "height", "type": "longSum" }
                 ],
-                "postAggregations": [],
                 "having": {
                     "havingSpecs": [
                         {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNAscendingDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNAscendingDataServletSpec.groovy
@@ -109,7 +109,6 @@ class TopNAscendingDataServletSpec extends BaseDataServletComponentSpec {
             "aggregations": [
                 { "name": "width", "fieldName": "width", "type": "longSum" }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNAscendingMultipleDimensionsDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNAscendingMultipleDimensionsDataServletSpec.groovy
@@ -114,7 +114,6 @@ class TopNAscendingMultipleDimensionsDataServletSpec extends BaseDataServletComp
                 "aggregations": [
                     { "name": "width", "fieldName": "width", "type": "longSum" }
                 ],
-                "postAggregations": [],
                 "limitSpec": {
                     "type": "default",
                     "columns": [

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNDataServletSpec.groovy
@@ -107,7 +107,6 @@ class TopNDataServletSpec extends BaseDataServletComponentSpec {
             "aggregations": [
                 { "name": "width", "fieldName": "width", "type": "longSum" }
             ],
-            "postAggregations": [],
             "context": {}
         }"""
     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNMultipleDimensionsDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNMultipleDimensionsDataServletSpec.groovy
@@ -115,7 +115,6 @@ class TopNMultipleDimensionsDataServletSpec extends BaseDataServletComponentSpec
                 "aggregations": [
                     { "name": "width", "fieldName": "width", "type": "longSum" }
                 ],
-                "postAggregations": [],
                 "limitSpec": {
                     "type": "default",
                     "columns": [

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNWithHavingDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/TopNWithHavingDataServletSpec.groovy
@@ -108,7 +108,6 @@ class TopNWithHavingDataServletSpec extends BaseDataServletComponentSpec {
                     { "name": "width", "fieldName": "width", "type": "longSum" },
                     { "name": "height", "fieldName": "height", "type": "longSum" }
                 ],
-                "postAggregations": [],
                 "having": {
                     "havingSpecs": [
                         {

--- a/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SingleDimensionMultipleComplexMetricDataServletSpec.groovy
+++ b/fili-generic-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SingleDimensionMultipleComplexMetricDataServletSpec.groovy
@@ -120,7 +120,6 @@ class SingleDimensionMultipleComplexMetricDataServletSpec extends BaseDataServle
           "intervals": [
             "2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"
           ],
-          "postAggregations": [],
           "queryType": "groupBy"
     }"""
     }

--- a/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SingleDimensionMultipleComplexMetricDataServletSpec.groovy
+++ b/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SingleDimensionMultipleComplexMetricDataServletSpec.groovy
@@ -123,7 +123,6 @@ class SingleDimensionMultipleComplexMetricDataServletSpec extends BaseDataServle
           "intervals": [
             "2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"
           ],
-          "postAggregations": [],
           "queryType": "groupBy"
     }"""
     }


### PR DESCRIPTION
Address issue https://github.com/yahoo/fili/issues/762

If API request does not need any post aggs, then serialized query will not include it in this PR