### PR TITLE
Add filename parameter to data queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,22 @@ Current
 
 ### Added:
 
+- [Added filename parameter to api query](https://github.com/yahoo/fili/issues/709)
+  * If the filename parameter is present in the request the response is assumed to be downloaded with the provided 
+  filename. The download format depends on the format provided to the format parameter. 
+  * Filename parameter is currently only available to data queries.
+
 ### Changed:
+
+- [ResponseFormatType now contains information relevant to generating response headers associated with response format](https://github.com/yahoo/fili/issues/709)
+  * `ResponseFormatType` interface exposes `getCharset()`, `getFileExtension()`, and `getContentType()` methods which 
+  provide information used to build response headers
+  
+- [ApiRequest interfaces exposes getDownloadFilename method](https://github.com/yahoo/fili/issues/709)
+  * `ApiRequestImpl` and other classes relating to the construction of `DataApiRequest` implementations have had 
+  new constructors added to handle the filename.
+  * Constructors that don't handle filename are now deprecated.
+
 - [Added config property for SSL cipher suites](https://github.com/yahoo/fili/issues/831)
 
 - [Updated asynch http dependency to resolve security issues](https://github.com/yahoo/fili/issues/821)
@@ -99,6 +114,15 @@ Current
 ### Known Issues:
 
 ## Contract changes:
+
+- [ResponseUtils is now responsible for generating response headers](https://github.com/yahoo/fili/issues/709)
+  * `ResponseUtils` now generates the Content-Type header and the Content-Disposition header if relevant.
+  * `ResponseUtils` handles all format types instead of just building the Content-Disposition header value for CSV
+  responses
+
+- [Response is assumed to be rendered in the browser unless a filename is provided](https://github.com/yahoo/fili/issues/709)
+  * `ResponseUtils` takes a list of formats that default to download. This list can be changed or overridden
+  * By default CSV is added to the default to download list. This is to maintain backwards compatibility
 
 - [ApiRequest.getApiDruidFilters() must now not be null]()
 

--- a/docs/end-user-api.md
+++ b/docs/end-user-api.md
@@ -24,6 +24,7 @@ Table of Contents
 - [Query Options](#query-options)
     - [Pagination / Limit](#pagination--limit)
     - [Response Format](#response-format)
+    - [Filename](#filename)
     - [Filtering](#filtering)
     - [Having](#having)
     - [Sorting](#sorting)
@@ -227,6 +228,7 @@ supported, and how the use the options:
 
 - [Pagination / Limit](#pagination--limit)
 - [Response Format](#response-format)
+- [Filename](#filename)
 - [Filtering](#filtering)
 - [Having](#having)
 - [Dimension Field Selection](#dimension-field-selection)
@@ -400,6 +402,19 @@ dateTime,gender|id,gender|desc,pageViews
     ]
 }
 ```
+
+### Filename ###
+
+The default naming formula can produce attachments with long, hard to parse names. Fili provides the `filename` query
+string parameter, which specifies a filename for the result attachment to be downloaded as. The format of the attachment
+is determined by the `format` parameter defined above. As such, do not provide a file extension to the `filename` query.
+
+For example, the [query](https://sampleapp.fili.io/v1/data/network/day/gender?metrics=pageViews&dateTime=2014-09-01/2014-09-02&format=json&filename=data): `GET https://sampleapp.fili.io/v1/data/network/day/gender?metrics=pageViews&dateTime=2014-09-01/2014-09-02&format=json&filename=data`
+
+downloads an attachment `data.json`
+
+The presence of the `filename` parameter indicates that the response should be downloaded as an attachment. Otherwise 
+the response is rendered by the browser. The exception to this is the CSV format, which is always downloaded.
 
 ### Filtering ###
 
@@ -678,13 +693,16 @@ If the ticket is not available in the system, we get a 404 error with the messag
 The user may access the results of a query by sending a `GET` request to `jobs/TICKET/results`. This
 resource takes the following parameters:
 
- 1. **`format`** - Allows the user to specify a response format, i.e. csv, or JSON. This behaves
+1. **`format`** - Allows the user to specify a response format, i.e. csv, or JSON. This behaves
 just like the [`format`](#response-format) parameter on queries sent to the `data` endpoint.
 
-2. **`page`, `perPage`** - The [pagination](#pagination--limit) parameters. Their behavior is the same as when sending
+2. **`filename`** - Allows the user to specify a filename for the result to be downloaded as. This behaves
+just like the [`filename`](#filename) parameter on queries sent to the `data` endpoint.
+
+3. **`page`, `perPage`** - The [pagination](#pagination--limit) parameters. Their behavior is the same as when sending
 a query to the `data` endpoint, and allow the user to get pages of the results.
 
-3. **`asyncAfter`** - Allows the user to specify how long they are willing to wait for results from the
+4. **`asyncAfter`** - Allows the user to specify how long they are willing to wait for results from the
 result store. Behaves like the [`asyncAfter`](async) parameter on the `data` endpoint.
 
 If the results for the given ticket are ready, we get the results in the format specified. Otherwise, we get the

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -125,6 +125,7 @@ import com.yahoo.bard.webservice.web.ratelimit.DefaultRateLimiter;
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessorFactory;
 import com.yahoo.bard.webservice.web.responseprocessors.ResultSetResponseProcessorFactory;
 import com.yahoo.bard.webservice.web.util.QueryWeightUtil;
+import com.yahoo.bard.webservice.web.util.ResponseUtils;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
@@ -341,6 +342,8 @@ public abstract class AbstractBinderFactory implements BinderFactory {
                 bind(getClock()).to(Clock.class);
 
                 bind(getHttpResponseMaker()).to(HttpResponseMaker.class);
+
+                bind(buildResponseUtils()).to(ResponseUtils.class);
 
                 bind(buildResponseWriter(getMappers())).to(ResponseWriter.class);
 
@@ -1110,6 +1113,15 @@ public abstract class AbstractBinderFactory implements BinderFactory {
      */
     protected Class<? extends HttpResponseMaker> getHttpResponseMaker() {
         return HttpResponseMaker.class;
+    }
+
+    /**
+     * Builds a response utils object with only CSV as a default always csv format.
+     *
+     * @return the response utils
+     */
+    protected ResponseUtils buildResponseUtils() {
+        return new ResponseUtils();
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
@@ -290,9 +290,10 @@ public class HttpResponseMaker {
                 responseFormatType
         );
 
+        ResponseBuilder responseBuilderWithHeaders = rspBuilder;
         for (Map.Entry<String, String> entry : responseHeaders.entrySet()) {
-            rspBuilder = rspBuilder.header(entry.getKey(), entry.getValue());
+            responseBuilderWithHeaders = responseBuilderWithHeaders.header(entry.getKey(), entry.getValue());
         }
-        return rspBuilder;
+        return responseBuilderWithHeaders;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
@@ -60,6 +60,7 @@ public class HttpResponseMaker {
      * @param responseWriter  Serializer which takes responseData and apiRequest, outputs formatted data stream.
      * @param responseUtils A class providing utility methods for processing response headers.
      */
+    @Inject
     public HttpResponseMaker(
             ObjectMappersSuite objectMappers,
             DimensionDictionary dimensionDictionary,
@@ -79,7 +80,6 @@ public class HttpResponseMaker {
      * @param dimensionDictionary  The dimension dictionary from which to look up dimensions by name
      * @param responseWriter  Serializer which takes responseData and apiRequest, outputs formatted data stream.
      */
-    @Inject
     public HttpResponseMaker(
             ObjectMappersSuite objectMappers,
             DimensionDictionary dimensionDictionary,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
@@ -277,7 +277,7 @@ public class HttpResponseMaker {
      * @param containerRequestContext  The request context
      * @param downloadFilename  The filename the response should be downloaded as. Null or empty indicates the response
      * should not be downloaded and instead rendered by the browser
-     * 
+     *
      * @return the response builder that has had the headers added
      */
     protected ResponseBuilder buildAndAddResponseHeaders(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
@@ -2,8 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data;
 
-import static com.yahoo.bard.webservice.web.DefaultResponseFormatType.CSV;
-import static com.yahoo.bard.webservice.web.DefaultResponseFormatType.JSON;
 import static com.yahoo.bard.webservice.web.handlers.PartialDataRequestHandler.getPartialIntervalsWithDefault;
 import static com.yahoo.bard.webservice.web.handlers.VolatileDataRequestHandler.getVolatileIntervalsWithDefault;
 import static com.yahoo.bard.webservice.web.responseprocessors.ResponseContextKeys.API_METRIC_COLUMN_NAMES;
@@ -19,6 +17,7 @@ import com.yahoo.bard.webservice.data.dimension.DimensionField;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 import com.yahoo.bard.webservice.util.Pagination;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
+import com.yahoo.bard.webservice.web.DefaultResponseFormatType;
 import com.yahoo.bard.webservice.web.PreResponse;
 import com.yahoo.bard.webservice.web.ResponseData;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
@@ -33,14 +32,11 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.StreamingOutput;
@@ -154,7 +150,7 @@ public class HttpResponseMaker {
         // Add headers for content type
         // default response format is JSON
         if (responseFormatType == null) {
-            responseFormatType = JSON;
+            responseFormatType = DefaultResponseFormatType.JSON;
         }
 
         LinkedHashMap<String, LinkedHashSet<DimensionField>> dimensionToDimensionFieldMap =
@@ -270,17 +266,6 @@ public class HttpResponseMaker {
             ContainerRequestContext containerRequestContext
     ) {
         return buildAndAddResponseHeaders(rspBuilder, responseFormatType, containerRequestContext, null);
-//        if (CSV.accepts(responseFormatType)) {
-//            return rspBuilder
-//                    .header(HttpHeaders.CONTENT_TYPE, "text/csv; charset=utf-8")
-//                    .header(
-//                            HttpHeaders.CONTENT_DISPOSITION,
-//                            responseUtils.getCsvContentDispositionValue(containerRequestContext)
-//                    );
-//        } else {
-//            return rspBuilder
-//                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON + "; charset=utf-8");
-//        }
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
@@ -258,6 +258,7 @@ public class HttpResponseMaker {
      * @param rspBuilder  ResponseBuilder that handles adding the headers to the response
      * @param responseFormatType  The type of the response
      * @param containerRequestContext  The request context
+     *
      * @return the response builder that has had the headers added
      */
     protected ResponseBuilder buildAndAddResponseHeaders(
@@ -276,6 +277,7 @@ public class HttpResponseMaker {
      * @param containerRequestContext  The request context
      * @param downloadFilename  The filename the response should be downloaded as. Null or empty indicates the response
      * should not be downloaded and instead rendered by the browser
+     * 
      * @return the response builder that has had the headers added
      */
     protected ResponseBuilder buildAndAddResponseHeaders(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/DefaultResponseFormatType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/DefaultResponseFormatType.java
@@ -11,8 +11,19 @@ import java.util.Objects;
 public enum DefaultResponseFormatType implements ResponseFormatType {
     JSON,
     CSV,
-    DEBUG,
-    JSONAPI;
+    DEBUG(".json"),
+    JSONAPI(".json")
+    ;
+
+    private String fileExtension;
+
+    DefaultResponseFormatType() {
+        this.fileExtension = "." + name().toLowerCase(Locale.ENGLISH);
+    }
+
+    DefaultResponseFormatType(String fileExtension) {
+        this.fileExtension = fileExtension;
+    }
 
     @Override
     public String toString() {
@@ -27,5 +38,10 @@ public enum DefaultResponseFormatType implements ResponseFormatType {
     @Override
     public boolean accepts(ResponseFormatType formatType) {
         return formatType.accepts(this.toString());
+    }
+
+    @Override
+    public String getFileExtension() {
+        return fileExtension;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/DefaultResponseFormatType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/DefaultResponseFormatType.java
@@ -5,23 +5,38 @@ package com.yahoo.bard.webservice.web;
 import java.util.Locale;
 import java.util.Objects;
 
+import javax.ws.rs.core.MediaType;
+
 /**
  * Standard reponse formats.
  */
 public enum DefaultResponseFormatType implements ResponseFormatType {
-    JSON,
-    CSV,
-    DEBUG(".json"),
-    JSONAPI(".json")
-    ;
+    JSON(MediaType.APPLICATION_JSON),
+    CSV(ResponseFormatType.CSV_CONTENT_TYPE),
+    DEBUG(MediaType.APPLICATION_JSON, ".json"),
+    JSONAPI(MediaType.APPLICATION_JSON, ".json");
 
     private String fileExtension;
+    private String contentType;
 
-    DefaultResponseFormatType() {
+    /**
+     * Constructor.
+     *
+     * @param contentType  content type value used to build a Content-Type header. e.g. text/csv or application/json
+     */
+    DefaultResponseFormatType(String contentType) {
         this.fileExtension = "." + name().toLowerCase(Locale.ENGLISH);
+        this.contentType = contentType;
     }
 
-    DefaultResponseFormatType(String fileExtension) {
+    /**
+     * Constructor.
+     *
+     * @param contentType  content type value used to build a Content-Type header. e.g. text/csv or application/json
+     * @param fileExtension  file extension that a response in this format would be downloaded as. e.g. .csv or .json
+     */
+    DefaultResponseFormatType(String contentType, String fileExtension) {
+        this.contentType = contentType;
         this.fileExtension = fileExtension;
     }
 
@@ -43,5 +58,10 @@ public enum DefaultResponseFormatType implements ResponseFormatType {
     @Override
     public String getFileExtension() {
         return fileExtension;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseFormatType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseFormatType.java
@@ -2,6 +2,8 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web;
 
+import javax.ws.rs.core.MediaType;
+
 /**
  * A type that an api requested response can be bound to.
  */
@@ -9,6 +11,8 @@ package com.yahoo.bard.webservice.web;
 public interface ResponseFormatType {
 
     String TEXT_FILE_EXTENSION = ".txt";
+    String CSV_CONTENT_TYPE = "text/csv";
+    String CHARSET_UTF8 = "utf-8";
 
     /**
      * Does this Response Format accept this api response format string.
@@ -36,5 +40,23 @@ public interface ResponseFormatType {
      */
     default String getFileExtension() {
         return TEXT_FILE_EXTENSION;
+    }
+
+    /**
+     * Provides the value for the content type header.
+     *
+     * @return the content type
+     */
+    default String getContentType() {
+        return MediaType.TEXT_PLAIN;
+    }
+
+    /**
+     * Provides the charset for the content type header.
+     *
+     * @return the charset
+     */
+    default String getCharset() {
+        return CHARSET_UTF8;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseFormatType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ResponseFormatType.java
@@ -8,6 +8,8 @@ package com.yahoo.bard.webservice.web;
 
 public interface ResponseFormatType {
 
+    String TEXT_FILE_EXTENSION = ".txt";
+
     /**
      * Does this Response Format accept this api response format string.
      *
@@ -25,6 +27,14 @@ public interface ResponseFormatType {
      *
      * @return  True if this format type is compatible with another..
      */
-
     boolean accepts(ResponseFormatType formatType);
+
+    /**
+     * Provides the file extension for the response format type, if the response is downloaded as a file.
+     *
+     * @return the file extension. includes the '.'
+     */
+    default String getFileExtension() {
+        return TEXT_FILE_EXTENSION;
+    }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequest.java
@@ -31,6 +31,18 @@ public interface ApiRequest {
     }
 
     /**
+     * Get the name of the file for the result to be downloaded as. By default, if the filename is present the response
+     * will be returned as an attachment with the return value of this method as its name. If the filename is not
+     * present the response may or may not be returned as an attachment.
+     * See {@link com.yahoo.bard.webservice.web.util.ResponseUtils} for more details.
+     *
+     * @return an optional containing the filename of the response attachment.
+     */
+    default Optional<String> getDownloadFilename() {
+        return Optional.empty();
+    }
+
+    /**
      * Get the type of the requested response format.
      *
      * @return The format of the response for this API request.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -188,6 +188,8 @@ public abstract class ApiRequestImpl implements ApiRequest {
      * All argument constructor, meant to be used for rewriting apiRequest.
      *
      * @param format  The format of the response
+     * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client with
+     * the provided filename. Otherwise indicates the response should be rendered in the browser.
      * @param asyncAfter  How long the user is willing to wait for a synchronous request, in milliseconds
      * @param paginationParameters  The parameters used to describe pagination
      */

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -81,8 +81,8 @@ public abstract class ApiRequestImpl implements ApiRequest {
             DEFAULT_PER_PAGE,
             DEFAULT_PAGE
     );
-    private static final String SYNCHRONOUS_REQUEST_FLAG = "never";
-    private static final String ASYNCHRONOUS_REQUEST_FLAG = "always";
+    protected static final String SYNCHRONOUS_REQUEST_FLAG = "never";
+    protected static final String ASYNCHRONOUS_REQUEST_FLAG = "always";
 
     protected final ResponseFormatType format;
     protected final Optional<PaginationParameters> paginationParameters;
@@ -101,7 +101,9 @@ public abstract class ApiRequestImpl implements ApiRequest {
      * present, must be the empty string.
      *
      * @throws BadApiRequestException if pagination parameters in the API request are not positive integers.
+     * @deprecated prefer constructor with downloadFilename
      */
+    @Deprecated
     public ApiRequestImpl(
             String format,
             String asyncAfter,
@@ -117,8 +119,8 @@ public abstract class ApiRequestImpl implements ApiRequest {
      * @param format  response data format JSON or CSV. Default is JSON.
      * @param asyncAfter  How long the user is willing to wait for a synchronous request in milliseconds, if null
      * defaults to the system config {@code default_asyncAfter}
-     * @param downloadFilename  The filename for the response to be downloaded as. If null indicates response should
-     * not be downloaded.
+     * @param downloadFilename  The filename for the response to be downloaded as. If null or empty indicates response
+     * should not be downloaded.
      * @param perPage  number of rows to display per page of results. If present in the original request, must be a
      * positive integer. If not present, must be the empty string.
      * @param page  desired page of results. If present in the original request, must be a positive integer. If not
@@ -159,7 +161,27 @@ public abstract class ApiRequestImpl implements ApiRequest {
             @NotNull String perPage,
             @NotNull String page
     ) throws BadApiRequestException {
-        this(format, SYNCHRONOUS_REQUEST_FLAG, perPage, page);
+        this(format, SYNCHRONOUS_REQUEST_FLAG, null, perPage, page);
+    }
+
+    /**
+     * All argument constructor, meant to be used for rewriting apiRequest.
+     *
+     * @param format  The format of the response
+     * @param asyncAfter  How long the user is willing to wait for a synchronous request, in milliseconds
+     * @param paginationParameters  The parameters used to describe pagination
+     * @deprecated prefer constructor with downloadFilename
+     */
+    @Deprecated
+    protected ApiRequestImpl(
+            ResponseFormatType format,
+            long asyncAfter,
+            Optional<PaginationParameters> paginationParameters
+    ) {
+        this.format = format;
+        this.asyncAfter = asyncAfter;
+        this.paginationParameters = paginationParameters;
+        this.downloadFilename = null;
     }
 
     /**
@@ -171,13 +193,14 @@ public abstract class ApiRequestImpl implements ApiRequest {
      */
     protected ApiRequestImpl(
             ResponseFormatType format,
+            String downloadFilename,
             long asyncAfter,
             Optional<PaginationParameters> paginationParameters
     ) {
         this.format = format;
+        this.downloadFilename = downloadFilename;
         this.asyncAfter = asyncAfter;
         this.paginationParameters = paginationParameters;
-        this.downloadFilename = null;
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -110,7 +110,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
             @NotNull String perPage,
             @NotNull String page
     ) throws BadApiRequestException {
-        this(format, asyncAfter, null, perPage, page);
+        this(format, null, asyncAfter, perPage, page);
     }
 
     /**
@@ -130,8 +130,8 @@ public abstract class ApiRequestImpl implements ApiRequest {
      */
     public ApiRequestImpl(
             String format,
-            String asyncAfter,
             String downloadFilename,
+            String asyncAfter,
             @NotNull String perPage,
             @NotNull String page
     ) throws BadApiRequestException {
@@ -161,7 +161,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
             @NotNull String perPage,
             @NotNull String page
     ) throws BadApiRequestException {
-        this(format, SYNCHRONOUS_REQUEST_FLAG, null, perPage, page);
+        this(format, null, SYNCHRONOUS_REQUEST_FLAG, perPage, page);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -87,6 +87,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
     protected final ResponseFormatType format;
     protected final Optional<PaginationParameters> paginationParameters;
     protected final long asyncAfter;
+    protected final Optional<String> downloadFilename;
 
     /**
      * Parses the API request URL and generates the API request object.
@@ -107,6 +108,31 @@ public abstract class ApiRequestImpl implements ApiRequest {
             @NotNull String perPage,
             @NotNull String page
     ) throws BadApiRequestException {
+        this(format, asyncAfter, null, perPage, page);
+    }
+
+    /**
+     * Parses the API request URL and generates the API request object.
+     *
+     * @param format  response data format JSON or CSV. Default is JSON.
+     * @param asyncAfter  How long the user is willing to wait for a synchronous request in milliseconds, if null
+     * defaults to the system config {@code default_asyncAfter}
+     * @param downloadFilename  The filename for the response to be downloaded as. If null indicates response should
+     * not be downloaded.
+     * @param perPage  number of rows to display per page of results. If present in the original request, must be a
+     * positive integer. If not present, must be the empty string.
+     * @param page  desired page of results. If present in the original request, must be a positive integer. If not
+     * present, must be the empty string.
+     *
+     * @throws BadApiRequestException if pagination parameters in the API request are not positive integers.
+     */
+    public ApiRequestImpl(
+            String format,
+            String asyncAfter,
+            String downloadFilename,
+            @NotNull String perPage,
+            @NotNull String page
+    ) throws BadApiRequestException {
         this.format = generateAcceptFormat(format);
         this.paginationParameters = generatePaginationParameters(perPage, page);
         this.asyncAfter = generateAsyncAfter(
@@ -114,7 +140,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
                         SYSTEM_CONFIG.getStringProperty(SYSTEM_CONFIG.getPackageVariableName("default_asyncAfter")) :
                         asyncAfter
         );
-
+        this.downloadFilename = Optional.ofNullable(downloadFilename);
     }
 
     /**
@@ -151,6 +177,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
         this.format = format;
         this.asyncAfter = asyncAfter;
         this.paginationParameters = paginationParameters;
+        this.downloadFilename = Optional.empty();
     }
 
     /**
@@ -587,6 +614,11 @@ public abstract class ApiRequestImpl implements ApiRequest {
 
         LOG.trace("Generated logical table: {} with granularity {}", generated, granularity);
         return generated;
+    }
+
+    @Override
+    public Optional<String> getDownloadFilename() {
+        return downloadFilename;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -87,7 +87,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
     protected final ResponseFormatType format;
     protected final Optional<PaginationParameters> paginationParameters;
     protected final long asyncAfter;
-    protected final Optional<String> downloadFilename;
+    protected final String downloadFilename;
 
     /**
      * Parses the API request URL and generates the API request object.
@@ -140,7 +140,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
                         SYSTEM_CONFIG.getStringProperty(SYSTEM_CONFIG.getPackageVariableName("default_asyncAfter")) :
                         asyncAfter
         );
-        this.downloadFilename = Optional.ofNullable(downloadFilename);
+        this.downloadFilename = downloadFilename;
     }
 
     /**
@@ -177,7 +177,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
         this.format = format;
         this.asyncAfter = asyncAfter;
         this.paginationParameters = paginationParameters;
-        this.downloadFilename = Optional.empty();
+        this.downloadFilename = null;
     }
 
     /**
@@ -618,7 +618,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
 
     @Override
     public Optional<String> getDownloadFilename() {
-        return downloadFilename;
+        return Optional.ofNullable(downloadFilename);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequest.java
@@ -273,6 +273,8 @@ public interface DataApiRequest extends ApiRequest {
 
     DataApiRequest withFormat(ResponseFormatType format);
 
+    DataApiRequest withDownloadFilename(String downloadFilename);
+
     // Processing concerns
 
     DataApiRequest withAsyncAfter(long asyncAfter);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestFactory.java
@@ -40,6 +40,55 @@ public interface DataApiRequestFactory {
      * @param bardConfigResources  The configuration resources used to build this api request
      *
      * @return A DataApiRequestImpl instance
+     * @deprecated in favor of the version that consumes a filename
+     */
+    @Deprecated
+    DataApiRequest buildApiRequest(
+            String tableName,
+            String granularity,
+            List<PathSegment> dimensions,
+            String logicalMetrics,
+            String intervals,
+            String apiFilters,
+            String havings,
+            String sorts,
+            String count,
+            String topN,
+            String format,
+            String timeZoneId,
+            String asyncAfter,
+            @NotNull String perPage,
+            @NotNull String page,
+            BardConfigResources bardConfigResources
+    );
+
+    /**
+     * Factory method for building {@link DataApiRequest} objects.
+     *
+     * @param tableName  logical table corresponding to the table name specified in the URL
+     * @param granularity  string time granularity in URL
+     * @param dimensions  single dimension or multiple dimensions separated by '/' in URL
+     * @param logicalMetrics  URL logical metric query string in the format:
+     * <pre>{@code single metric or multiple logical metrics separated by ',' }</pre>
+     * @param intervals  URL intervals query string in the format:
+     * <pre>{@code single interval in ISO 8601 format, multiple values separated by ',' }</pre>
+     * @param apiFilters  URL filter query String
+     * @param havings  URL having query String
+     * @param sorts  string of sort columns along with sort direction
+     * @param count  count of number of records to be returned in the response
+     * @param topN  number of first records per time bucket to be returned in the response
+     * @param format  response data format
+     * @param timeZoneId  a joda time zone id
+     * @param asyncAfter  How long the user is willing to wait for a synchronous request in milliseconds
+     * @param downloadFilename  The filename for the response to be downloaded as. If null indicates response should
+     * not be downloaded.
+     * @param perPage  number of rows to display per page of results. If present in the original request,
+     * must be a positive integer. If not present, must be the empty string.
+     * @param page  desired page of results. If present in the original request, must be a positive
+     * integer. If not present, must be the empty string.
+     * @param bardConfigResources  The configuration resources used to build this api request
+     *
+     * @return A DataApiRequestImpl instance
      */
     DataApiRequest buildApiRequest(
             String tableName,
@@ -55,6 +104,7 @@ public interface DataApiRequestFactory {
             String format,
             String timeZoneId,
             String asyncAfter,
+            String downloadFilename,
             @NotNull String perPage,
             @NotNull String page,
             BardConfigResources bardConfigResources

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestFactory.java
@@ -102,9 +102,9 @@ public interface DataApiRequestFactory {
             String count,
             String topN,
             String format,
+            String downloadFilename,
             String timeZoneId,
             String asyncAfter,
-            String downloadFilename,
             @NotNull String perPage,
             @NotNull String page,
             BardConfigResources bardConfigResources

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestFactory.java
@@ -40,7 +40,7 @@ public interface DataApiRequestFactory {
      * @param bardConfigResources  The configuration resources used to build this api request
      *
      * @return A DataApiRequestImpl instance
-     * @deprecated in favor of the version that consumes a filename
+     * @deprecated in favor of the version that uses the filename parameter
      */
     @Deprecated
     DataApiRequest buildApiRequest(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -157,7 +157,9 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
      *     <li>Invalid having metrics in the API request.</li>
      *     <li>Pagination parameters in the API request that are not positive integers.</li>
      * </ol>
+     * @deprecated prefer constructors that use filename parameter instead
      */
+    @Deprecated
     public DataApiRequestImpl(
             String tableName,
             String granularity,
@@ -345,7 +347,9 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
      *     <li>Invalid having metrics in the API request.</li>
      *     <li>Pagination parameters in the API request that are not positive integers.</li>
      * </ol>
+     * @deprecated prefer constructors that use filename parameter instead
      */
+    @Deprecated
     public DataApiRequestImpl(
             String tableName,
             String granularityRequest,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -1668,12 +1668,17 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
     // CHECKSTYLE:OFF
     @Override
     public DataApiRequestImpl withFormat(ResponseFormatType format) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
+    }
+
+    @Override
+    public DataApiRequest withDownloadFilename(String downloadFilename) {
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withPaginationParameters(Optional<PaginationParameters> paginationParameters) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
@@ -1683,32 +1688,32 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
 
     @Override
     public DataApiRequestImpl withTable(LogicalTable table) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withGranularity(Granularity granularity) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withDimensions(LinkedHashSet<Dimension> dimensions) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withPerDimensionFields(LinkedHashMap<Dimension, LinkedHashSet<DimensionField>> perDimensionFields) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withLogicalMetrics(LinkedHashSet<LogicalMetric> logicalMetrics) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withIntervals(List<Interval> intervals) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Deprecated
@@ -1718,48 +1723,48 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
 
     @Override
     public DataApiRequestImpl withFilters(ApiFilters apiFilters) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withHavings(Map<LogicalMetric, Set<ApiHaving>> havings) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withSorts(LinkedHashSet<OrderByColumn> sorts) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     // TODO
     @Override
     public DataApiRequestImpl withTimeSort(Optional<OrderByColumn> timeSort) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withCount(int count) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withTopN(int topN) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withAsyncAfter(long asyncAfter) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withTimeZone(DateTimeZone timeZone) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     @Override
     public DataApiRequestImpl withFilterBuilder(DruidFilterBuilder filterBuilder) {
-        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, asyncAfter, filterBuilder);
+        return new DataApiRequestImpl(table, granularity, dimensions, perDimensionFields, logicalMetrics, intervals, apiFilters, havings, sorts, Optional.ofNullable(dateTimeSort), timeZone, topN, count, paginationParameters, format, downloadFilename, asyncAfter, filterBuilder);
     }
 
     // CHECKSTYLE:ON

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -227,10 +227,10 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
      * @param count  count of number of records to be returned in the response
      * @param topN  number of first records per time bucket to be returned in the response
      * @param format  response data format JSON or CSV. Default is JSON.
-     * @param timeZoneId  a joda time zone id
-     * @param asyncAfter  How long the user is willing to wait for a synchronous request in milliseconds
      * @param downloadFilename  The filename for the response to be downloaded as. If null indicates response should
      * not be downloaded.
+     * @param timeZoneId  a joda time zone id
+     * @param asyncAfter  How long the user is willing to wait for a synchronous request in milliseconds
      * @param perPage  number of rows to display per page of results. If present in the original request,
      * must be a positive integer. If not present, must be the empty string.
      * @param page  desired page of results. If present in the original request, must be a positive
@@ -424,10 +424,10 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
      * @param countRequest  count of number of records to be returned in the response
      * @param topNRequest  number of first records per time bucket to be returned in the response
      * @param formatRequest  response data format JSON or CSV. Default is JSON.
-     * @param timeZoneId  a joda time zone id
-     * @param asyncAfterRequest  How long the user is willing to wait for a synchronous request in milliseconds
      * @param downloadFilename  The filename for the response to be downloaded as. If null indicates response should
      * not be downloaded.
+     * @param timeZoneId  a joda time zone id
+     * @param asyncAfterRequest  How long the user is willing to wait for a synchronous request in milliseconds
      * @param perPage  number of rows to display per page of results. If present in the original request,
      * must be a positive integer. If not present, must be the empty string.
      * @param page  desired page of results. If present in the original request, must be a positive
@@ -635,6 +635,8 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
      * All argument constructor, meant to be used for rewriting apiRequest.
      *
      * @param format  Format for the response
+     * @param downloadFilename  The filename for the response to be downloaded as. If null indicates response should
+     * not be downloaded.
      * @param paginationParameters  Pagination info
      * @param table  Logical table requested
      * @param granularity  Granularity of the request
@@ -766,6 +768,8 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
      * Filter builder in constructor should be removed when some deprecations come out.
      *
      * @param format  Format for the response
+     * @param downloadFilename  The filename for the response to be downloaded as. If null indicates response should
+     * not be downloaded.
      * @param paginationParameters  Pagination info
      * @param table  Logical table requested
      * @param granularity  Granularity of the request

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -263,9 +263,9 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
             String count,
             String topN,
             String format,
+            String downloadFilename,
             String timeZoneId,
             String asyncAfter,
-            String downloadFilename,
             @NotNull String perPage,
             @NotNull String page,
             BardConfigResources bardConfigResources
@@ -282,9 +282,9 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
                 count,
                 topN,
                 format,
+                downloadFilename,
                 timeZoneId,
                 asyncAfter,
-                downloadFilename,
                 perPage,
                 page,
                 bardConfigResources.getDimensionDictionary(),
@@ -386,9 +386,9 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
                 countRequest,
                 topNRequest,
                 formatRequest,
+                null,
                 timeZoneId,
                 asyncAfterRequest,
-                null,
                 perPage,
                 page,
                 dimensionDictionary,
@@ -466,9 +466,9 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
             String countRequest,
             String topNRequest,
             String formatRequest,
+            String downloadFilename,
             String timeZoneId,
             String asyncAfterRequest,
-            String downloadFilename,
             @NotNull String perPage,
             @NotNull String page,
             DimensionDictionary dimensionDictionary,
@@ -479,7 +479,7 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
             DruidFilterBuilder druidFilterBuilder,
             HavingGenerator havingGenerator
     ) throws BadApiRequestException {
-        super(formatRequest, asyncAfterRequest, downloadFilename, perPage, page);
+        super(formatRequest, downloadFilename, asyncAfterRequest, perPage, page);
 
         timeZone = generateTimeZone(timeZoneId, systemTimeZone);
 
@@ -588,7 +588,9 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
      * @param timeZone  TimeZone for the request
      * @param filterBuilder  A builder to use when building filters for the request
      * @param dateTimeSort  A dateTime sort column with its direction
+     * @deprecated prefer constructor with downloadFilename
      */
+    @Deprecated
     protected DataApiRequestImpl(
             ResponseFormatType format,
             Optional<PaginationParameters> paginationParameters,
@@ -629,6 +631,134 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
         );
     }
 
+    /**
+     * All argument constructor, meant to be used for rewriting apiRequest.
+     *
+     * @param format  Format for the response
+     * @param paginationParameters  Pagination info
+     * @param table  Logical table requested
+     * @param granularity  Granularity of the request
+     * @param dimensions  Grouping dimensions of the request
+     * @param perDimensionFields  Fields for each of the grouped dimensions
+     * @param logicalMetrics  Metrics requested
+     * @param intervals  Intervals requested
+     * @param apiFilters  Global filters
+     * @param havings  Top-level Having caluses for the request
+     * @param sorts  Sorting info for the request
+     * @param count  Global limit for the request
+     * @param topN  Count of per-bucket limit (TopN) for the request
+     * @param asyncAfter  How long in milliseconds the user is willing to wait for a synchronous response
+     * @param timeZone  TimeZone for the request
+     * @param filterBuilder  A builder to use when building filters for the request
+     * @param dateTimeSort  A dateTime sort column with its direction
+     */
+    protected DataApiRequestImpl(
+            ResponseFormatType format,
+            String downloadFilename,
+            Optional<PaginationParameters> paginationParameters,
+            LogicalTable table,
+            Granularity granularity,
+            LinkedHashSet<Dimension> dimensions,
+            LinkedHashMap<Dimension, LinkedHashSet<DimensionField>> perDimensionFields,
+            LinkedHashSet<LogicalMetric> logicalMetrics,
+            List<Interval> intervals,
+            ApiFilters apiFilters,
+            Map<LogicalMetric, Set<ApiHaving>> havings,
+            LinkedHashSet<OrderByColumn> sorts,
+            int count,
+            int topN,
+            long asyncAfter,
+            DateTimeZone timeZone,
+            DruidFilterBuilder filterBuilder,
+            Optional<OrderByColumn> dateTimeSort
+    ) {
+        this(
+                table,
+                granularity,
+                dimensions,
+                perDimensionFields,
+                logicalMetrics,
+                intervals,
+                apiFilters,
+                havings,
+                sorts,
+                dateTimeSort,
+                timeZone,
+                topN,
+                count,
+                paginationParameters,
+                format,
+                downloadFilename,
+                asyncAfter,
+                filterBuilder
+        );
+    }
+
+    /**
+     * All argument constructor, meant to be used for rewriting apiRequest.
+     *
+     * Filter builder in constructor should be removed when some deprecations come out.
+     *
+     * @param format  Format for the response
+     * @param paginationParameters  Pagination info
+     * @param table  Logical table requested
+     * @param granularity  Granularity of the request
+     * @param groupingDimensions  Grouping dimensions of the request
+     * @param perDimensionFields  Fields for each of the grouped dimensions
+     * @param logicalMetrics  Metrics requested
+     * @param intervals  Intervals requested
+     * @param apiFilters  Global filters
+     * @param havings  Top-level Having caluses for the request
+     * @param sorts  Sorting info for the request
+     * @param dateTimeSort Override sort on time
+     * @param count  Global limit for the request
+     * @param topN  Count of per-bucket limit (TopN) for the request
+     * @param asyncAfter  How long in milliseconds the user is willing to wait for a synchronous response
+     * @param timeZone  TimeZone for the request
+     * @param filterBuilder  A builder to use when building filters for the request
+     * @deprecated prefer constructor with downloadFilename
+     */
+    @Deprecated
+    protected DataApiRequestImpl(
+            LogicalTable table,
+            Granularity granularity,
+            LinkedHashSet<Dimension> groupingDimensions,
+            LinkedHashMap<Dimension, LinkedHashSet<DimensionField>> perDimensionFields,
+            LinkedHashSet<LogicalMetric> logicalMetrics,
+            List<Interval> intervals,
+            ApiFilters apiFilters,
+            Map<LogicalMetric, Set<ApiHaving>> havings,
+            LinkedHashSet<OrderByColumn> sorts,
+            Optional<OrderByColumn> dateTimeSort,
+            DateTimeZone timeZone,
+            int topN,
+            int count,
+            Optional<PaginationParameters> paginationParameters,
+            ResponseFormatType format,
+            Long asyncAfter,
+            DruidFilterBuilder filterBuilder
+    ) {
+        this(
+                table,
+                granularity,
+                groupingDimensions,
+                perDimensionFields,
+                logicalMetrics,
+                intervals,
+                apiFilters,
+                havings,
+                sorts,
+                dateTimeSort,
+                timeZone,
+                topN,
+                count,
+                paginationParameters,
+                format,
+                null,
+                asyncAfter,
+                filterBuilder
+        );
+    }
 
     /**
      * All argument constructor, meant to be used for rewriting apiRequest.
@@ -669,10 +799,11 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
             int count,
             Optional<PaginationParameters> paginationParameters,
             ResponseFormatType format,
+            String downloadFilename,
             Long asyncAfter,
             DruidFilterBuilder filterBuilder
     ) {
-        super(format, asyncAfter, paginationParameters);
+        super(format, downloadFilename, asyncAfter, paginationParameters);
         this.table = table;
         this.granularity = granularity;
         this.dimensions = groupingDimensions;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DefaultDataApiRequestFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DefaultDataApiRequestFactory.java
@@ -32,6 +32,47 @@ public class DefaultDataApiRequestFactory implements DataApiRequestFactory {
             String page,
             BardConfigResources bardConfigResources
     ) {
+        return buildApiRequest(
+                tableName,
+                granularity,
+                dimensions,
+                logicalMetrics,
+                intervals,
+                apiFilters,
+                havings,
+                sorts,
+                count,
+                topN,
+                format,
+                timeZoneId,
+                asyncAfter,
+                null,
+                perPage,
+                page,
+                bardConfigResources
+        );
+    }
+
+    @Override
+    public DataApiRequest buildApiRequest(
+            String tableName,
+            String granularity,
+            List<PathSegment> dimensions,
+            String logicalMetrics,
+            String intervals,
+            String apiFilters,
+            String havings,
+            String sorts,
+            String count,
+            String topN,
+            String format,
+            String timeZoneId,
+            String asyncAfter,
+            String downloadFilename,
+            String perPage,
+            String page,
+            BardConfigResources bardConfigResources
+    ) {
         return new DataApiRequestImpl(
                 tableName,
                 granularity,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DefaultDataApiRequestFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DefaultDataApiRequestFactory.java
@@ -66,9 +66,9 @@ public class DefaultDataApiRequestFactory implements DataApiRequestFactory {
             String count,
             String topN,
             String format,
+            String downloadFilename,
             String timeZoneId,
             String asyncAfter,
-            String downloadFilename,
             String perPage,
             String page,
             BardConfigResources bardConfigResources
@@ -85,6 +85,7 @@ public class DefaultDataApiRequestFactory implements DataApiRequestFactory {
                 count,
                 topN,
                 format,
+                downloadFilename,
                 timeZoneId,
                 asyncAfter,
                 perPage,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequest.java
@@ -32,6 +32,8 @@ public interface DimensionsApiRequest extends ApiRequest {
 
     DimensionsApiRequest withFilters(Set<ApiFilter> filters);
 
+    DimensionsApiRequest withDownloadFilename(String downloadFilename);
+
     LinkedHashSet<Dimension> getDimensions();
 
     Dimension getDimension();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 /**
@@ -60,7 +61,9 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
      *     <li>Invalid filter dimensions in the API request.</li>
      *     <li>Pagination parameters in the API request that are not positive integers.</li>
      * </ol>
+     * @deprecated prefer constructor with download filename
      */
+    @Deprecated
     public DimensionsApiRequestImpl(
             String dimension,
             String filters,
@@ -69,7 +72,42 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
             @NotNull String page,
             DimensionDictionary dimensionDictionary
     ) throws BadApiRequestException {
-        super(format, perPage, page);
+        this(dimension, filters, format, null, perPage, page, dimensionDictionary);
+    }
+
+    /**
+     * Parses the API request URL and generates the Api Request object.
+     *
+     * @param dimension  single dimension URL
+     * @param filters  URL filter query String in the format:
+     * <pre>{@code
+     * ((field name and operation):((multiple values bounded by [])or(single value))))(followed by , or end of string)
+     * }</pre>
+     * @param format  response data format JSON or CSV. Default is JSON.
+     * @param perPage  number of rows to display per page of results. If present in the original request,
+     * must be a positive integer. If not present, must be the empty string.
+     * @param page  desired page of results. If present in the original request, must be a positive
+     * integer. If not present, must be the empty string.
+     * @param dimensionDictionary  cache containing all the valid dimension objects.
+     *
+     * @throws BadApiRequestException is thrown in the following scenarios:
+     * <ol>
+     *     <li>Invalid dimension in the API request.</li>
+     *     <li>Invalid filter syntax in the API request.</li>
+     *     <li>Invalid filter dimensions in the API request.</li>
+     *     <li>Pagination parameters in the API request that are not positive integers.</li>
+     * </ol>
+     */
+    public DimensionsApiRequestImpl(
+            String dimension,
+            String filters,
+            String format,
+            String downloadFilename,
+            @NotNull String perPage,
+            @NotNull String page,
+            DimensionDictionary dimensionDictionary
+    ) throws BadApiRequestException {
+        super(format,SYNCHRONOUS_REQUEST_FLAG, downloadFilename, perPage, page);
 
         // Zero or more grouping dimensions may be specified
         this.dimensions = generateDimensions(dimension, dimensionDictionary);
@@ -78,10 +116,11 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
         this.filters = generateFilters(filters, dimensionDictionary);
 
         LOG.debug(
-                "Api request: \nDimensions: {},\nFilters: {},\nFormat: {}\nPagination: {}",
+                "Api request: \nDimensions: {},\nFilters: {},\nFormat: {},\nFilename: {},\nPagination: {}",
                 this.dimensions,
                 this.filters,
                 this.format,
+                this.downloadFilename,
                 this.paginationParameters
         );
     }
@@ -93,7 +132,9 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
      * @param paginationParameters  Pagination info for the request
      * @param dimensions  Desired dimensions of the request
      * @param filters  Filters applied to the request
+     * @deprecated prefer constructor with downloadFilename
      */
+    @Deprecated
     private DimensionsApiRequestImpl(
             ResponseFormatType format,
             Optional<PaginationParameters> paginationParameters,
@@ -101,6 +142,25 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
             Iterable<ApiFilter> filters
     ) {
         super(format, SYNCHRONOUS_ASYNC_AFTER_VALUE, paginationParameters);
+        this.dimensions = Sets.newLinkedHashSet(dimensions);
+        this.filters = Sets.newLinkedHashSet(filters);
+    }
+    /**
+     * All argument constructor, meant to be used for rewriting apiRequest.
+     *
+     * @param format  Format of the request
+     * @param paginationParameters  Pagination info for the request
+     * @param dimensions  Desired dimensions of the request
+     * @param filters  Filters applied to the request
+     */
+    private DimensionsApiRequestImpl(
+            ResponseFormatType format,
+            String downloadFilename,
+            Optional<PaginationParameters> paginationParameters,
+            Iterable<Dimension> dimensions,
+            Iterable<ApiFilter> filters
+    ) {
+        super(format, downloadFilename, SYNCHRONOUS_ASYNC_AFTER_VALUE, paginationParameters);
         this.dimensions = Sets.newLinkedHashSet(dimensions);
         this.filters = Sets.newLinkedHashSet(filters);
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 /**
@@ -84,6 +83,8 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
      * ((field name and operation):((multiple values bounded by [])or(single value))))(followed by , or end of string)
      * }</pre>
      * @param format  response data format JSON or CSV. Default is JSON.
+     * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client with
+     * the provided filename. Otherwise indicates the response should be rendered in the browser.
      * @param perPage  number of rows to display per page of results. If present in the original request,
      * must be a positive integer. If not present, must be the empty string.
      * @param page  desired page of results. If present in the original request, must be a positive
@@ -107,7 +108,7 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
             @NotNull String page,
             DimensionDictionary dimensionDictionary
     ) throws BadApiRequestException {
-        super(format,downloadFilename, SYNCHRONOUS_REQUEST_FLAG, perPage, page);
+        super(format, downloadFilename, SYNCHRONOUS_REQUEST_FLAG, perPage, page);
 
         // Zero or more grouping dimensions may be specified
         this.dimensions = generateDimensions(dimension, dimensionDictionary);
@@ -149,6 +150,8 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
      * All argument constructor, meant to be used for rewriting apiRequest.
      *
      * @param format  Format of the request
+     * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client with
+     * the provided filename. Otherwise indicates the response should be rendered in the browser.
      * @param paginationParameters  Pagination info for the request
      * @param dimensions  Desired dimensions of the request
      * @param filters  Filters applied to the request

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
@@ -260,27 +260,32 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
 
     @Override
     public DimensionsApiRequest withFormat(ResponseFormatType format) {
-        return new DimensionsApiRequestImpl(format, paginationParameters, dimensions, filters);
+        return new DimensionsApiRequestImpl(format, downloadFilename, paginationParameters, dimensions, filters);
     }
 
     @Override
     public DimensionsApiRequest withPaginationParameters(Optional<PaginationParameters> paginationParameters) {
-        return new DimensionsApiRequestImpl(format, paginationParameters, dimensions, filters);
+        return new DimensionsApiRequestImpl(format, downloadFilename, paginationParameters, dimensions, filters);
     }
 
     @Override
     public DimensionsApiRequest withBuilder(Response.ResponseBuilder builder) {
-        return new DimensionsApiRequestImpl(format, paginationParameters, dimensions, filters);
+        return new DimensionsApiRequestImpl(format, downloadFilename, paginationParameters, dimensions, filters);
     }
 
     @Override
     public DimensionsApiRequest withDimensions(LinkedHashSet<Dimension> dimensions) {
-        return new DimensionsApiRequestImpl(format, paginationParameters, dimensions, filters);
+        return new DimensionsApiRequestImpl(format, downloadFilename, paginationParameters, dimensions, filters);
     }
 
     @Override
     public DimensionsApiRequest withFilters(Set<ApiFilter> filters) {
-        return new DimensionsApiRequestImpl(format, paginationParameters, dimensions, filters);
+        return new DimensionsApiRequestImpl(format, downloadFilename, paginationParameters, dimensions, filters);
+    }
+
+    @Override
+    public DimensionsApiRequest withDownloadFilename(String downloadFilename) {
+        return new DimensionsApiRequestImpl(format, downloadFilename, paginationParameters, dimensions, filters);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DimensionsApiRequestImpl.java
@@ -107,7 +107,7 @@ public class DimensionsApiRequestImpl extends ApiRequestImpl implements Dimensio
             @NotNull String page,
             DimensionDictionary dimensionDictionary
     ) throws BadApiRequestException {
-        super(format,SYNCHRONOUS_REQUEST_FLAG, downloadFilename, perPage, page);
+        super(format,downloadFilename, SYNCHRONOUS_REQUEST_FLAG, perPage, page);
 
         // Zero or more grouping dimensions may be specified
         this.dimensions = generateDimensions(dimension, dimensionDictionary);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/JobsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/JobsApiRequestImpl.java
@@ -76,6 +76,8 @@ public class JobsApiRequestImpl extends ApiRequestImpl implements JobsApiRequest
      * Parses the API request URL and generates the Api Request object.
      *
      * @param format  response data format JSON or CSV. Default is JSON.
+     * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client with
+     * the provided filename. Otherwise indicates the response should be rendered in the browser.
      * @param asyncAfter  How long the user is willing to wait for a synchronous request in milliseconds
      * @param perPage  number of rows to display per page of results. If present in the original request,
      * must be a positive integer. If not present, must be the empty string.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/JobsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/JobsApiRequestImpl.java
@@ -52,7 +52,9 @@ public class JobsApiRequestImpl extends ApiRequestImpl implements JobsApiRequest
      * @param uriInfo  The URI of the request object.
      * @param jobPayloadBuilder  The JobRowMapper to be used to map JobRow to the Job returned by the api
      * @param apiJobStore  The ApiJobStore containing Job metadata
+     * @deprecated prefer constructor with downloadFilename
      */
+    @Deprecated
     public JobsApiRequestImpl(
             String format,
             String asyncAfter,
@@ -64,6 +66,41 @@ public class JobsApiRequestImpl extends ApiRequestImpl implements JobsApiRequest
             ApiJobStore apiJobStore
     ) {
         super(format, asyncAfter, perPage, page);
+        this.uriInfo = uriInfo;
+        this.jobPayloadBuilder = jobPayloadBuilder;
+        this.apiJobStore = apiJobStore;
+        this.filters = filters;
+    }
+
+    /**
+     * Parses the API request URL and generates the Api Request object.
+     *
+     * @param format  response data format JSON or CSV. Default is JSON.
+     * @param asyncAfter  How long the user is willing to wait for a synchronous request in milliseconds
+     * @param perPage  number of rows to display per page of results. If present in the original request,
+     * must be a positive integer. If not present, must be the empty string.
+     * @param page  desired page of results. If present in the original request, must be a positive
+     * integer. If not present, must be the empty string.
+     * @param filters  URL filter query String in the format:
+     * <pre>{@code
+     * ((field name and operation):((multiple values bounded by [])or(single value))))(followed by , or end of string)
+     * }</pre>
+     * @param uriInfo  The URI of the request object.
+     * @param jobPayloadBuilder  The JobRowMapper to be used to map JobRow to the Job returned by the api
+     * @param apiJobStore  The ApiJobStore containing Job metadata
+     */
+    public JobsApiRequestImpl(
+            String format,
+            String downloadFilename,
+            String asyncAfter,
+            @NotNull String perPage,
+            @NotNull String page,
+            String filters,
+            UriInfo uriInfo,
+            JobPayloadBuilder jobPayloadBuilder,
+            ApiJobStore apiJobStore
+    ) {
+        super(format, downloadFilename, asyncAfter, perPage, page);
         this.uriInfo = uriInfo;
         this.jobPayloadBuilder = jobPayloadBuilder;
         this.apiJobStore = apiJobStore;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/MetricsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/MetricsApiRequestImpl.java
@@ -44,7 +44,9 @@ public class MetricsApiRequestImpl extends ApiRequestImpl implements MetricsApiR
      *     <li>Invalid logical metric in the API request.</li>
      *     <li>Pagination parameters in the API request that are not positive integers.</li>
      * </ol>
+     * @deprecated prefer constructor with downloadFilename
      */
+    @Deprecated
     public MetricsApiRequestImpl(
             String metricName,
             String format,
@@ -52,14 +54,47 @@ public class MetricsApiRequestImpl extends ApiRequestImpl implements MetricsApiR
             @NotNull String page,
             MetricDictionary metricDictionary
     ) throws BadApiRequestException {
-        super(format, perPage, page);
+        this(metricName, format, null, perPage, page, metricDictionary);
+    }
+
+    /**
+     * Parses the API request URL and generates the Api Request object.
+     *
+     * @param metricName  string corresponding to the metric name specified in the URL
+     * <pre>{@code
+     * ((field name and operation):((multiple values bounded by [])or(single value))))(followed by , or end of string)
+     * }</pre>
+     * @param format  response data format JSON or CSV. Default is JSON.
+     * @param perPage  number of rows to display per page of results. If present in the original request,
+     * must be a positive integer. If not present, must be the empty string.
+     * @param page  desired page of results. If present in the original request, must be a positive
+     * integer. If not present, must be the empty string.
+     * @param metricDictionary  cache containing all the valid metric objects.
+     *
+     * @throws BadApiRequestException is thrown in the following scenarios:
+     * <ol>
+     *     <li>Invalid logical metric in the API request.</li>
+     *     <li>Pagination parameters in the API request that are not positive integers.</li>
+     * </ol>
+     */
+    public MetricsApiRequestImpl(
+            String metricName,
+            String format,
+            String downloadFilename,
+            @NotNull String perPage,
+            @NotNull String page,
+            MetricDictionary metricDictionary
+    ) throws BadApiRequestException {
+        super(format, downloadFilename, SYNCHRONOUS_REQUEST_FLAG, perPage, page);
 
         this.metrics = generateMetrics(metricName, metricDictionary);
 
         LOG.debug(
-                "Api request: \nMetrics: {},\nFormat: {}\nPagination: {}",
+                "Api request: \nMetrics: {},\nFormat: {},\nFilename: {},\nPagination: {}",
                 this.metrics,
                 this.format,
+                this.format,
+                this.downloadFilename,
                 this.paginationParameters
         );
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/MetricsApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/MetricsApiRequestImpl.java
@@ -65,6 +65,8 @@ public class MetricsApiRequestImpl extends ApiRequestImpl implements MetricsApiR
      * ((field name and operation):((multiple values bounded by [])or(single value))))(followed by , or end of string)
      * }</pre>
      * @param format  response data format JSON or CSV. Default is JSON.
+     * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client with
+     * the provided filename. Otherwise indicates the response should be rendered in the browser.
      * @param perPage  number of rows to display per page of results. If present in the original request,
      * must be a positive integer. If not present, must be the empty string.
      * @param page  desired page of results. If present in the original request, must be a positive

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImpl.java
@@ -85,6 +85,8 @@ public class SlicesApiRequestImpl extends ApiRequestImpl implements SlicesApiReq
      * ((field name and operation):((multiple values bounded by [])or(single value))))(followed by , or end of string)
      * }</pre>
      * @param format  response data format JSON or CSV. Default is JSON.
+     * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client with
+     * the provided filename. Otherwise indicates the response should be rendered in the browser.
      * @param perPage  number of rows to display per page of results. If present in the original request,
      * must be a positive integer. If not present, must be the empty string.
      * @param page  desired page of results. If present in the original request, must be a positive

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/SlicesApiRequestImpl.java
@@ -62,7 +62,9 @@ public class SlicesApiRequestImpl extends ApiRequestImpl implements SlicesApiReq
      *     <li>Invalid slice in the API request.</li>
      *     <li>Pagination parameters in the API request that are not positive integers.</li>
      * </ol>
+     * @deprecated prefer constructor with
      */
+    @Deprecated
     public SlicesApiRequestImpl(
             String sliceName,
             String format,
@@ -72,7 +74,42 @@ public class SlicesApiRequestImpl extends ApiRequestImpl implements SlicesApiReq
             DataSourceMetadataService dataSourceMetadataService,
             UriInfo uriInfo
     ) throws BadApiRequestException {
-        super(format, perPage, page);
+        this(sliceName, format, null, perPage, page, tableDictionary, dataSourceMetadataService, uriInfo);
+    }
+
+    /**
+     * Parses the API request URL and generates the Api Request object.
+     *
+     * @param sliceName  string corresponding to the slice name specified in the URL
+     * <pre>{@code
+     * ((field name and operation):((multiple values bounded by [])or(single value))))(followed by , or end of string)
+     * }</pre>
+     * @param format  response data format JSON or CSV. Default is JSON.
+     * @param perPage  number of rows to display per page of results. If present in the original request,
+     * must be a positive integer. If not present, must be the empty string.
+     * @param page  desired page of results. If present in the original request, must be a positive
+     * integer. If not present, must be the empty string.
+     * @param tableDictionary  cache containing all the valid physical table objects.
+     * @param dataSourceMetadataService  a resource holding the available datasource metadata
+     * @param uriInfo  The URI of the request object.
+     *
+     * @throws BadApiRequestException is thrown in the following scenarios:
+     * <ol>
+     *     <li>Invalid slice in the API request.</li>
+     *     <li>Pagination parameters in the API request that are not positive integers.</li>
+     * </ol>
+     */
+    public SlicesApiRequestImpl(
+            String sliceName,
+            String format,
+            String downloadFilename,
+            @NotNull String perPage,
+            @NotNull String page,
+            PhysicalTableDictionary tableDictionary,
+            DataSourceMetadataService dataSourceMetadataService,
+            UriInfo uriInfo
+    ) throws BadApiRequestException {
+        super(format, downloadFilename, SYNCHRONOUS_REQUEST_FLAG, perPage, page);
         this.slices = generateSlices(tableDictionary, uriInfo);
 
         this.slice = sliceName != null ? generateSlice(
@@ -83,9 +120,10 @@ public class SlicesApiRequestImpl extends ApiRequestImpl implements SlicesApiReq
         ) : null;
 
         LOG.debug(
-                "Api request: \nSlices: {},\nFormat: {}\nPagination: {}",
+                "Api request: \nSlices: {},\nFormat: {},\nFilename: {},\nPagination: {}",
                 this.slices,
                 this.format,
+                this.downloadFilename,
                 this.paginationParameters
         );
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequest.java
@@ -103,6 +103,8 @@ public interface TablesApiRequest extends ApiRequest {
 
     TablesApiRequest withIntervals(List<Interval> intervals);
 
+    TablesApiRequest withDownloadFilename(String downloadFilename);
+
     @Deprecated
     /**
      * @deprecated Use {@link #withIntervals(List)}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequestImpl.java
@@ -559,6 +559,11 @@ public class TablesApiRequestImpl extends ApiRequestImpl implements TablesApiReq
     }
 
     @Override
+    public TablesApiRequest withDownloadFilename(String downloadFilename) {
+        return new TablesApiRequestImpl(format, downloadFilename, paginationParameters, tables, table, granularity, dimensions, logicalMetrics, intervals, apiFilters);
+    }
+
+    @Override
     public TablesApiRequest withFilters(Map<Dimension, Set<ApiFilter>> filters) {
         return new TablesApiRequestImpl(format, downloadFilename, paginationParameters, tables, table, granularity, dimensions, logicalMetrics, intervals, apiFilters);
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequestImpl.java
@@ -100,6 +100,8 @@ public class TablesApiRequestImpl extends ApiRequestImpl implements TablesApiReq
      * ((field name and operation):((multiple values bounded by [])or(single value))))(followed by , or end of string)
      * }</pre>
      * @param format  response data format JSON or CSV. Default is JSON.
+     * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client with
+     * the provided filename. Otherwise indicates the response should be rendered in the browser.
      * @param perPage  number of rows to display per page of results. If present in the original request,
      * must be a positive integer. If not present, must be the empty string.
      * @param page  desired page of results. If present in the original request, must be a positive
@@ -215,6 +217,8 @@ public class TablesApiRequestImpl extends ApiRequestImpl implements TablesApiReq
      * @param tableName  Logical table corresponding to the table name specified in the URL
      * @param granularity  Requested time granularity
      * @param format  Response data format JSON or CSV. Default is JSON.
+     * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client with
+     * the provided filename. Otherwise indicates the response should be rendered in the browser.
      * @param perPage  Number of rows to display per page of results. It must represent a positive integer or an empty
      * string if it's not specified
      * @param page  Desired page of results. It must represent a positive integer or an empty
@@ -355,6 +359,8 @@ public class TablesApiRequestImpl extends ApiRequestImpl implements TablesApiReq
      * All argument constructor and its used primarily for withers - hence its private.
      *
      * @param format Response data format JSON or CSV. Default is JSON
+     * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client with
+     * the provided filename. Otherwise indicates the response should be rendered in the browser.
      * @param paginationParameters The parameters used to describe pagination
      * @param tables Set of logical tables
      * @param table Logical table

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
@@ -396,9 +396,9 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
                         count,
                         topN,
                         formatResolver.apply(format, containerRequestContext),
+                        downloadFilename,
                         timeZone,
                         asyncAfter,
-                        downloadFilename,
                         perPage,
                         page,
                         this

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
@@ -273,6 +273,8 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
      * @param timeZone  Requested time zone (impacts day based granularities and intervals)
      * @param asyncAfter  The maximum time length (in milliseconds) a request is allowed to be synchronous before
      * becoming asynchronous, if "never" then the request is forever synchronous
+     * @param downloadFilename  The filename for the response to be downloaded as. If null indicates response should
+     * not be downloaded.
      * @param perPage  Requested number of rows of data to be displayed on each page of results
      * @param page  Requested page of results desired
      * @param readCache  false to bypass cache
@@ -297,6 +299,7 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
             @QueryParam("format") String format,
             @QueryParam("timeZone") String timeZone,
             @QueryParam("asyncAfter") String asyncAfter,
+            @QueryParam("filename") String downloadFilename,
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @DefaultValue("true") @NotNull @QueryParam("_cache") Boolean readCache,
@@ -318,6 +321,7 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
                 format,
                 timeZone,
                 asyncAfter,
+                downloadFilename,
                 perPage,
                 page,
                 readCache,
@@ -344,6 +348,8 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
      * @param format  Requested format
      * @param asyncAfter  The maximum time length (in milliseconds) a request is allowed to be synchronous before
      * becoming asynchronous, if "never" then the request is forever synchronous
+     * @param downloadFilename  The filename for the response to be downloaded as. If null indicates response should
+     * not be downloaded.
      * @param perPage  Requested number of rows of data to be displayed on each page of results
      * @param page  Requested page of results desired
      * @param readCache  false to bypass cache
@@ -369,6 +375,7 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
             @QueryParam("format") String format,
             @QueryParam("timeZone") String timeZone,
             @QueryParam("asyncAfter") String asyncAfter,
+            @QueryParam("filename") String downloadFilename,
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @DefaultValue("true") @NotNull @QueryParam("_cache") Boolean readCache,
@@ -391,6 +398,7 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
                         formatResolver.apply(format, containerRequestContext),
                         timeZone,
                         asyncAfter,
+                        downloadFilename,
                         perPage,
                         page,
                         this

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -102,6 +102,8 @@ public class DimensionsServlet extends EndpointServlet {
      * @param perPage  number of values to return per page
      * @param page  the page to start from
      * @param format  the format to use for the response
+     * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
+     * username. Otherwise indicates the response should be rendered in the browser.
      * @param uriInfo  UriInfo of the request
      * @param containerRequestContext  The context of data provided by the Jersey container for this request
      *
@@ -235,6 +237,8 @@ public class DimensionsServlet extends EndpointServlet {
      * @param page  The page number
      * @param perPage  The number of rows per page
      * @param format  The format of the response
+     * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
+     * username. Otherwise indicates the response should be rendered in the browser.
      * @param uriInfo The injected UriInfo
      * @param containerRequestContext The injected request context
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -238,7 +238,7 @@ public class DimensionsServlet extends EndpointServlet {
      * @param perPage  The number of rows per page
      * @param format  The format of the response
      * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
-     * username. Otherwise indicates the response should be rendered in the browser.
+     * filename. Otherwise indicates the response should be rendered in the browser.
      * @param uriInfo The injected UriInfo
      * @param containerRequestContext The injected request context
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -191,6 +191,7 @@ public class DimensionsServlet extends EndpointServlet {
                     dimensionName,
                     null,
                     null,
+                    null,
                     "",
                     "",
                     dimensionDictionary

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -119,6 +119,7 @@ public class DimensionsServlet extends EndpointServlet {
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @QueryParam("format") String format,
+            @QueryParam("filename") String downloadFilename,
             @Context final UriInfo uriInfo,
             @Context final ContainerRequestContext containerRequestContext
     ) {
@@ -131,6 +132,7 @@ public class DimensionsServlet extends EndpointServlet {
                     null,
                     null,
                     formatResolver.apply(format, containerRequestContext),
+                    downloadFilename,
                     perPage,
                     page,
                     dimensionDictionary
@@ -263,6 +265,7 @@ public class DimensionsServlet extends EndpointServlet {
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @QueryParam("format") String format,
+            @QueryParam("filename") String downloadFilename,
             @Context final UriInfo uriInfo,
             @Context final ContainerRequestContext containerRequestContext
     ) {
@@ -276,6 +279,7 @@ public class DimensionsServlet extends EndpointServlet {
                     dimensionName,
                     filterQuery,
                     formatResolver.apply(format, containerRequestContext),
+                    downloadFilename,
                     perPage,
                     page,
                     dimensionDictionary

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/EndpointServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/EndpointServlet.java
@@ -33,7 +33,7 @@ import javax.ws.rs.core.UriInfo;
 public abstract class EndpointServlet {
 
     protected final ObjectMappersSuite objectMappers;
-    private final ResponseUtils responseUtils;
+    protected final ResponseUtils responseUtils;
     private final Supplier<Response.ResponseBuilder> responseBuilderSupplier;
 
 
@@ -88,6 +88,7 @@ public abstract class EndpointServlet {
         UriInfo uriInfo = containerRequestContext.getUriInfo();
         StreamingOutput output;
         if (CSV.accepts(apiRequest.getFormat())) {
+            // TODO: use responseUtils to build the headers instead
             builder.header(HttpHeaders.CONTENT_TYPE, "text/csv; charset=utf-8")
                     .header(
                             HttpHeaders.CONTENT_DISPOSITION,
@@ -101,6 +102,7 @@ public abstract class EndpointServlet {
                     objectMappers
             ).getResponseStream();
         } else {
+            // TODO: use responseUtils to build the headers instead
             // JSON is the default
             builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON + "; charset=utf-8");
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
@@ -81,7 +81,7 @@ public class FeatureFlagsServlet extends EndpointServlet {
          *
          * @param format  Format of the request
          * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client
-         * with the provided username. Otherwise indicates the response should be rendered in the browser.
+         * with the provided filename. Otherwise indicates the response should be rendered in the browser.
          * @param perPage  How many items to show per page
          * @param page  Which page to show
          */
@@ -116,7 +116,7 @@ public class FeatureFlagsServlet extends EndpointServlet {
      * @param page the page to start from
      * @param format the format to use
      * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
-     * username. Otherwise indicates the response should be rendered in the browser.
+     * filename. Otherwise indicates the response should be rendered in the browser.
      * @param containerRequestContext the request context needed to process responses
      *
      * @return Response Format:

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
@@ -69,9 +69,22 @@ public class FeatureFlagsServlet extends EndpointServlet {
          * @param format  Format of the request
          * @param perPage  How many items to show per page
          * @param page  Which page to show
+         * @deprecated
          */
+        @Deprecated
         FeatureFlagApiRequest(String format, String perPage, String page) {
             super(format, perPage, page);
+        }
+
+        /**
+         * Constructor.
+         *
+         * @param format  Format of the request
+         * @param perPage  How many items to show per page
+         * @param page  Which page to show
+         */
+        FeatureFlagApiRequest(String format, String downloadFilename, String perPage, String page) {
+            super(format, downloadFilename, SYNCHRONOUS_REQUEST_FLAG, perPage, page);
         }
     }
 
@@ -121,6 +134,7 @@ public class FeatureFlagsServlet extends EndpointServlet {
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @QueryParam("format") String format,
+            @QueryParam("filename") String downloadFilename,
             @Context ContainerRequestContext containerRequestContext
     ) {
         Supplier<Response> responseSender;
@@ -130,6 +144,7 @@ public class FeatureFlagsServlet extends EndpointServlet {
 
             FeatureFlagApiRequest apiRequest = new FeatureFlagApiRequest(
                     format,
+                    downloadFilename,
                     perPage,
                     page
             );
@@ -162,7 +177,6 @@ public class FeatureFlagsServlet extends EndpointServlet {
      * Get the status of a specific feature flag.
      *
      * @param flagName The feature flag
-     * @param format  The format to return results in
      *
      * @return Response Format:
      * <pre><code>
@@ -179,8 +193,7 @@ public class FeatureFlagsServlet extends EndpointServlet {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{flagName}")
     public Response getFeatureFlagStatus(
-            @PathParam("flagName") String flagName,
-            @QueryParam("format") String format
+            @PathParam("flagName") String flagName
     ) {
         Supplier<Response> responseSender;
         try {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/FeatureFlagsServlet.java
@@ -69,7 +69,7 @@ public class FeatureFlagsServlet extends EndpointServlet {
          * @param format  Format of the request
          * @param perPage  How many items to show per page
          * @param page  Which page to show
-         * @deprecated
+         * @deprecated prefer constructor with downloadFilename
          */
         @Deprecated
         FeatureFlagApiRequest(String format, String perPage, String page) {
@@ -80,6 +80,8 @@ public class FeatureFlagsServlet extends EndpointServlet {
          * Constructor.
          *
          * @param format  Format of the request
+         * @param downloadFilename If not null and not empty, indicates the response should be downloaded by the client
+         * with the provided username. Otherwise indicates the response should be rendered in the browser.
          * @param perPage  How many items to show per page
          * @param page  Which page to show
          */
@@ -113,6 +115,8 @@ public class FeatureFlagsServlet extends EndpointServlet {
      * @param perPage the number per page to return
      * @param page the page to start from
      * @param format the format to use
+     * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
+     * username. Otherwise indicates the response should be rendered in the browser.
      * @param containerRequestContext the request context needed to process responses
      *
      * @return Response Format:

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
@@ -151,6 +151,7 @@ public class JobsServlet extends EndpointServlet {
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @QueryParam("format") String format,
+            @QueryParam("filename") String downloadFilename,
             @QueryParam("filters") String filters,
             @Context ContainerRequestContext containerRequestContext,
             @Suspended AsyncResponse asyncResponse
@@ -163,6 +164,7 @@ public class JobsServlet extends EndpointServlet {
 
             apiRequest = new JobsApiRequestImpl(
                     formatResolver.apply(format, containerRequestContext),
+                    downloadFilename,
                     null, //asyncAfter is null so it behaves like a synchronous request
                     perPage,
                     page,
@@ -281,6 +283,7 @@ public class JobsServlet extends EndpointServlet {
     public void getJobResultsByTicket(
             @PathParam("ticket") String ticket,
             @QueryParam("format") String format,
+            @QueryParam("filename") String downloadFilename,
             @QueryParam("asyncAfter") String asyncAfter,
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
@@ -296,6 +299,7 @@ public class JobsServlet extends EndpointServlet {
 
             apiRequest = new JobsApiRequestImpl(
                     format,
+                    downloadFilename,
                     asyncAfter,
                     perPage,
                     page,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
@@ -140,7 +140,7 @@ public class JobsServlet extends EndpointServlet {
      * @param page  Requested page of results desired
      * @param format  Requested format
      * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
-     * username. Otherwise indicates the response should be rendered in the browser.
+     * filename. Otherwise indicates the response should be rendered in the browser.
      * @param filters  Filters to be applied on the JobRows. Expects a URL filter query String that may contain multiple
      * filter strings separated by comma.  The format of a filter String is :
      * (JobField name)-(operation)[(value or comma separated values)]?
@@ -272,7 +272,7 @@ public class JobsServlet extends EndpointServlet {
      * @param ticket  The ticket that can uniquely identify a Job
      * @param format  Requested format of the response
      * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
-     * username. Otherwise indicates the response should be rendered in the browser.
+     * filename. Otherwise indicates the response should be rendered in the browser.
      * @param asyncAfter  How long the user is willing to wait for a synchronous request in milliseconds, if null
      * defaults to the system config {@code default_asyncAfter}
      * @param perPage  Requested number of rows of data to be displayed on each page of results

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/JobsServlet.java
@@ -139,6 +139,8 @@ public class JobsServlet extends EndpointServlet {
      * @param perPage  Requested number of rows of data to be displayed on each page of results
      * @param page  Requested page of results desired
      * @param format  Requested format
+     * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
+     * username. Otherwise indicates the response should be rendered in the browser.
      * @param filters  Filters to be applied on the JobRows. Expects a URL filter query String that may contain multiple
      * filter strings separated by comma.  The format of a filter String is :
      * (JobField name)-(operation)[(value or comma separated values)]?
@@ -269,6 +271,8 @@ public class JobsServlet extends EndpointServlet {
      *
      * @param ticket  The ticket that can uniquely identify a Job
      * @param format  Requested format of the response
+     * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
+     * username. Otherwise indicates the response should be rendered in the browser.
      * @param asyncAfter  How long the user is willing to wait for a synchronous request in milliseconds, if null
      * defaults to the system config {@code default_asyncAfter}
      * @param perPage  Requested number of rows of data to be displayed on each page of results

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
@@ -95,7 +95,7 @@ public class MetricsServlet extends EndpointServlet {
      * @param page  the page to start from
      * @param format  The name of the output format type
      * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
-     * username. Otherwise indicates the response should be rendered in the browser.
+     * filename. Otherwise indicates the response should be rendered in the browser.
      * @param containerRequestContext  The context of data provided by the Jersey container for this request
      *
      * @return The list of logical metrics

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
@@ -111,6 +111,7 @@ public class MetricsServlet extends EndpointServlet {
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @QueryParam("format") String format,
+            @QueryParam("filename") String downloadFilename,
             @Context final ContainerRequestContext containerRequestContext
     ) {
         UriInfo uriInfo = containerRequestContext.getUriInfo();
@@ -122,6 +123,7 @@ public class MetricsServlet extends EndpointServlet {
             apiRequest = new MetricsApiRequestImpl(
                     null,
                     formatResolver.apply(format, containerRequestContext),
+                    downloadFilename,
                     perPage,
                     page,
                     metricDictionary

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/MetricsServlet.java
@@ -94,6 +94,8 @@ public class MetricsServlet extends EndpointServlet {
      * @param perPage  number of values to return per page
      * @param page  the page to start from
      * @param format  The name of the output format type
+     * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
+     * username. Otherwise indicates the response should be rendered in the browser.
      * @param containerRequestContext  The context of data provided by the Jersey container for this request
      *
      * @return The list of logical metrics

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
@@ -106,6 +106,7 @@ public class SlicesServlet extends EndpointServlet {
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @QueryParam("format") String format,
+            @QueryParam("filename") String downloadFilename,
             @Context ContainerRequestContext containerRequestContext
     ) {
         SlicesApiRequest apiRequest = null;
@@ -117,6 +118,7 @@ public class SlicesServlet extends EndpointServlet {
             apiRequest = new SlicesApiRequestImpl(
                     null,
                     formatResolver.apply(format, containerRequestContext),
+                    downloadFilename,
                     perPage,
                     page,
                     physicalTableDictionary,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
@@ -87,7 +87,7 @@ public class SlicesServlet extends EndpointServlet {
      * @param page  the page to start from
      * @param format  The name of the output format type
      * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
-     * username. Otherwise indicates the response should be rendered in the browser.
+     * filename. Otherwise indicates the response should be rendered in the browser.
      * @param containerRequestContext  The context of data provided by the Jersey container for this request
 
      * @return OK(200) else Bad Request(400) Response format:

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/SlicesServlet.java
@@ -86,6 +86,8 @@ public class SlicesServlet extends EndpointServlet {
      * @param perPage  number of values to return per page
      * @param page  the page to start from
      * @param format  The name of the output format type
+     * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
+     * username. Otherwise indicates the response should be rendered in the browser.
      * @param containerRequestContext  The context of data provided by the Jersey container for this request
 
      * @return OK(200) else Bad Request(400) Response format:

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
@@ -125,13 +125,14 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @QueryParam("format") String format,
+            @QueryParam("filename") String downloadFilename,
             @Context UriInfo uriInfo,
             @Context final ContainerRequestContext containerRequestContext
     ) {
         if (format != null && format.toLowerCase(Locale.ENGLISH).equals("fullview")) {
             return getTablesFullView(perPage, page, uriInfo, containerRequestContext);
         } else {
-            return getTable(null, perPage, page, format, containerRequestContext);
+            return getTable(null, perPage, page, format, downloadFilename, containerRequestContext);
         }
     }
 
@@ -162,6 +163,7 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
             @DefaultValue("") @NotNull @QueryParam("perPage") String perPage,
             @DefaultValue("") @NotNull @QueryParam("page") String page,
             @QueryParam("format") String format,
+            @QueryParam("filename") String downloadFilename,
             @Context final ContainerRequestContext containerRequestContext
     ) {
         TablesApiRequestImpl tablesApiRequestImpl = null;
@@ -174,6 +176,7 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
                     tableName,
                     null,
                     formatResolver.apply(format, containerRequestContext),
+                    downloadFilename,
                     perPage,
                     page,
                     this

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
@@ -108,7 +108,7 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
      * @param page  the page to start from
      * @param format  The name of the output format type
      * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
-     * username. Otherwise indicates the response should be rendered in the browser.
+     * filename. Otherwise indicates the response should be rendered in the browser.
      * @param uriInfo  UriInfo of the request
      * @param containerRequestContext  The context of data provided by the Jersey container for this request
      *
@@ -147,7 +147,7 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
      * @param page  the page to start from
      * @param format  The name of the output format type
      * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
-     * username. Otherwise indicates the response should be rendered in the browser.
+     * filename. Otherwise indicates the response should be rendered in the browser.
      * @param containerRequestContext  The context of data provided by the Jersey container for this request
      *
      * @return The list of grain-specific logical tables

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/TablesServlet.java
@@ -107,6 +107,8 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
      * @param perPage  number of values to return per page
      * @param page  the page to start from
      * @param format  The name of the output format type
+     * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
+     * username. Otherwise indicates the response should be rendered in the browser.
      * @param uriInfo  UriInfo of the request
      * @param containerRequestContext  The context of data provided by the Jersey container for this request
      *
@@ -144,6 +146,8 @@ public class TablesServlet extends EndpointServlet implements BardConfigResource
      * @param perPage  number of values to return per page
      * @param page  the page to start from
      * @param format  The name of the output format type
+     * @param downloadFilename If present, indicates the response should be downloaded by the client with the provided
+     * username. Otherwise indicates the response should be rendered in the browser.
      * @param containerRequestContext  The context of data provided by the Jersey container for this request
      *
      * @return The list of grain-specific logical tables

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
@@ -91,7 +91,7 @@ public class ResponseUtils {
      * @param containerRequestContext  the state of the container for building response headers
      *
      * @return A content disposition header telling the browser the name of the CSV file to be downloaded
-     * @deprecated prefer to use getResponseFormatHeaders() or at least getContentDispositionValue()
+     * @deprecated prefer to use buildResponseFormatHeaders() or at least getContentDispositionValue()
      */
     @Deprecated
     public String getCsvContentDispositionValue(ContainerRequestContext containerRequestContext) {
@@ -105,11 +105,11 @@ public class ResponseUtils {
      * @param responseFormatType  the response format type for that request.
      * @return A map of applicable headers to values.
      */
-    public Map<String, String> getResponseFormatHeaders(
+    public Map<String, String> buildResponseFormatHeaders(
             ContainerRequestContext containerRequestContext,
             ResponseFormatType responseFormatType
     ) {
-        return getResponseFormatHeaders(containerRequestContext, null, responseFormatType);
+        return buildResponseFormatHeaders(containerRequestContext, null, responseFormatType);
     }
 
     /**
@@ -130,7 +130,7 @@ public class ResponseUtils {
      * @param responseFormatType the response format type for that request.
      * @return A map of applicable headers to values.
      */
-    public Map<String, String> getResponseFormatHeaders(
+    public Map<String, String> buildResponseFormatHeaders(
             ContainerRequestContext containerRequestContext,
             String downloadFilename,
             ResponseFormatType responseFormatType

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
@@ -4,6 +4,8 @@ package com.yahoo.bard.webservice.web.util;
 
 import com.yahoo.bard.webservice.config.SystemConfig;
 import com.yahoo.bard.webservice.config.SystemConfigProvider;
+import com.yahoo.bard.webservice.web.ResponseFormatType;
+import com.yahoo.bard.webservice.web.apirequest.ApiRequest;
 
 import java.util.stream.Collectors;
 
@@ -34,7 +36,9 @@ public class ResponseUtils {
      * @param containerRequestContext  the state of the container for building response headers
      *
      * @return A content disposition header telling the browser the name of the CSV file to be downloaded
+     * @deprecated TODO: WRITE THIS
      */
+    @Deprecated
     public String getCsvContentDispositionValue(ContainerRequestContext containerRequestContext) {
         UriInfo uriInfo = containerRequestContext.getUriInfo();
         String uriPath = uriInfo.getPathSegments().stream()
@@ -56,5 +60,25 @@ public class ResponseUtils {
                 : filePath;
 
         return "attachment; filename=" + filePath + extension;
+    }
+
+    public String getContentDispositionValue(ContainerRequestContext containerRequestContext, ApiRequest apiRequest) {
+        return null;
+    }
+
+    protected String prepareDefaultFileNameNoExtension(ContainerRequestContext containerRequestContext) {
+        UriInfo uriInfo = containerRequestContext.getUriInfo();
+        String uriPath = uriInfo.getPathSegments().stream()
+                .map(PathSegment::getPath)
+                .collect(Collectors.joining("-"));
+
+        String interval = uriInfo.getQueryParameters().getFirst("dateTime");
+        if (interval == null) {
+            interval = "";
+        } else {
+            // Chrome treats ',' as duplicate header so replace it with '__' to make chrome happy.
+            interval = "_" + interval.replace("/", "_").replace(",", "__");
+        }
+        return uriPath + interval;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
@@ -198,7 +198,7 @@ public class ResponseUtils {
         if (downloadFilename == null || downloadFilename.isEmpty()) {
             downloadFilename = generateDefaultFileNameNoExtension(containerRequestContext);
         }
-
+        downloadFilename = replaceReservedCharacters(downloadFilename);
         String filepath = truncateFilename(downloadFilename);
         String extension = responseFormatType.getFileExtension();
         return CONTENT_DISPOSITION_HEADER_PREFIX + filepath + extension;
@@ -229,8 +229,7 @@ public class ResponseUtils {
         if (interval == null) {
             interval = "";
         } else {
-            // Chrome treats ',' as duplicate header so replace it with '__' to make chrome happy.
-            interval = "_" + interval.replace("/", "_").replace(",", "__");
+            interval = "_" + replaceReservedCharacters(interval);
         }
         return uriPath + interval;
     }
@@ -246,5 +245,18 @@ public class ResponseUtils {
         return (maxFileLength > 0 && filename.length() > maxFileLength)
                 ? filename.substring(0, maxFileLength)
                 : filename;
+    }
+
+    /**
+     * Replaces a small set of illegal characters with underscores.
+     *
+     * '/' and '\' are file path delimiters in unix and windows respectively, so they must be replaced. Chrome treats
+     * ',' as duplicate header so it must also be replaced to make chrome happy.
+     *
+     * @param str  Input to perform replace on
+     * @return the input with reserved characters replaced with underscores
+     */
+    protected String replaceReservedCharacters(String str) {
+        return str.replaceAll("[\\\\/]", "_").replaceAll(",", "__");
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
@@ -141,7 +141,7 @@ public class ResponseUtils {
         // if filename is present and not empty then the druid response should be sent back as an attachment
         if (
                 alwaysDownloadFormats.contains(responseFormatType) ||
-                        (downloadFilename != null && !downloadFilename.isEmpty())
+                        downloadFilename != null && !downloadFilename.isEmpty()
         ) {
             result.put(
                     HttpHeaders.CONTENT_DISPOSITION,
@@ -186,16 +186,17 @@ public class ResponseUtils {
      * generated instead.
      *
      * @param containerRequestContext  container request context of the request currently being handled
-     * @param downloadFilename  the filename for the response to be downloaded as
+     * @param requestedFilename  the filename for the response to be downloaded as
      * @param responseFormatType  data object that contains information necessary to build the response headers
      * @return the value for the Content-Disposition header
      */
     public String getContentDispositionValue(
             ContainerRequestContext containerRequestContext,
-            String downloadFilename,
+            String requestedFilename,
             ResponseFormatType responseFormatType
     ) {
-        if (downloadFilename == null || downloadFilename.isEmpty()) {
+        String downloadFilename = requestedFilename;
+        if (requestedFilename == null || requestedFilename.isEmpty()) {
             downloadFilename = generateDefaultFileNameNoExtension(containerRequestContext);
         }
         downloadFilename = replaceReservedCharacters(downloadFilename);
@@ -242,7 +243,7 @@ public class ResponseUtils {
      * @return  the filename truncated to the configured maximum length if necessary
      */
     protected String truncateFilename(String filename) {
-        return (maxFileLength > 0 && filename.length() > maxFileLength)
+        return maxFileLength > 0 && filename.length() > maxFileLength
                 ? filename.substring(0, maxFileLength)
                 : filename;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
@@ -4,16 +4,17 @@ package com.yahoo.bard.webservice.web.util;
 
 import com.yahoo.bard.webservice.config.SystemConfig;
 import com.yahoo.bard.webservice.config.SystemConfigProvider;
-import com.yahoo.bard.webservice.data.config.dimension.DefaultDimensionField;
 import com.yahoo.bard.webservice.web.DefaultResponseFormatType;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
-import com.yahoo.bard.webservice.web.apirequest.ApiRequest;
 
-import java.util.Optional;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.swing.text.html.Option;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.UriInfo;
 
@@ -29,6 +30,54 @@ public class ResponseUtils {
 
     protected int maxFileLength = SYSTEM_CONFIG.getIntProperty(MAX_NAME_LENGTH, 0);
 
+    protected Set<ResponseFormatType> alwaysDownloadFormats;
+
+    /**
+     * Constructor. By default the CSV format is a format that is always returned as an attachment instead of rendered
+     * in the browser.
+     */
+    public ResponseUtils() {
+        this.alwaysDownloadFormats = new HashSet<>();
+        this.alwaysDownloadFormats.add(DefaultResponseFormatType.CSV);
+    }
+
+    /**
+     * Set of format that should always be returned as an attachment.
+     *
+     * @param alwaysDownloadFormats the set of formats
+     */
+    public ResponseUtils(Set<ResponseFormatType> alwaysDownloadFormats) {
+        this.alwaysDownloadFormats = alwaysDownloadFormats;
+    }
+
+    /**
+     * Adds a response format to the list of always download formats.
+     *
+     * @param responseFormatType the format to be marked as always download
+     */
+    public void addAlwaysDownloadFormatType(ResponseFormatType responseFormatType) {
+        alwaysDownloadFormats.add(responseFormatType);
+    }
+
+    /**
+     * Removes a format type from the always download format types.
+     *
+     * @param responseFormatType the format type to be removed
+     * @return true if the format type was in the set and removed, false if it was not in the set
+     */
+    public boolean removeAlwaysDownloadFormatType(ResponseFormatType responseFormatType) {
+        return alwaysDownloadFormats.remove(responseFormatType);
+    }
+
+    /**
+     * Overrides the existing set of always download format types.
+     *
+     * @param alwaysDownloadFormats the new set of always download formats to replacing the existing set.
+     */
+    public void overrideAlwaysDownloadFormats(Set<ResponseFormatType> alwaysDownloadFormats) {
+        this.alwaysDownloadFormats = alwaysDownloadFormats;
+    }
+
     /**
      * This method will get the path segments and the interval (if it is part of the request) from the apiRequest and
      * create a content-disposition header value with a proposed filename in the following format.
@@ -42,27 +91,135 @@ public class ResponseUtils {
      * @param containerRequestContext  the state of the container for building response headers
      *
      * @return A content disposition header telling the browser the name of the CSV file to be downloaded
-     * @deprecated prefer to use
+     * @deprecated prefer to use getResponseFormatHeaders() or at least getContentDispositionValue()
      */
     @Deprecated
     public String getCsvContentDispositionValue(ContainerRequestContext containerRequestContext) {
-        return getContentDispositionValue(containerRequestContext, Optional.empty(), DefaultResponseFormatType.CSV);
+        return getContentDispositionValue(containerRequestContext, DefaultResponseFormatType.CSV);
     }
 
-    public String getContentDispositionValue(
+    /**
+     * Gets the response headers. Convenience method for if there is no user provided download filename.
+     *
+     * @param containerRequestContext  the container request context of the request currently being handled
+     * @param responseFormatType  the response format type for that request.
+     * @return A map of applicable headers to values.
+     */
+    public Map<String, String> getResponseFormatHeaders(
             ContainerRequestContext containerRequestContext,
-            Optional<String> downloadFileName,
             ResponseFormatType responseFormatType
     ) {
-        String filepath = truncateFilePath(
-                downloadFileName.orElse(prepareDefaultFileNameNoExtension(containerRequestContext))
+        return getResponseFormatHeaders(containerRequestContext, null, responseFormatType);
+    }
+
+    /**
+     * Returns a map of all response headers having to do with the response format. Currently this includes the
+     * Content-Type header and the Content-Disposition header. The Content-Type header is always returned, but the
+     * Content-Disposition header is only returned if the response is supposed to be downloaded.
+     *
+     * Whether or not the response should be downloaded is based on two pieces of data. First, if a user defined
+     * filename is present then the response will always be downloaded. Intuitively, it would only make sense to
+     * provide a filename if you intend for the results to be downloaded into a file of that name. The second case is
+     * if the provided response format type is considered to be an always download format type. A format type is
+     * considered always download if it is in the alwaysDownloadFormats set. If the response format type is an
+     * always download format type AND no download filename is provide a default filename is generated based on the
+     * path elements and time range provided in the api query.
+     *
+     * @param containerRequestContext the container request context of the request currently being handled
+     * @param downloadFilename  the filename for the response to be downloaded as
+     * @param responseFormatType the response format type for that request.
+     * @return A map of applicable headers to values.
+     */
+    public Map<String, String> getResponseFormatHeaders(
+            ContainerRequestContext containerRequestContext,
+            String downloadFilename,
+            ResponseFormatType responseFormatType
+    ) {
+        Map<String, String> result = new HashMap<>();
+        result.put(HttpHeaders.CONTENT_TYPE, getContentTypeValue(responseFormatType));
+        // if the response format is CSV we ALWAYS respond with a
+        // if filename is present and not empty then the druid response should be sent back as an attachment
+        if (
+                alwaysDownloadFormats.contains(responseFormatType) ||
+                        (downloadFilename != null && !downloadFilename.isEmpty())
+        ) {
+            result.put(
+                    HttpHeaders.CONTENT_DISPOSITION,
+                    getContentDispositionValue(containerRequestContext, downloadFilename, responseFormatType)
+            );
+        }
+        return result;
+    }
+
+    /**
+     * Builds the value for the Content-Type header. The value is constructed out of data provided by the
+     * Response Format Type.
+     *
+     * @param responseFormatType  data object that contains information necessary to build the response headers
+     * @return the value for the Content-Type header
+     */
+    public String getContentTypeValue(ResponseFormatType responseFormatType) {
+        return responseFormatType.getContentType() + "; charset=" + responseFormatType.getCharset();
+    }
+
+    /**
+     * Builds the value for the Content-Disposition header. convenience method for when there is no user provided
+     * download filename. A default filename is generated and used instead.
+     *
+     * @param containerRequestContext  the container request context of the request currently being handled
+     * @param responseFormatType  the response format type for that request.
+     * @return the value for the Content-Disposition header
+     */
+    public String getContentDispositionValue(
+            ContainerRequestContext containerRequestContext,
+            ResponseFormatType responseFormatType
+    ) {
+        return getContentDispositionValue(
+                containerRequestContext,
+                generateDefaultFileNameNoExtension(containerRequestContext),
+                responseFormatType
         );
+    }
+
+    /**
+     * Builds the value for the Content-Disposition header. If downloadFilename is null or empty a default name is
+     * generated instead.
+     *
+     * @param containerRequestContext  container request context of the request currently being handled
+     * @param downloadFilename  the filename for the response to be downloaded as
+     * @param responseFormatType  data object that contains information necessary to build the response headers
+     * @return the value for the Content-Disposition header
+     */
+    public String getContentDispositionValue(
+            ContainerRequestContext containerRequestContext,
+            String downloadFilename,
+            ResponseFormatType responseFormatType
+    ) {
+        if (downloadFilename == null || downloadFilename.isEmpty()) {
+            downloadFilename = generateDefaultFileNameNoExtension(containerRequestContext);
+        }
+
+        String filepath = truncateFilename(downloadFilename);
         String extension = responseFormatType.getFileExtension();
         return CONTENT_DISPOSITION_HEADER_PREFIX + filepath + extension;
 
     }
 
-    protected String prepareDefaultFileNameNoExtension(ContainerRequestContext containerRequestContext) {
+    /**
+     * This method will get the path segments and the interval (if it is part of the request) from the api request and
+     * generate a default filename to be used with the content-disposition header.
+     * <p>
+     * If the path segments are ["data", "datasource", "granularity", "dim1"] and the query params have interval
+     * {"dateTime": "a/b"}, then the result would be "attachment; filename=data-datasource-granularity-dim1_a_b.csv".
+     * For a dimension query without a "dateTime" query param and path segments
+     * ["dimensions", "datasource", "dim1"], then the result would be
+     * "attachment; filename=dimensions-datasource-dim1.csv".
+     * </p>
+     *
+     * @param containerRequestContext  container request context of the request currently being handled
+     * @return the generated default filename
+     */
+    protected String generateDefaultFileNameNoExtension(ContainerRequestContext containerRequestContext) {
         UriInfo uriInfo = containerRequestContext.getUriInfo();
         String uriPath = uriInfo.getPathSegments().stream()
                 .map(PathSegment::getPath)
@@ -78,9 +235,16 @@ public class ResponseUtils {
         return uriPath + interval;
     }
 
-    protected String truncateFilePath(String filePath) {
-        return (maxFileLength > 0 && filePath.length() > maxFileLength)
-                ? filePath.substring(0, maxFileLength)
-                : filePath;
+    /**
+     * truncates the provided filename if it exceeds the maximum filename length. A maxFileLength of zero indicates
+     * no maximum file length is configured and thus the filename will not be truncated.
+     *
+     * @param filename  the filename to maybe truncate
+     * @return  the filename truncated to the configured maximum length if necessary
+     */
+    protected String truncateFilename(String filename) {
+        return (maxFileLength > 0 && filename.length() > maxFileLength)
+                ? filename.substring(0, maxFileLength)
+                : filename;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/ResponseUtils.java
@@ -4,11 +4,15 @@ package com.yahoo.bard.webservice.web.util;
 
 import com.yahoo.bard.webservice.config.SystemConfig;
 import com.yahoo.bard.webservice.config.SystemConfigProvider;
+import com.yahoo.bard.webservice.data.config.dimension.DefaultDimensionField;
+import com.yahoo.bard.webservice.web.DefaultResponseFormatType;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
 import com.yahoo.bard.webservice.web.apirequest.ApiRequest;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javax.swing.text.html.Option;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.UriInfo;
@@ -21,7 +25,9 @@ public class ResponseUtils {
     public static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
     public static final String MAX_NAME_LENGTH = SYSTEM_CONFIG.getPackageVariableName("download_file_max_name_length");
 
-    int maxFileLength = SYSTEM_CONFIG.getIntProperty(MAX_NAME_LENGTH, 0);
+    public static final String CONTENT_DISPOSITION_HEADER_PREFIX = "attachment; filename=";
+
+    protected int maxFileLength = SYSTEM_CONFIG.getIntProperty(MAX_NAME_LENGTH, 0);
 
     /**
      * This method will get the path segments and the interval (if it is part of the request) from the apiRequest and
@@ -36,34 +42,24 @@ public class ResponseUtils {
      * @param containerRequestContext  the state of the container for building response headers
      *
      * @return A content disposition header telling the browser the name of the CSV file to be downloaded
-     * @deprecated TODO: WRITE THIS
+     * @deprecated prefer to use
      */
     @Deprecated
     public String getCsvContentDispositionValue(ContainerRequestContext containerRequestContext) {
-        UriInfo uriInfo = containerRequestContext.getUriInfo();
-        String uriPath = uriInfo.getPathSegments().stream()
-                .map(PathSegment::getPath)
-                .collect(Collectors.joining("-"));
-
-        String interval = uriInfo.getQueryParameters().getFirst("dateTime");
-        if (interval == null) {
-            interval = "";
-        } else {
-            // Chrome treats ',' as duplicate header so replace it with '__' to make chrome happy.
-            interval = "_" + interval.replace("/", "_").replace(",", "__");
-        }
-
-        String extension = ".csv";
-        String filePath = uriPath + interval;
-        filePath = (maxFileLength > 0 && filePath.length() > maxFileLength) ?
-                filePath.substring(0, maxFileLength)
-                : filePath;
-
-        return "attachment; filename=" + filePath + extension;
+        return getContentDispositionValue(containerRequestContext, Optional.empty(), DefaultResponseFormatType.CSV);
     }
 
-    public String getContentDispositionValue(ContainerRequestContext containerRequestContext, ApiRequest apiRequest) {
-        return null;
+    public String getContentDispositionValue(
+            ContainerRequestContext containerRequestContext,
+            Optional<String> downloadFileName,
+            ResponseFormatType responseFormatType
+    ) {
+        String filepath = truncateFilePath(
+                downloadFileName.orElse(prepareDefaultFileNameNoExtension(containerRequestContext))
+        );
+        String extension = responseFormatType.getFileExtension();
+        return CONTENT_DISPOSITION_HEADER_PREFIX + filepath + extension;
+
     }
 
     protected String prepareDefaultFileNameNoExtension(ContainerRequestContext containerRequestContext) {
@@ -80,5 +76,11 @@ public class ResponseUtils {
             interval = "_" + interval.replace("/", "_").replace(",", "__");
         }
         return uriPath + interval;
+    }
+
+    protected String truncateFilePath(String filePath) {
+        return (maxFileLength > 0 && filePath.length() > maxFileLength)
+                ? filePath.substring(0, maxFileLength)
+                : filePath;
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/util/ResponseUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/util/ResponseUtilsSpec.groovy
@@ -53,7 +53,6 @@ class ResponseUtilsSpec extends Specification {
         responseUtils.getCsvContentDispositionValue(
                 containerRequestContext
         ) == "attachment; filename=foo-bar_2017_2018.csv"
-
     }
 
 
@@ -113,6 +112,18 @@ class ResponseUtilsSpec extends Specification {
 
         then:
         result == "hello/world; charset=utf-8"
+    }
+
+    def "replaceReservedCharacters replaces '/' with '_' and ',' with '__'"() {
+        setup:
+        String input = "\\h\\e/l/l//o_wor,l,d,"
+        String expectedOutput = "_h_e_l_l__o_wor__l__d__"
+
+        when:
+        String result = new ResponseUtils().replaceReservedCharacters(input)
+
+        then:
+        result == expectedOutput
     }
 
     @Unroll
@@ -318,12 +329,12 @@ class ResponseUtilsSpec extends Specification {
         responseFormatType.getCharset() >> "utf-8"
         responseFormatType.getFileExtension() >> ".txt"
 
-        String fileName = "fname"
+        String fileName = "f,na/me"
 
         ResponseUtils responseUtils = new ResponseUtils()
 
         String expectedContentTypeValue = "hello/world; charset=utf-8"
-        String expectedContentDispositionValue = "attachment; filename=fname.txt"
+        String expectedContentDispositionValue = "attachment; filename=f__na_me.txt"
 
         when:
         Map<String, String> result = responseUtils.buildResponseFormatHeaders(Mock(ContainerRequestContext), fileName, responseFormatType)

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/util/ResponseUtilsSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/util/ResponseUtilsSpec.groovy
@@ -287,7 +287,7 @@ class ResponseUtilsSpec extends Specification {
         String expectedContentTypeValue = "hello/world; charset=utf-8"
 
         when:
-        Map<String, String> result = responseUtils.getResponseFormatHeaders(Mock(ContainerRequestContext), responseFormatType)
+        Map<String, String> result = responseUtils.buildResponseFormatHeaders(Mock(ContainerRequestContext), responseFormatType)
 
         then:
         result.keySet().size() == 1
@@ -295,7 +295,7 @@ class ResponseUtilsSpec extends Specification {
         result.get(HttpHeaders.CONTENT_TYPE) == expectedContentTypeValue
 
         when:
-        result = responseUtils.getResponseFormatHeaders(Mock(ContainerRequestContext), null, responseFormatType)
+        result = responseUtils.buildResponseFormatHeaders(Mock(ContainerRequestContext), null, responseFormatType)
 
         then:
         result.keySet().size() == 1
@@ -303,7 +303,7 @@ class ResponseUtilsSpec extends Specification {
         result.get(HttpHeaders.CONTENT_TYPE) == expectedContentTypeValue
 
         when:
-        result = responseUtils.getResponseFormatHeaders(Mock(ContainerRequestContext), "", responseFormatType)
+        result = responseUtils.buildResponseFormatHeaders(Mock(ContainerRequestContext), "", responseFormatType)
 
         then:
         result.keySet().size() == 1
@@ -326,7 +326,7 @@ class ResponseUtilsSpec extends Specification {
         String expectedContentDispositionValue = "attachment; filename=fname.txt"
 
         when:
-        Map<String, String> result = responseUtils.getResponseFormatHeaders(Mock(ContainerRequestContext), fileName, responseFormatType)
+        Map<String, String> result = responseUtils.buildResponseFormatHeaders(Mock(ContainerRequestContext), fileName, responseFormatType)
 
         then:
         result.keySet().size() == 2
@@ -344,7 +344,7 @@ class ResponseUtilsSpec extends Specification {
         String expectedContentDispositionValue = "attachment; filename=foo-bar_2017_2018.csv"
 
         when:
-        Map<String, String> result = responseUtils.getResponseFormatHeaders(containerRequestContext, DefaultResponseFormatType.CSV)
+        Map<String, String> result = responseUtils.buildResponseFormatHeaders(containerRequestContext, DefaultResponseFormatType.CSV)
 
         then:
         result.keySet().size() == 2


### PR DESCRIPTION
Issue: https://github.com/yahoo/fili/issues/709

This PR only exposes the filename parameter to data queries, though `getDownloadFilename()` was added to the `ApiRequest` interface. If you think more query types should have this parameter exposed please comment.