### PR TITLE
upgrading spock-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
             <dependency><!-- Mandatory dependency for using Spock -->
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-core</artifactId>
-                <version>1.0-groovy-2.4</version>
+                <version>1.2-groovy-2.4</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
Spock-core version `1.0-groovy-2.4` and below does not allow Mocking final classes like Optional. This PR upgrades spock-core to a stable version that allows Mocking final classes.