### PR TITLE
Resolving code warnings and other IDE detected nusiances

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -145,7 +145,6 @@ import rx.subjects.PublishSubject;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.lang.reflect.Constructor;
 import java.time.Clock;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -1243,9 +1242,10 @@ public abstract class AbstractBinderFactory implements BinderFactory {
         String customSupplierClassString = SYSTEM_CONFIG.getStringProperty(DRUID_HEADER_SUPPLIER_CLASS, null);
         if (customSupplierClassString != null && !customSupplierClassString.equals("")) {
             try {
-                Class<?> c = Class.forName(customSupplierClassString);
-                Constructor<?> constructor = c.getConstructor();
-                supplier = (Supplier<Map<String, String>>) constructor.newInstance();
+                @SuppressWarnings("unchecked")
+                Class<? extends Supplier<Map<String, String>>> c = (Class) Class
+                    .forName(customSupplierClassString).asSubclass(Supplier.class);
+                supplier = c.getConstructor().newInstance();
             } catch (Exception e) {
                 LOG.error(
                         "Unable to load the Druid query header supplier, className: {}, exception: {}",

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -1244,7 +1244,7 @@ public abstract class AbstractBinderFactory implements BinderFactory {
             try {
                 @SuppressWarnings("unchecked")
                 Class<? extends Supplier<Map<String, String>>> c = (Class) Class
-                    .forName(customSupplierClassString).asSubclass(Supplier.class);
+                        .forName(customSupplierClassString).asSubclass(Supplier.class);
                 supplier = c.getConstructor().newInstance();
             } catch (Exception e) {
                 LOG.error(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/ResourceConfig.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/ResourceConfig.java
@@ -39,8 +39,8 @@ public class ResourceConfig extends org.glassfish.jersey.server.ResourceConfig {
      */
     public ResourceConfig() throws ClassNotFoundException, InstantiationException, IllegalAccessException {
         // Build the binder using the configured factory
-        Class<?> binderClass = Class.forName(bindingFactory);
-        BinderFactory binderFactory = (BinderFactory) binderClass.newInstance();
+        Class<? extends BinderFactory> binderClass = Class.forName(bindingFactory).asSubclass(BinderFactory.class);
+        BinderFactory binderFactory = binderClass.newInstance();
         Binder binder = binderFactory.buildBinder();
 
         // Register Instrumentation

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
@@ -137,7 +137,6 @@ public class HttpResponseMaker {
             ApiRequest apiRequest,
             ContainerRequestContext containerRequestContext
     ) {
-        @SuppressWarnings("unchecked")
         ResponseFormatType responseFormatType = apiRequest.getFormat();
         Map<String, URI> bodyLinks = (Map<String, URI>) responseContext.get(
                 PAGINATION_LINKS_CONTEXT_KEY.getName()

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/HttpResponseMaker.java
@@ -138,13 +138,14 @@ public class HttpResponseMaker {
             ContainerRequestContext containerRequestContext
     ) {
         ResponseFormatType responseFormatType = apiRequest.getFormat();
+        @SuppressWarnings("unchecked")
         Map<String, URI> bodyLinks = (Map<String, URI>) responseContext.get(
                 PAGINATION_LINKS_CONTEXT_KEY.getName()
         );
         if (bodyLinks == null) {
             bodyLinks = Collections.emptyMap();
         }
-        Pagination pagination = (Pagination) responseContext.get(PAGINATION_CONTEXT_KEY.getName());
+        Pagination<?> pagination = (Pagination<?>) responseContext.get(PAGINATION_CONTEXT_KEY.getName());
 
         // Add headers for content type
         // default response format is JSON
@@ -152,6 +153,7 @@ public class HttpResponseMaker {
             responseFormatType = DefaultResponseFormatType.JSON;
         }
 
+        @SuppressWarnings("unchecked")
         LinkedHashMap<String, LinkedHashSet<DimensionField>> dimensionToDimensionFieldMap =
                 (LinkedHashMap<String, LinkedHashSet<DimensionField>>) responseContext.get(
                         REQUESTED_API_DIMENSION_FIELDS.getName());
@@ -169,6 +171,7 @@ public class HttpResponseMaker {
                                 LinkedHashMap::new
                         ));
 
+        @SuppressWarnings("unchecked")
         ResponseData responseData = buildResponseData(
                 resultSet,
                 (LinkedHashSet<String>) responseContext.get(API_METRIC_COLUMN_NAMES.getName()),
@@ -237,7 +240,7 @@ public class HttpResponseMaker {
             LinkedHashMap<Dimension, LinkedHashSet<DimensionField>> requestedApiDimensionFields,
             SimplifiedIntervalList partialIntervals,
             SimplifiedIntervalList volatileIntervals,
-            Pagination pagination,
+            Pagination<?> pagination,
             Map<String, URI> paginationLinks
     ) {
         return new ResponseData(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/MetricMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/MetricMaker.java
@@ -254,7 +254,7 @@ public abstract class MetricMaker {
         return field.isSketch() ?
                 FieldConverterSupplier.sketchConverter.asSketchEstimate(field) :
                 field instanceof Aggregation ?
-                        new FieldAccessorPostAggregation((Aggregation) field) :
+                        new FieldAccessorPostAggregation(field) :
                         (PostAggregation) field;
     }
 
@@ -319,7 +319,7 @@ public abstract class MetricMaker {
         // Handle it if it's an Aggregation (ie. wrap it in a fieldAccessorPostAggregation)
         // If it's already a post-agg, we're good, and if it was an agg, we've already wrapped it
         return field instanceof Aggregation ?
-                new FieldAccessorPostAggregation((Aggregation) field) :
+                new FieldAccessorPostAggregation(field) :
                 (PostAggregation) field;
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/RowNumMaker.java
@@ -16,7 +16,6 @@ public class RowNumMaker extends MetricMaker {
 
     private static final RowNumMapper ROW_NUM_MAPPER = new RowNumMapper();
     private static final int DEPENDENT_METRICS_REQUIRED = 0;
-    private static final String DEFAULT_DESCRIPTION = "Generator for Row Numbers";
 
     /**
      * Constructor.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchMaker.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/metric/makers/ThetaSketchMaker.java
@@ -20,7 +20,7 @@ public class ThetaSketchMaker extends RawAggregationMetricMaker {
      * @param sketchSize  The size beyond which the sketch constructed by this maker should perform approximations.
      */
     public ThetaSketchMaker(MetricDictionary metrics, int sketchSize) {
-        super(metrics, ((name, fieldName) -> new ThetaSketchAggregation(name, fieldName, sketchSize)));
+        super(metrics, (name, fieldName) -> new ThetaSketchAggregation(name, fieldName, sketchSize));
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
@@ -91,8 +91,6 @@ public abstract class BaseTableLoader implements TableLoader {
                 tableDefinitions
         );
 
-        PhysicalTableDictionary physicalTableDictionary = dictionaries.getPhysicalDictionary();
-
         // Get the physical table from physical table dictionary, if not exist, build it and put it in dictionary
         LinkedHashSet<PhysicalTable> physicalTables = currentTableGroupTableNames.stream()
                 .map(TableName::asName)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
@@ -117,7 +117,7 @@ public class MetricUnionCompositeTableDefinition extends PhysicalTableDefinition
                                     )))
             );
         } catch (IllegalArgumentException e) {
-            String message = String.format(VALIDATION_ERROR_FORMAT, e.getMessage());
+            String message = String.format(VALIDATION_ERROR_FORMAT, getName(), e.getMessage());
             LOG.error(message);
             throw new IllegalArgumentException(message);
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/MetricUnionCompositeTableDefinition.java
@@ -13,6 +13,7 @@ import com.yahoo.bard.webservice.table.BaseCompositePhysicalTable;
 import com.yahoo.bard.webservice.table.Column;
 import com.yahoo.bard.webservice.table.ConfigPhysicalTable;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
+import com.yahoo.bard.webservice.table.Schema;
 import com.yahoo.bard.webservice.table.Table;
 import com.yahoo.bard.webservice.table.availability.MetricUnionAvailability;
 import com.yahoo.bard.webservice.util.Utils;
@@ -143,7 +144,7 @@ public class MetricUnionCompositeTableDefinition extends PhysicalTableDefinition
             throw new IllegalArgumentException(message);
         }
         return tableNames.stream()
-                .map(it -> physicalTableDictionary.get(it))
+                .map(physicalTableDictionary::get)
                 .collect(Collectors.toSet());
     }
 
@@ -172,7 +173,7 @@ public class MetricUnionCompositeTableDefinition extends PhysicalTableDefinition
 
         Set<String> tableColumnNames = tableMetricMap.keySet().stream()
                 .map(Table::getSchema)
-                .map(schema -> schema.getColumns())
+                .map(Schema::getColumns)
                 .flatMap(Set::stream)
                 .map(Column::getName)
                 .collect(Collectors.toSet());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/ScanSearchProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/dimension/impl/ScanSearchProvider.java
@@ -410,7 +410,8 @@ public class ScanSearchProvider implements SearchProvider, FilterDimensionRows {
      * @return  The index of rows
      */
     private List<String> getDimRowIndexes() {
-        return readValue(new TypeReference<List>() { }, keyValueStore.get(DimensionStoreKeyUtils.getAllValuesKey()));
+        return readValue(new TypeReference<List<String>>() { },
+            keyValueStore.get(DimensionStoreKeyUtils.getAllValuesKey()));
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/MemoizingDimensionMappingResultSetMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/MemoizingDimensionMappingResultSetMapper.java
@@ -94,10 +94,10 @@ public class MemoizingDimensionMappingResultSetMapper extends ResultSetMapper {
                 (dimensionColumn, dimensionRow) -> dimensionColumn.getDimension().equals(dimensionToMap);
 
         BiFunction<DimensionColumn, DimensionRow, Map.Entry<DimensionColumn, DimensionRow>> entryMapper =
-                ((dimensionColumn, dimensionRow) -> {
+                (dimensionColumn, dimensionRow) -> {
                     DimensionRow newRow = DimensionRow.copyWithReplace(dimensionRow, fieldMapper);
                     return new AbstractMap.SimpleEntry<>(dimensionColumn, newRow);
-                });
+                };
 
         return new MemoizingDimensionMappingResultSetMapper(entryMatcher,  entryMapper, true);
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/PartialDataResultSetMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/PartialDataResultSetMapper.java
@@ -10,8 +10,6 @@ import com.yahoo.bard.webservice.data.time.TimeGrain;
 import com.yahoo.bard.webservice.util.SimplifiedIntervalList;
 
 import org.joda.time.Interval;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -20,8 +18,6 @@ import java.util.function.Supplier;
  * A mapper that removes results which overlap a missing interval set.
  */
 public class PartialDataResultSetMapper extends ResultSetMapper {
-    private static final Logger LOG = LoggerFactory.getLogger(PartialDataResultSetMapper.class);
-
     final SimplifiedIntervalList missingIntervals;
     final Supplier<SimplifiedIntervalList> volatileIntervalSupply;
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/builders/ConjunctionDruidFilterBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/builders/ConjunctionDruidFilterBuilder.java
@@ -230,7 +230,7 @@ public abstract class ConjunctionDruidFilterBuilder implements DruidFilterBuilde
         final Function<DimensionRow, Filter> finalFilterBuilder = filterBuilder;
 
         return rows.stream()
-                .map(row -> finalFilterBuilder.apply(row))
+                .map(finalFilterBuilder::apply)
                 .collect(Collectors.toList());
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/filter/InFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/filter/InFilter.java
@@ -53,7 +53,7 @@ public class InFilter extends DimensionalFilter<InFilter> {
      * @return The set of values to filter on
      */
     public TreeSet<String> getValues() {
-        return new TreeSet(values);
+        return new TreeSet<>(values);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/DruidAggregationQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/DruidAggregationQuery.java
@@ -94,7 +94,7 @@ public interface DruidAggregationQuery<Q extends DruidAggregationQuery<? super Q
     @Override
     @JsonIgnore
     default Optional<? extends DruidAggregationQuery> getInnerQuery() {
-        return (Optional<? extends DruidAggregationQuery>) DruidFactQuery.super.getInnerQuery();
+        return DruidFactQuery.super.getInnerQuery().map(DruidAggregationQuery.class::cast);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/DruidFactQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/DruidFactQuery.java
@@ -82,7 +82,7 @@ public interface DruidFactQuery<Q extends DruidFactQuery<? super Q>> extends Dru
     @Override
     @JsonIgnore
     default Optional<? extends DruidFactQuery> getInnerQuery() {
-        return (Optional<? extends DruidFactQuery>) DruidQuery.super.getInnerQuery();
+        return DruidQuery.super.getInnerQuery().map(DruidFactQuery.class::cast);
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/GroupByQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/GroupByQuery.java
@@ -161,7 +161,6 @@ public class GroupByQuery extends AbstractDruidAggregationQuery<GroupByQuery> {
 
     @Override
     public GroupByQuery withInnermostDataSource(DataSource dataSource) {
-        @SuppressWarnings("unchecked")
         Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast);
         return !innerQuery.isPresent() ?
                 withDataSource(dataSource) :

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/GroupByQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/GroupByQuery.java
@@ -162,7 +162,7 @@ public class GroupByQuery extends AbstractDruidAggregationQuery<GroupByQuery> {
     @Override
     public GroupByQuery withInnermostDataSource(DataSource dataSource) {
         @SuppressWarnings("unchecked")
-        Optional<DruidFactQuery<?>> innerQuery = (Optional<DruidFactQuery<?>>) this.dataSource.getQuery();
+        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast);
         return !innerQuery.isPresent() ?
                 withDataSource(dataSource) :
                 withDataSource(new QueryDataSource(innerQuery.get().withInnermostDataSource(dataSource)));

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/GroupByQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/GroupByQuery.java
@@ -161,6 +161,7 @@ public class GroupByQuery extends AbstractDruidAggregationQuery<GroupByQuery> {
 
     @Override
     public GroupByQuery withInnermostDataSource(DataSource dataSource) {
+        @SuppressWarnings("unchecked")
         Optional<DruidFactQuery<?>> innerQuery = (Optional<DruidFactQuery<?>>) this.dataSource.getQuery();
         return !innerQuery.isPresent() ?
                 withDataSource(dataSource) :
@@ -206,7 +207,7 @@ public class GroupByQuery extends AbstractDruidAggregationQuery<GroupByQuery> {
 
     @Override
     public GroupByQuery withAllIntervals(Collection<Interval> intervals) {
-        Optional<DruidFactQuery<?>> innerQuery = (Optional<DruidFactQuery<?>>) this.dataSource.getQuery();
+        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast);
         return !innerQuery.isPresent() ?
                 withIntervals(intervals) :
                 withDataSource(new QueryDataSource(innerQuery.get().withAllIntervals(intervals))).withIntervals(intervals);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/LookbackQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/LookbackQuery.java
@@ -137,7 +137,7 @@ public class LookbackQuery extends AbstractDruidAggregationQuery<LookbackQuery> 
 
     @Override
     public Optional<? extends DruidAggregationQuery> getInnerQuery() {
-        return (Optional<? extends DruidAggregationQuery>) this.dataSource.getQuery();
+        return this.dataSource.getQuery().map(DruidAggregationQuery.class::cast);
     }
 
     /**
@@ -284,7 +284,7 @@ public class LookbackQuery extends AbstractDruidAggregationQuery<LookbackQuery> 
 
     @Override
     public LookbackQuery withAllIntervals(Collection<Interval> intervals) {
-        Optional<DruidFactQuery<?>> innerQuery = (Optional<DruidFactQuery<?>>) this.dataSource.getQuery();
+        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast);
         return !innerQuery.isPresent() ?
                 withIntervals(intervals) :
                 withDataSource(new QueryDataSource(innerQuery.get().withAllIntervals(intervals))).withIntervals(intervals);
@@ -297,7 +297,7 @@ public class LookbackQuery extends AbstractDruidAggregationQuery<LookbackQuery> 
 
     @Override
     public LookbackQuery withInnermostDataSource(DataSource dataSource) {
-        Optional<DruidFactQuery<?>> innerQuery = (Optional<DruidFactQuery<?>>) this.dataSource.getQuery();
+        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast);;
         return (innerQuery == null) ?
                 withDataSource(dataSource) :
                 withDataSource(new QueryDataSource(innerQuery.get().withInnermostDataSource(dataSource)));

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/LookbackQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/LookbackQuery.java
@@ -297,7 +297,7 @@ public class LookbackQuery extends AbstractDruidAggregationQuery<LookbackQuery> 
 
     @Override
     public LookbackQuery withInnermostDataSource(DataSource dataSource) {
-        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast);;
+        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast);
         return (innerQuery == null) ?
                 withDataSource(dataSource) :
                 withDataSource(new QueryDataSource(innerQuery.get().withInnermostDataSource(dataSource)));

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogFormatterProvider.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/LogFormatterProvider.java
@@ -37,7 +37,7 @@ public class LogFormatterProvider {
                     DEFAULT_LOG_FORMATTER_IMPL
             );
             try {
-                logFormatter = (LogFormatter) Class.forName(logFormatterImplementation).newInstance();
+                logFormatter = Class.forName(logFormatterImplementation).asSubclass(LogFormatter.class).newInstance();
             } catch (Exception exception) {
                 LOG.error("Exception while loading Log formatter: {}", exception);
                 throw new IllegalStateException(exception);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -112,8 +112,7 @@ public class RequestLog {
         getLoginfoOrder().stream().filter(entry -> !Objects.equals(entry, "Epilogue")).forEachOrdered(
                 entry -> {
                     try {
-                        @SuppressWarnings("unchecked")
-                        Class<LogInfo> cls = (Class<LogInfo>) Class.forName(entry);
+                        Class<? extends LogInfo> cls = Class.forName(entry).asSubclass(LogInfo.class);
                         info.add(cls);
                     } catch (ClassNotFoundException | ClassCastException e) {
                         String msg = ErrorMessageFormat.LOGINFO_CLASS_INVALID.logFormat(entry);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/blocks/BardQueryInfo.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/blocks/BardQueryInfo.java
@@ -7,9 +7,6 @@ import com.yahoo.bard.webservice.logging.RequestLog;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -21,7 +18,6 @@ import java.util.stream.Stream;
  */
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY)
 public class BardQueryInfo implements LogInfo {
-    private static final Logger LOG = LoggerFactory.getLogger(BardQueryInfo.class);
     public static final String WEIGHT_CHECK = "weightCheckQueries";
     public static final String FACT_QUERIES = "factQueryCount";
     public static final String FACT_QUERY_CACHE_HIT = "factCacheHits";

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/IntervalUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/IntervalUtils.java
@@ -88,7 +88,7 @@ public class IntervalUtils {
      * @return A set of intervals describing the time common to both sets
      */
     public static Set<Interval> getOverlappingSubintervals(Set<Interval> left, Set<Interval> right) {
-        return getOverlappingSubintervals((Collection) left, (Collection) right);
+        return getOverlappingSubintervals((Collection<Interval>) left, (Collection<Interval>) right);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/Utils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/Utils.java
@@ -75,8 +75,8 @@ public class Utils {
      */
     public static <T, K extends T> LinkedHashSet<K> getSubsetByType(Collection<T> set, Class<K> type) {
         return set.stream()
-                .filter(member -> type.isAssignableFrom(member.getClass()))
-                .map(StreamUtils.uncheckedCast(type))
+                .filter(type::isInstance)
+                .map(type::cast)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/Utils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/Utils.java
@@ -76,7 +76,7 @@ public class Utils {
     public static <T, K extends T> LinkedHashSet<K> getSubsetByType(Collection<T> set, Class<K> type) {
         return set.stream()
                 .filter(type::isInstance)
-                .map(type::cast)
+                .map(StreamUtils.uncheckedCast(type))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ApiFilterGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ApiFilterGenerator.java
@@ -5,11 +5,6 @@ package com.yahoo.bard.webservice.web;
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 import com.yahoo.bard.webservice.web.apirequest.binders.FilterBinders;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.regex.Pattern;
-
 import javax.validation.constraints.NotNull;
 
 /**
@@ -20,10 +15,6 @@ import javax.validation.constraints.NotNull;
  */
 @Deprecated
 public class ApiFilterGenerator {
-    private static final Logger LOG = LoggerFactory.getLogger(ApiFilterGenerator.class);
-
-    private static Pattern pattern = Pattern.compile("([^\\|]+)\\|([^-]+)-([^\\[]+)\\[([^\\]]+)\\]?");
-
     /**
      * Parses the URL filter Query and generates the ApiFilter object.
      *
@@ -37,6 +28,7 @@ public class ApiFilterGenerator {
      *
      * @deprecated Use {@link FilterBinders#generateApiFilter(String, DimensionDictionary)}
      */
+    @Deprecated
     public static ApiFilter build(
             @NotNull String filterQuery,
             DimensionDictionary dimensionDictionary

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/FilteredThetaSketchMetricsHelper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/FilteredThetaSketchMetricsHelper.java
@@ -326,7 +326,7 @@ public class FilteredThetaSketchMetricsHelper implements MetricsFilterSetBuilder
             Map<String, List<FilteredAggregation>> filteredAggDictionary
     ) {
         if (postAggregation instanceof WithFields) {
-            WithFields withFieldsPostAgg = (WithFields) postAggregation;
+            WithFields<?> withFieldsPostAgg = (WithFields<?>) postAggregation;
 
             List<PostAggregation> resultPostAggsList = new ArrayList<>();
             //In case the postAgg has the function NOT, we apply INTERSECT on the left operand of the
@@ -356,7 +356,6 @@ public class FilteredThetaSketchMetricsHelper implements MetricsFilterSetBuilder
                 return withFieldsPostAgg.withFields(resultPostAggsList);
             }
 
-            @SuppressWarnings("unchecked")
             List<PostAggregation> childPostAggs = withFieldsPostAgg.getFields();
             for (PostAggregation postAgg : childPostAggs) {
                 resultPostAggsList.add(
@@ -398,22 +397,19 @@ public class FilteredThetaSketchMetricsHelper implements MetricsFilterSetBuilder
             String fieldName = ((FieldAccessorPostAggregation) postAggregation).getFieldName();
             if (oldNameToNewAggregationMapping.containsKey(fieldName)) {
                 return new FieldAccessorPostAggregation(oldNameToNewAggregationMapping.get(fieldName));
-
-            } else {
-                //The agg which this fieldAccessor is referencing has not changed. So return the fieldAccessor as it is.
-                return postAggregation;
             }
+            //The agg which this fieldAccessor is referencing has not changed. So return the fieldAccessor as it is.
+            return postAggregation;
 
         } else if (postAggregation instanceof WithFields) {
 
             List<PostAggregation> resultPostAggsList = new ArrayList<>();
-            @SuppressWarnings("unchecked")
-            List<PostAggregation> childPostAggs = ((WithFields) postAggregation).getFields();
+            List<PostAggregation> childPostAggs = ((WithFields<?>) postAggregation).getFields();
             for (PostAggregation postAgg : childPostAggs) {
                 resultPostAggsList.add(replacePostAggWithPostAggFromMap(postAgg, oldNameToNewAggregationMapping));
             }
 
-            return ((WithFields) postAggregation).withFields(resultPostAggsList);
+            return ((WithFields<?>) postAggregation).withFields(resultPostAggsList);
         } else {
             return postAggregation;
         }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DimensionsServlet.java
@@ -274,7 +274,6 @@ public class DimensionsServlet extends EndpointServlet {
             @Context final UriInfo uriInfo,
             @Context final ContainerRequestContext containerRequestContext
     ) {
-        Supplier<Response> responseSender;
         DimensionsApiRequest apiRequest = null;
         try {
             RequestLog.startTiming(this);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/EndpointServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/EndpointServlet.java
@@ -185,6 +185,7 @@ public abstract class EndpointServlet {
 
         Response.ResponseBuilder builder = responseBuilderSupplier.get();
 
+        @SuppressWarnings("unchecked")
         Stream<T> stream = ResponsePaginator.paginate(builder, pagination, uriInfo);
         Response.ResponseBuilder responseBuilder = Response.status(Response.Status.OK);
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/QueryParameterNormalizationFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/QueryParameterNormalizationFilter.java
@@ -190,7 +190,7 @@ public class QueryParameterNormalizationFilter implements ApplicationEventListen
     private static Stream<QueryParam> extractQueryParameters(Method method) {
         return Stream.of(method.getParameterAnnotations())
                 .flatMap(Stream::of)
-                .filter(annotation -> annotation.annotationType().isAssignableFrom(QueryParam.class))
+                .filter(QueryParam.class::isInstance)
                 .map(QueryParam.class::cast);
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/PartialDataRequestHandler.java
@@ -98,6 +98,7 @@ public class PartialDataRequestHandler implements DataRequestHandler {
      *
      * @return the missing intervals from the request or an empty list
      */
+    @SuppressWarnings("unchecked")
     public static SimplifiedIntervalList getPartialIntervalsWithDefault(Map<String, Serializable> context) {
         return new SimplifiedIntervalList(
                 (Collection<Interval>) context.computeIfAbsent(

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/VolatileDataRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/VolatileDataRequestHandler.java
@@ -87,6 +87,7 @@ public class VolatileDataRequestHandler implements DataRequestHandler {
      *
      * @return the volatile intervals from the request or an empty list
      */
+    @SuppressWarnings("unchecked")
     public static SimplifiedIntervalList getVolatileIntervalsWithDefault(Map<String, Serializable> context) {
         return new SimplifiedIntervalList(
                 (Collection<Interval>) context.computeIfAbsent(

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionMonthlyNonMonthlyMetricDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionMonthlyNonMonthlyMetricDataServletSpec.groovy
@@ -8,7 +8,6 @@ package com.yahoo.bard.webservice.web.endpoints
  */
 class NoDimensionMonthlyNonMonthlyMetricDataServletSpec extends BaseDataServletComponentSpec {
 
-    @SuppressWarnings("rawtypes")
     @Override
     Class<?>[] getResourceClasses() {
         [DataServlet.class]

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionNoTrailingSlashFilterDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionNoTrailingSlashFilterDataServletSpec.groovy
@@ -4,7 +4,6 @@ package com.yahoo.bard.webservice.web.endpoints
 
 class NoDimensionNoTrailingSlashFilterDataServletSpec extends BaseDataServletComponentSpec {
 
-    @SuppressWarnings("rawtypes")
     @Override
     Class<?>[] getResourceClasses() {
         [DataServlet.class]

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionTrailingSlashFilterDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/NoDimensionTrailingSlashFilterDataServletSpec.groovy
@@ -4,7 +4,6 @@ package com.yahoo.bard.webservice.web.endpoints
 
 class NoDimensionTrailingSlashFilterDataServletSpec extends BaseDataServletComponentSpec {
 
-    @SuppressWarnings("rawtypes")
     @Override
     Class<?>[] getResourceClasses() {
         [DataServlet.class]

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
@@ -302,7 +302,7 @@ public class ClassScanner {
         if (arg != null) {
             putInArgumentValueCache(arg.getClass(), arg);
         }
-        return (T) arg;
+        return arg;
     }
 
     /**
@@ -349,8 +349,7 @@ public class ClassScanner {
                 // find a subclass to construct
                 if (cls.isAssignableFrom(subclass) && !Modifier.isAbstract(subclass.getModifiers())) {
                     try {
-                        @SuppressWarnings("unchecked")
-                        T arg = constructObject((Class<T>) subclass, mode, stack);
+                        T arg = constructObject(subclass.asSubclass(cls), mode, stack);
                         if (arg != null) {
                             return arg;
                         }

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
@@ -375,7 +375,6 @@ public class ClassScanner {
      *
      * @return a mock if we have one, otherise just null
      */
-    @SuppressWarnings("unchecked")
     private <T> T getCachedValue(Class<T> cls) {
         return argumentValueCache.keySet().stream()
                 .filter(cls::isAssignableFrom)

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
@@ -215,7 +215,7 @@ public class ClassScanner {
                 boolean notnull = false;
                 Args argMode = mode;
                 for (Annotation annotation : constructor.getParameterAnnotations()[i]) {
-                    if (annotation.annotationType().isAssignableFrom(NotNull.class)) {
+                    if (NotNull.class.isInstance(annotation)) {
                         argMode = Args.VALUES;
                         notnull = true;
                         break;
@@ -377,11 +377,11 @@ public class ClassScanner {
      */
     @SuppressWarnings("unchecked")
     private <T> T getCachedValue(Class<T> cls) {
-        return (T) argumentValueCache.entrySet().stream()
-                .map(Map.Entry::getKey)
+        return argumentValueCache.keySet().stream()
                 .filter(cls::isAssignableFrom)
                 .findFirst()
                 .map(argumentValueCache::get)
+                .map(cls::cast)
                 .orElse(null);
     }
 

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/util/ClassScanner.java
@@ -381,7 +381,7 @@ public class ClassScanner {
                 .filter(cls::isAssignableFrom)
                 .findFirst()
                 .map(argumentValueCache::get)
-                .map(cls::cast)
+                .map(StreamUtils.uncheckedCast(cls))
                 .orElse(null);
     }
 

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/web/endpoints/JobsEndpointResources.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/web/endpoints/JobsEndpointResources.java
@@ -104,9 +104,9 @@ public class JobsEndpointResources {
         apiMetricColumnNames.add("pageViews");
 
         ResponseContext responseContext = new ResponseContext();
-        responseContext.put("headers", new MultivaluedHashMap<>());
-        responseContext.put("apiMetricColumnNames", apiMetricColumnNames);
-        responseContext.put("requestedApiDimensionFields", new LinkedHashMap<>());
+        responseContext.put(ResponseContextKeys.HEADERS.getName(), new MultivaluedHashMap<>());
+        responseContext.put(ResponseContextKeys.API_METRIC_COLUMN_NAMES.getName(), apiMetricColumnNames);
+        responseContext.put(ResponseContextKeys.REQUESTED_API_DIMENSION_FIELDS.getName(), new LinkedHashMap<>());
 
         PreResponse preResponse = new PreResponse(resultSet, responseContext);
         preResponseStore.save("ticket1", preResponse);
@@ -114,11 +114,11 @@ public class JobsEndpointResources {
         preResponseStore.save("IExistOnlyInPreResponseStore", preResponse);
 
         ResponseContext errorResponseContext = new ResponseContext();
-        errorResponseContext.put("headers", new MultivaluedHashMap<>());
+        errorResponseContext.put(ResponseContextKeys.HEADERS.getName(), new MultivaluedHashMap<>());
         errorResponseContext.put(ResponseContextKeys.STATUS.getName(), 500);
         errorResponseContext.put(ResponseContextKeys.ERROR_MESSAGE.getName(), "Error");
-        errorResponseContext.put("apiMetricColumnNames", apiMetricColumnNames);
-        errorResponseContext.put("requestedApiDimensionFields", new HashMap<>());
+        errorResponseContext.put(ResponseContextKeys.API_METRIC_COLUMN_NAMES.getName(), apiMetricColumnNames);
+        errorResponseContext.put(ResponseContextKeys.REQUESTED_API_DIMENSION_FIELDS.getName(), new LinkedHashMap<>());
         PreResponse errorPresResponse = new PreResponse(resultSet, errorResponseContext);
         preResponseStore.save("errorPreResponse", errorPresResponse);
 

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/SqlAggregationQuery.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/SqlAggregationQuery.java
@@ -90,7 +90,7 @@ public class SqlAggregationQuery extends AbstractDruidAggregationQuery<SqlAggreg
 
     @Override
     public SqlAggregationQuery withInnermostDataSource(DataSource dataSource) {
-        Optional<DruidFactQuery<?>> innerQuery = (Optional<DruidFactQuery<?>>) this.dataSource.getQuery();
+        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast)
         return !innerQuery.isPresent() ?
                 withDataSource(dataSource) :
                 withDataSource(new QueryDataSource(innerQuery.get().withInnermostDataSource(dataSource)));
@@ -135,7 +135,7 @@ public class SqlAggregationQuery extends AbstractDruidAggregationQuery<SqlAggreg
 
     @Override
     public SqlAggregationQuery withAllIntervals(Collection<Interval> intervals) {
-        Optional<DruidFactQuery<?>> innerQuery = (Optional<DruidFactQuery<?>>) this.dataSource.getQuery();
+        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast);
         return !innerQuery.isPresent() ?
                 withIntervals(intervals) :
                 withDataSource(new QueryDataSource(innerQuery.get().withAllIntervals(intervals))).withIntervals(intervals);

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/SqlAggregationQuery.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/SqlAggregationQuery.java
@@ -90,7 +90,7 @@ public class SqlAggregationQuery extends AbstractDruidAggregationQuery<SqlAggreg
 
     @Override
     public SqlAggregationQuery withInnermostDataSource(DataSource dataSource) {
-        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast)
+        Optional<DruidFactQuery<?>> innerQuery = this.dataSource.getQuery().map(DruidFactQuery.class::cast);
         return !innerQuery.isPresent() ?
                 withDataSource(dataSource) :
                 withDataSource(new QueryDataSource(innerQuery.get().withInnermostDataSource(dataSource)));

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigurationGraph.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/ConfigurationGraph.java
@@ -79,7 +79,6 @@ public class ConfigurationGraph {
      * @param configName  The resource name for that configuration
      * @param nameValidator  A function which throws exceptions on module names which are not valid.
      */
-    @SuppressWarnings("unchecked")
     private void addVertex(Configuration configuration, String configName, Consumer<String> nameValidator) {
         if (!configuration.containsKey(MODULE_NAME_KEY)) {
             // This may be the result of another library using one of our configuration names

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/LayeredFileSystemConfig.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/LayeredFileSystemConfig.java
@@ -67,7 +67,6 @@ public class LayeredFileSystemConfig implements SystemConfig {
      * Build a Layered File System Configuration, using first the environment and an application configuration source,
      * then drill down into available modules and load each of them in package dependency order.
      */
-    @SuppressWarnings(value = "unchecked")
     public LayeredFileSystemConfig() {
         masterConfiguration = new CompositeConfiguration();
         masterConfiguration.setThrowExceptionOnMissing(true);

--- a/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/SystemConfigProvider.java
+++ b/fili-system-config/src/main/java/com/yahoo/bard/webservice/config/SystemConfigProvider.java
@@ -33,7 +33,7 @@ public class SystemConfigProvider {
                 if (systemConfigImplementation == null) {
                     systemConfigImplementation = System.getProperty(SYSTEM_CONFIG_IMPL_KEY, DEFAULT_SYSTEM_CONFIG_IMPL);
                 }
-                return (SystemConfig) Class.forName(systemConfigImplementation).newInstance();
+                return Class.forName(systemConfigImplementation).asSubclass(SystemConfig.class).newInstance();
             } catch (Exception e) {
                 LOG.error("Exception while loading System configuration: {}", e.getMessage(), e);
                 throw new IllegalStateException(e);

--- a/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/WikiDimensions.java
+++ b/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/WikiDimensions.java
@@ -30,8 +30,6 @@ public class WikiDimensions {
 
     private final SystemConfig systemConfig = SystemConfigProvider.getInstance();
 
-    private final String defaultDimensionBackendKey = systemConfig.getPackageVariableName("dimension_backend");
-
     private final Set<DimensionConfig> dimensionConfigs;
     private final LinkedHashMap<String, DimensionConfig> wikiApiDimensionNameToConfig;
 

--- a/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/WikiDimensions.java
+++ b/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/dimension/WikiDimensions.java
@@ -2,8 +2,6 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.wiki.webservice.data.config.dimension;
 
-import com.yahoo.bard.webservice.config.SystemConfig;
-import com.yahoo.bard.webservice.config.SystemConfigProvider;
 import com.yahoo.bard.webservice.data.config.dimension.DefaultKeyValueStoreDimensionConfig;
 import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
 import com.yahoo.bard.webservice.data.dimension.DimensionField;
@@ -27,8 +25,6 @@ import java.util.stream.Collectors;
  * Hold all the dimension configurations for the sample Bard instance.
  */
 public class WikiDimensions {
-
-    private final SystemConfig systemConfig = SystemConfigProvider.getInstance();
 
     private final Set<DimensionConfig> dimensionConfigs;
     private final LinkedHashMap<String, DimensionConfig> wikiApiDimensionNameToConfig;


### PR DESCRIPTION
Use `Class.asSubclass` for clearer compile time and runtime type checking.

Led to some spring cleaning of IDE warnings.