### PR TITLE
Fixing sonar integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
 - ssh-agent -k || true
 
 before_cache:
-- rm -rf ~/.m2/repository/com/com/yahoo/fili
+- rm -rf ~/.m2/repository/com/yahoo/fili
 
 after_success:
 - echo "Success."

--- a/pom.xml
+++ b/pom.xml
@@ -1028,6 +1028,9 @@
                     <name>env.SONAR_TOKEN</name>
                 </property>
             </activation>
+            <properties>
+                <sonar.login>${env.SONAR_TOKEN}</sonar.login>
+            </properties>
             <build>
                 <pluginManagement>
                     <plugins>


### PR DESCRIPTION
Cache was incorrectly storing recently built objects and authentication token wasn't being passed to Sonar.