### PR TITLE
Better expose concrete start and end date 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Current
 
 ### Added:
 
+- [Added expected start and end dates to PhysicalTableDefiniton](https://github.com/yahoo/fili/issues/822)
+    * New constructors on `PhysicalTableDefinition` and `ConcretePhysicalTableDefinition` that take expected start and end date
+    * New public getters on `PhysicalTableDefinition` for expected start and end date
+
 - [Added expected start and end dates to availability](https://github.com/yahoo/fili/issues/822)
     * Add methods for getting expected start and end dates given a datasource constraint to the `Availability` interface.
         - start and end dates are optional, with an empty optional indicating no expected start or end date.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
@@ -23,7 +23,7 @@ import java.util.Set;
 public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
 
     /**
-     * Define a physical table using a zoned time grain.
+     * Define a physical table using a zoned time grain. Defaults to table with no expected start nor end dates.
      *
      * @param name  The table name
      * @param timeGrain  The zoned time grain
@@ -46,9 +46,9 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
      * @param timeGrain  The zoned time grain
      * @param metricNames  The Set of metric names on the table
      * @param dimensionConfigs  The dimension configurations
-     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Empty
+     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Null
      * indicates there is NO expected start date
-     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Empty
+     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Null
      * indicates there is NO expected end date
      */
     public ConcretePhysicalTableDefinition(
@@ -63,7 +63,8 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
     }
 
     /**
-     * Define a physical table with provided logical to physical column name mappings.
+     * Define a physical table with provided logical to physical column name mappings. Defaults to config with no
+     * expected start nor end dates.
      *
      * @param name  The table name
      * @param timeGrain  The zoned time grain
@@ -78,15 +79,7 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames
     ) {
-        super(
-                name,
-                timeGrain,
-                metricNames,
-                dimensionConfigs,
-                logicalToPhysicalNames,
-                null,
-                null
-        );
+        super(name, timeGrain, metricNames, dimensionConfigs, logicalToPhysicalNames, null, null);
     }
 
     /**
@@ -97,9 +90,9 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
      * @param metricNames  The Set of metric names on the table
      * @param dimensionConfigs  The dimension configurations
      * @param logicalToPhysicalNames  A map from logical column names to physical column names
-     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Empty
+     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Null
      * indicates there is NO expected start date
-     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Empty
+     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Null
      * indicates there is NO expected end date
      */
     public ConcretePhysicalTableDefinition(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
@@ -15,6 +15,7 @@ import org.joda.time.DateTime;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -36,7 +37,7 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs
     ) {
-        super(name, timeGrain, metricNames, dimensionConfigs, null, null);
+        super(name, timeGrain, metricNames, dimensionConfigs, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -46,9 +47,9 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
      * @param timeGrain  The zoned time grain
      * @param metricNames  The Set of metric names on the table
      * @param dimensionConfigs  The dimension configurations
-     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Null
+     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Empty
      * indicates there is NO expected start date
-     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Null
+     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Empty
      * indicates there is NO expected end date
      */
     public ConcretePhysicalTableDefinition(
@@ -56,8 +57,8 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             ZonedTimeGrain timeGrain,
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs,
-            DateTime expectedStartDate,
-            DateTime expectedEndDate
+            Optional<DateTime> expectedStartDate,
+            Optional<DateTime> expectedEndDate
     ) {
         super(name, timeGrain, metricNames, dimensionConfigs, expectedStartDate, expectedEndDate);
     }
@@ -78,7 +79,15 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames
     ) {
-        super(name, timeGrain, metricNames, dimensionConfigs, logicalToPhysicalNames, null, null);
+        super(
+                name,
+                timeGrain,
+                metricNames,
+                dimensionConfigs,
+                logicalToPhysicalNames,
+                Optional.empty(),
+                Optional.empty()
+        );
     }
 
     /**
@@ -89,9 +98,9 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
      * @param metricNames  The Set of metric names on the table
      * @param dimensionConfigs  The dimension configurations
      * @param logicalToPhysicalNames  A map from logical column names to physical column names
-     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Null
+     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Empty
      * indicates there is NO expected start date
-     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Null
+     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Empty
      * indicates there is NO expected end date
      */
     public ConcretePhysicalTableDefinition(
@@ -100,8 +109,8 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames,
-            DateTime expectedStartDate,
-            DateTime expectedEndDate
+            Optional<DateTime> expectedStartDate,
+            Optional<DateTime> expectedEndDate
     ) {
         super(
                 name,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
@@ -11,6 +11,8 @@ import com.yahoo.bard.webservice.metadata.DataSourceMetadataService;
 import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.StrictPhysicalTable;
 
+import org.joda.time.DateTime;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -34,7 +36,30 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs
     ) {
-        super(name, timeGrain, metricNames, dimensionConfigs);
+        super(name, timeGrain, metricNames, dimensionConfigs, null, null);
+    }
+
+    /**
+     * Define a physical table using a zoned time grain.
+     *
+     * @param name  The table name
+     * @param timeGrain  The zoned time grain
+     * @param metricNames  The Set of metric names on the table
+     * @param dimensionConfigs  The dimension configurations
+     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Null
+     * indicates there is NO expected start date
+     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Null
+     * indicates there is NO expected end date
+     */
+    public ConcretePhysicalTableDefinition(
+            TableName name,
+            ZonedTimeGrain timeGrain,
+            Set<FieldName> metricNames,
+            Set<? extends DimensionConfig> dimensionConfigs,
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
+    ) {
+        super(name, timeGrain, metricNames, dimensionConfigs, expectedStartDate, expectedEndDate);
     }
 
     /**
@@ -53,7 +78,40 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames
     ) {
-        super(name, timeGrain, metricNames, dimensionConfigs, logicalToPhysicalNames);
+        super(name, timeGrain, metricNames, dimensionConfigs, logicalToPhysicalNames, null, null);
+    }
+
+    /**
+     * Define a physical table with provided logical to physical column name mappings.
+     *
+     * @param name  The table name
+     * @param timeGrain  The zoned time grain
+     * @param metricNames  The Set of metric names on the table
+     * @param dimensionConfigs  The dimension configurations
+     * @param logicalToPhysicalNames  A map from logical column names to physical column names
+     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Null
+     * indicates there is NO expected start date
+     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Null
+     * indicates there is NO expected end date
+     */
+    public ConcretePhysicalTableDefinition(
+            TableName name,
+            ZonedTimeGrain timeGrain,
+            Set<FieldName> metricNames,
+            Set<? extends DimensionConfig> dimensionConfigs,
+            Map<String, String> logicalToPhysicalNames,
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
+    ) {
+        super(
+                name,
+                timeGrain,
+                metricNames,
+                dimensionConfigs,
+                logicalToPhysicalNames,
+                expectedStartDate,
+                expectedEndDate
+        );
     }
 
     @Override
@@ -64,11 +122,13 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
     @Override
     public ConfigPhysicalTable build(ResourceDictionaries dictionaries, DataSourceMetadataService metadataService) {
         return new StrictPhysicalTable(
-                        getName(),
-                        getTimeGrain(),
-                        buildColumns(dictionaries.getDimensionDictionary()),
-                        getLogicalToPhysicalNames(),
-                        metadataService
-                );
+                getName(),
+                getTimeGrain(),
+                buildColumns(dictionaries.getDimensionDictionary()),
+                getLogicalToPhysicalNames(),
+                metadataService,
+                getExpectedStartDate(),
+                getExpectedEndDate()
+        );
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/ConcretePhysicalTableDefinition.java
@@ -15,7 +15,6 @@ import org.joda.time.DateTime;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -37,7 +36,7 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs
     ) {
-        super(name, timeGrain, metricNames, dimensionConfigs, Optional.empty(), Optional.empty());
+        super(name, timeGrain, metricNames, dimensionConfigs, null, null);
     }
 
     /**
@@ -57,8 +56,8 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             ZonedTimeGrain timeGrain,
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs,
-            Optional<DateTime> expectedStartDate,
-            Optional<DateTime> expectedEndDate
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
     ) {
         super(name, timeGrain, metricNames, dimensionConfigs, expectedStartDate, expectedEndDate);
     }
@@ -85,8 +84,8 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
                 metricNames,
                 dimensionConfigs,
                 logicalToPhysicalNames,
-                Optional.empty(),
-                Optional.empty()
+                null,
+                null
         );
     }
 
@@ -109,8 +108,8 @@ public class ConcretePhysicalTableDefinition extends PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames,
-            Optional<DateTime> expectedStartDate,
-            Optional<DateTime> expectedEndDate
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
     ) {
         super(
                 name,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,7 +40,7 @@ public abstract class PhysicalTableDefinition {
     private final Set<FieldName> metricNames;
     private final Set<? extends DimensionConfig> dimensionConfigs;
     private final Map<String, String> logicalToPhysicalNames;
-    private final DateTime expectedStartDate, expectedEndDate;
+    private final Optional<DateTime> expectedStartDate, expectedEndDate;
 
     /**
      * Constructor for sub-class to call.
@@ -55,7 +56,7 @@ public abstract class PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs
     ) {
-        this(name, timeGrain, metricNames, dimensionConfigs, null, null);
+        this(name, timeGrain, metricNames, dimensionConfigs, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -75,8 +76,8 @@ public abstract class PhysicalTableDefinition {
             ZonedTimeGrain timeGrain,
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs,
-            DateTime expectedStartDate,
-            DateTime expectedEndDate
+            Optional<DateTime> expectedStartDate,
+            Optional<DateTime> expectedEndDate
     ) {
         this.name = name;
         this.timeGrain = timeGrain;
@@ -103,7 +104,15 @@ public abstract class PhysicalTableDefinition {
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames
     ) {
-        this(name, timeGrain, metricNames, dimensionConfigs, logicalToPhysicalNames, null, null);
+        this(
+                name,
+                timeGrain,
+                metricNames,
+                dimensionConfigs,
+                logicalToPhysicalNames,
+                Optional.empty(),
+                Optional.empty()
+        );
     }
 
     /**
@@ -125,8 +134,8 @@ public abstract class PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames,
-            DateTime expectedStartDate,
-            DateTime expectedEndDate
+            Optional<DateTime> expectedStartDate,
+            Optional<DateTime> expectedEndDate
     ) {
         this.name = name;
         this.timeGrain = timeGrain;
@@ -157,11 +166,11 @@ public abstract class PhysicalTableDefinition {
             DataSourceMetadataService metadataService
     );
 
-    public DateTime getExpectedStartDate() {
+    public Optional<DateTime> getExpectedStartDate() {
         return expectedStartDate;
     }
 
-    public DateTime getExpectedEndDate() {
+    public Optional<DateTime> getExpectedEndDate() {
         return expectedEndDate;
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
@@ -17,6 +17,7 @@ import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ public abstract class PhysicalTableDefinition {
     private final Set<FieldName> metricNames;
     private final Set<? extends DimensionConfig> dimensionConfigs;
     private final Map<String, String> logicalToPhysicalNames;
+    private final DateTime expectedStartDate, expectedEndDate;
 
     /**
      * Constructor for sub-class to call.
@@ -53,11 +55,36 @@ public abstract class PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs
     ) {
+        this(name, timeGrain, metricNames, dimensionConfigs, null, null);
+    }
+
+    /**
+     * Constructor for sub-class to call.
+     *
+     * @param name  Table name of the physical table
+     * @param timeGrain  Zoned time grain of the table
+     * @param metricNames  The Set of metric names on the table
+     * @param dimensionConfigs  Set of dimensions on the table as dimension configs
+     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Null
+     * indicates there is NO expected start date
+     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Null
+     * indicates there is NO expected end date
+     */
+    protected PhysicalTableDefinition(
+            TableName name,
+            ZonedTimeGrain timeGrain,
+            Set<FieldName> metricNames,
+            Set<? extends DimensionConfig> dimensionConfigs,
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
+    ) {
         this.name = name;
         this.timeGrain = timeGrain;
         this.metricNames = ImmutableSet.copyOf(metricNames);
         this.dimensionConfigs = ImmutableSet.copyOf(dimensionConfigs);
         this.logicalToPhysicalNames = Collections.unmodifiableMap(buildLogicalToPhysicalNames(dimensionConfigs));
+        this.expectedStartDate = expectedStartDate;
+        this.expectedEndDate = expectedEndDate;
     }
 
     /**
@@ -76,11 +103,38 @@ public abstract class PhysicalTableDefinition {
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames
     ) {
+        this(name, timeGrain, metricNames, dimensionConfigs, logicalToPhysicalNames, null, null);
+    }
+
+    /**
+     * Constructor with provided logical to physical name mapping.
+     *
+     * @param name  Table name of the physical table
+     * @param timeGrain  Zoned time grain of the table
+     * @param metricNames  The Set of metric names on the table
+     * @param dimensionConfigs  Set of dimensions on the table as dimension configs
+     * @param logicalToPhysicalNames  A map from logical column names to physical column names
+     * @param expectedStartDate  The expected start date of the datasource the constructed table will represent. Null
+     * indicates there is NO expected start date
+     * @param expectedEndDate  The expected end date of the datasource the constructed table will represent. Null
+     * indicates there is NO expected end date
+     */
+    protected PhysicalTableDefinition(
+            TableName name,
+            ZonedTimeGrain timeGrain,
+            Set<FieldName> metricNames,
+            Set<? extends DimensionConfig> dimensionConfigs,
+            Map<String, String> logicalToPhysicalNames,
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
+    ) {
         this.name = name;
         this.timeGrain = timeGrain;
         this.metricNames = ImmutableSet.copyOf(metricNames);
         this.dimensionConfigs = ImmutableSet.copyOf(dimensionConfigs);
         this.logicalToPhysicalNames = ImmutableMap.copyOf(logicalToPhysicalNames);
+        this.expectedStartDate = expectedStartDate;
+        this.expectedEndDate = expectedEndDate;
     }
 
     /**
@@ -102,6 +156,14 @@ public abstract class PhysicalTableDefinition {
             ResourceDictionaries dictionaries,
             DataSourceMetadataService metadataService
     );
+
+    public DateTime getExpectedStartDate() {
+        return expectedStartDate;
+    }
+
+    public DateTime getExpectedEndDate() {
+        return expectedEndDate;
+    }
 
     public TableName getName() {
         return name;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,7 +39,7 @@ public abstract class PhysicalTableDefinition {
     private final Set<FieldName> metricNames;
     private final Set<? extends DimensionConfig> dimensionConfigs;
     private final Map<String, String> logicalToPhysicalNames;
-    private final Optional<DateTime> expectedStartDate, expectedEndDate;
+    private final DateTime expectedStartDate, expectedEndDate;
 
     /**
      * Constructor for sub-class to call.
@@ -56,7 +55,7 @@ public abstract class PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs
     ) {
-        this(name, timeGrain, metricNames, dimensionConfigs, Optional.empty(), Optional.empty());
+        this(name, timeGrain, metricNames, dimensionConfigs, null, null);
     }
 
     /**
@@ -76,8 +75,8 @@ public abstract class PhysicalTableDefinition {
             ZonedTimeGrain timeGrain,
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs,
-            Optional<DateTime> expectedStartDate,
-            Optional<DateTime> expectedEndDate
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
     ) {
         this.name = name;
         this.timeGrain = timeGrain;
@@ -110,8 +109,8 @@ public abstract class PhysicalTableDefinition {
                 metricNames,
                 dimensionConfigs,
                 logicalToPhysicalNames,
-                Optional.empty(),
-                Optional.empty()
+                null,
+                null
         );
     }
 
@@ -134,8 +133,8 @@ public abstract class PhysicalTableDefinition {
             Set<FieldName> metricNames,
             Set<? extends DimensionConfig> dimensionConfigs,
             Map<String, String> logicalToPhysicalNames,
-            Optional<DateTime> expectedStartDate,
-            Optional<DateTime> expectedEndDate
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
     ) {
         this.name = name;
         this.timeGrain = timeGrain;
@@ -166,11 +165,11 @@ public abstract class PhysicalTableDefinition {
             DataSourceMetadataService metadataService
     );
 
-    public Optional<DateTime> getExpectedStartDate() {
+    public DateTime getExpectedStartDate() {
         return expectedStartDate;
     }
 
-    public Optional<DateTime> getExpectedEndDate() {
+    public DateTime getExpectedEndDate() {
         return expectedEndDate;
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/PhysicalTableDefinition.java
@@ -42,7 +42,7 @@ public abstract class PhysicalTableDefinition {
     private final DateTime expectedStartDate, expectedEndDate;
 
     /**
-     * Constructor for sub-class to call.
+     * Constructor for sub-class to call. Defaults to no expected start nor end dates.
      *
      * @param name  Table name of the physical table
      * @param timeGrain  Zoned time grain of the table
@@ -88,7 +88,7 @@ public abstract class PhysicalTableDefinition {
     }
 
     /**
-     * Constructor with provided logical to physical name mapping.
+     * Constructor with provided logical to physical name mapping. Defaults to no expected start nor end dates.
      *
      * @param name  Table name of the physical table
      * @param timeGrain  Zoned time grain of the table

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/StrictPhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/StrictPhysicalTable.java
@@ -11,6 +11,7 @@ import com.yahoo.bard.webservice.table.availability.StrictAvailability;
 import org.joda.time.DateTime;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.constraints.NotNull;
@@ -42,8 +43,8 @@ public class StrictPhysicalTable extends SingleDataSourcePhysicalTable {
                 columns,
                 logicalToPhysicalColumnNames,
                 metadataService,
-                null,
-                null
+                Optional.empty(),
+                Optional.empty()
         );
     }
 
@@ -56,9 +57,9 @@ public class StrictPhysicalTable extends SingleDataSourcePhysicalTable {
      * @param columns  The columns for this table
      * @param logicalToPhysicalColumnNames  Mappings from logical to physical names
      * @param metadataService  Datasource metadata service containing availability data for the table
-     * @param expectedStartDate  The expected start date of the datasource for this availability. Null indicates no
+     * @param expectedStartDate  The expected start date of the datasource for this availability. Empty indicates no
      * expected start date
-     * @param expectedEndDate  The expected end date of the datasource for this availability. Null indicates no
+     * @param expectedEndDate  The expected end date of the datasource for this availability. Empty indicates no
      * expected end date
      */
     public StrictPhysicalTable(
@@ -67,8 +68,8 @@ public class StrictPhysicalTable extends SingleDataSourcePhysicalTable {
             @NotNull Set<Column> columns,
             @NotNull Map<String, String> logicalToPhysicalColumnNames,
             @NotNull DataSourceMetadataService metadataService,
-            DateTime expectedStartDate,
-            DateTime expectedEndDate
+            Optional<DateTime> expectedStartDate,
+            Optional<DateTime> expectedEndDate
     ) {
         this(
                 name,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/StrictPhysicalTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/StrictPhysicalTable.java
@@ -11,7 +11,6 @@ import com.yahoo.bard.webservice.table.availability.StrictAvailability;
 import org.joda.time.DateTime;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.constraints.NotNull;
@@ -43,8 +42,8 @@ public class StrictPhysicalTable extends SingleDataSourcePhysicalTable {
                 columns,
                 logicalToPhysicalColumnNames,
                 metadataService,
-                Optional.empty(),
-                Optional.empty()
+                null,
+                null
         );
     }
 
@@ -68,8 +67,8 @@ public class StrictPhysicalTable extends SingleDataSourcePhysicalTable {
             @NotNull Set<Column> columns,
             @NotNull Map<String, String> logicalToPhysicalColumnNames,
             @NotNull DataSourceMetadataService metadataService,
-            Optional<DateTime> expectedStartDate,
-            Optional<DateTime> expectedEndDate
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
     ) {
         this(
                 name,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/StrictAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/StrictAvailability.java
@@ -33,7 +33,7 @@ public class StrictAvailability extends BaseMetadataAvailability {
             @NotNull DataSourceName dataSourceName,
             @NotNull DataSourceMetadataService metadataService
     ) {
-        this(dataSourceName, metadataService, null, null);
+        this(dataSourceName, metadataService, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -41,18 +41,18 @@ public class StrictAvailability extends BaseMetadataAvailability {
      *
      * @param dataSourceName  The name of the data source associated with this Availability
      * @param metadataService  A service containing the datasource segment data
-     * @param expectedStartDate  The expected start date of this availability. Null indicates no expected start date
+     * @param expectedStartDate  The expected start date of this availability. Empty indicates no expected start date
      * @param expectedEndDate  The expected end date of this availability. Null indicates no expected end date
      */
     public StrictAvailability(
             @NotNull DataSourceName dataSourceName,
             @NotNull DataSourceMetadataService metadataService,
-            DateTime expectedStartDate,
-            DateTime expectedEndDate
+            Optional<DateTime> expectedStartDate,
+            Optional<DateTime> expectedEndDate
     ) {
         super(dataSourceName, metadataService);
-        this.expectedStartDate = Optional.ofNullable(expectedStartDate);
-        this.expectedEndDate = Optional.ofNullable(expectedEndDate);
+        this.expectedStartDate = expectedStartDate;
+        this.expectedEndDate = expectedEndDate;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/StrictAvailability.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/availability/StrictAvailability.java
@@ -33,7 +33,7 @@ public class StrictAvailability extends BaseMetadataAvailability {
             @NotNull DataSourceName dataSourceName,
             @NotNull DataSourceMetadataService metadataService
     ) {
-        this(dataSourceName, metadataService, Optional.empty(), Optional.empty());
+        this(dataSourceName, metadataService, null, null);
     }
 
     /**
@@ -47,12 +47,12 @@ public class StrictAvailability extends BaseMetadataAvailability {
     public StrictAvailability(
             @NotNull DataSourceName dataSourceName,
             @NotNull DataSourceMetadataService metadataService,
-            Optional<DateTime> expectedStartDate,
-            Optional<DateTime> expectedEndDate
+            DateTime expectedStartDate,
+            DateTime expectedEndDate
     ) {
         super(dataSourceName, metadataService);
-        this.expectedStartDate = expectedStartDate;
-        this.expectedEndDate = expectedEndDate;
+        this.expectedStartDate = Optional.ofNullable(expectedStartDate);
+        this.expectedEndDate = Optional.ofNullable(expectedEndDate);
     }
 
     @Override


### PR DESCRIPTION
issue: https://github.com/yahoo/fili/issues/822

Customers that depend on physical table definitions to construct tables and availabilities have a difficult time using the expected start and end date functionality. This PR adds some constructors to make the feature more usable.