### PR TITLE
Unlikely argument type TableName for String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,8 @@ Current
 
 - [Updated copyright style to include Verizon Media Group](https://github.com/yahoo/fili/issues/856)
 
+- [Fixed incorrect key for physicalTableDictionary lookup](https://github.com/yahoo/fili/pull/859)
+
 ### Known Issues:
 
 ## Contract changes:

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table/BaseTableLoader.java
@@ -260,7 +260,7 @@ public abstract class BaseTableLoader implements TableLoader {
         currentTableDefinition.getDependentTableNames()
                 .forEach(
                         tableName -> {
-                            if (!physicalTableDictionary.containsKey(tableName)) {
+                            if (!physicalTableDictionary.containsKey(tableName.asName())) {
                                 physicalTableDictionary.put(
                                         tableName.asName(),
                                         buildPhysicalTableWithDependency(


### PR DESCRIPTION
Unlikely argument type `TableName` for `containsKey` on a `Map<String,ConfigPhysicalTable>`
	/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/table	line 263	