### PR TITLE
Removes static on a bunch of helper methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ pull request if there was one.
 
 ### Changed:
 
+- [Make ConjunctionDruidFilterBuilder's protected helper methods instance methods](https://github.com/yahoo/fili/issues/792)
+
 - [Widen access privileges to suppress IDE warnings](https://github.com/yahoo/fili/issues/785)
 
 - [Extract logic for getting pagination of dimension rows](https://github.com/yahoo/fili/issues/782)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/filterbuilders/ConjunctionDruidFilterBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/filterbuilders/ConjunctionDruidFilterBuilder.java
@@ -113,7 +113,7 @@ public abstract class ConjunctionDruidFilterBuilder implements DruidFilterBuilde
      *
      * @return a pair whose left is positive filter and whose right is negative filers
      */
-    protected static Pair<Set<ApiFilter>, Set<ApiFilter>> splitApiFilters(Set<ApiFilter> filters) {
+    protected Pair<Set<ApiFilter>, Set<ApiFilter>> splitApiFilters(Set<ApiFilter> filters) {
         Set<ApiFilter> positiveFilters = new HashSet<>();
         Set<ApiFilter> negativeFilters = new HashSet<>();
 
@@ -144,7 +144,7 @@ public abstract class ConjunctionDruidFilterBuilder implements DruidFilterBuilde
      *
      * @return a stream of the negated filters
      */
-    protected static Set<ApiFilter> negateNegativeFilters(Collection<ApiFilter> negativeFilters) {
+    protected Set<ApiFilter> negateNegativeFilters(Collection<ApiFilter> negativeFilters) {
         return negativeFilters.stream()
                 // TODO - refactor this and next map when more than 1 not* FilterOperations are supported.
                 .peek(filter -> {
@@ -168,7 +168,7 @@ public abstract class ConjunctionDruidFilterBuilder implements DruidFilterBuilde
      *
      * @throws DimensionRowNotFoundException if the filters filter out all dimension rows
      */
-    protected static List<String> getFilteredDimensionRowValues(Dimension dimension, Set<ApiFilter> filters)
+    protected List<String> getFilteredDimensionRowValues(Dimension dimension, Set<ApiFilter> filters)
             throws DimensionRowNotFoundException {
         return getFilteredDimensionRows(dimension, filters).stream()
                 .map(DimensionRow::getKeyValue)
@@ -185,7 +185,7 @@ public abstract class ConjunctionDruidFilterBuilder implements DruidFilterBuilde
      *
      * @throws DimensionRowNotFoundException if the filters filter out all dimension rows
      */
-    protected static Set<DimensionRow> getFilteredDimensionRows(Dimension dimension, Set<ApiFilter> filters)
+    protected Set<DimensionRow> getFilteredDimensionRows(Dimension dimension, Set<ApiFilter> filters)
             throws DimensionRowNotFoundException {
         Set<DimensionRow> rows = dimension.getSearchProvider().findFilteredDimensionRows(filters);
 
@@ -206,7 +206,7 @@ public abstract class ConjunctionDruidFilterBuilder implements DruidFilterBuilde
      *
      * @return a list of Druid selector filters
      */
-    protected static List<Filter> buildSelectorFilters(Dimension dimension, Set<DimensionRow> rows) {
+    protected List<Filter> buildSelectorFilters(Dimension dimension, Set<DimensionRow> rows) {
 
         Function<DimensionRow, Filter> filterBuilder = row -> new SelectorFilter(
                 dimension,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/filterbuilders/DruidInFilterBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/filterbuilders/DruidInFilterBuilder.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  * negative API filters are grouped in the other in-filter wrapped in the not-filter.
  * <p>
  * For example, suppose a dimension {@code D} has dimension rows {@code 1}, {@code 2}, {@code 3}, {@code 4}, {@code 5}.
- * A filter clause in in a request like {@code D|id-in[1, 2],D|id-notin[4, 5]} results in an and-filter by
+ * A filter clause in a request like {@code D|id-in[1, 2],D|id-notin[4, 5]} results in an and-filter by
  * {@code DruidInFilterBuilder}: {@code AND(IN(1, 2), NOT(IN(4, 5)))}. This and-filter is a conjunction of a in-filter
  * and another in-filter wrapped in a not-filter.
  * <p>


### PR DESCRIPTION
-- The ConjunctionDruidFilterBuilder has a whole bunch of protected
helper methods that are meant to be used only by it and its children.
However, those methods are all static, meaning they can't be overridden
by customers. This makes the ConjunctionDruidFilterBuilder *very* rigid,
and removes a lot of the benefit of having protected helper methods for
each step in the first place.

-- This PR makes those helper methods instance methods.

-- It also corrects a typo in the DruidInFilterBuilder documentation.