### PR TITLE
Demonstrate error using immutableLinkedHashSet

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -1317,6 +1317,7 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
                             pathSegment -> dimensionDictionary.findByApiName(pathSegment.getPath()),
                             pathSegment -> bindShowClause(pathSegment, dimensionDictionary),
                             (LinkedHashSet<DimensionField> e, LinkedHashSet<DimensionField> i) -> {
+                                // I do not think you should  be modifying the provided LinkedHashSet here
                                 e.addAll(i);
                                 return e;
                             },

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -1362,6 +1362,12 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
         }
     }
 
+    /**
+     * Wrap LinkedHashSet as immutable LinkedHashSet.
+     * @param <E> type
+     * @param values source data
+     * @return immutable LinkedHashSet
+     */
     private static <E> LinkedHashSet<E> immutableLinkedHashSet(LinkedHashSet<E> values) {
         return new LinkedHashSet<E>(values) {
             private boolean locked = false;


### PR DESCRIPTION
We tracked down a bug where a query with a show causes the dimension's getDefaultDimensionFields to become corrupted. 

Attempting to recreate the error when I wrapped `getDefaultDimensionFields` in `ImmutableLinkedHashSet`
```
2019-04-25 23:48:37 INFO  c.y.b.w.e.FiliDataExceptionHandler - Exception processing request
java.lang.UnsupportedOperationException: null
    at ImmutableLinkedHashSet.addAll(ImmutableLinkedHashSet.java:90)
    at com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl.lambda$generateDimensionFields$5(DataApiRequestImpl.java:1317)
    at java.util.HashMap.merge(HashMap.java:1254)
    at com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl.generateDimensionFields(DataApiRequestImpl.java:1313)
    at com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl.bindDimensionFields(DataApiRequestImpl.java:929)
    at com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl.<init>(DataApiRequestImpl.java:497)
    at com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl.<init>(DataApiRequestImpl.java:273)
    at com.yahoo.bard.webservice.web.apirequest.DefaultDataApiRequestFactory.buildApiRequest(DefaultDataApiRequestFactory.java:76)
    at com.yahoo.bard.webservice.web.endpoints.DataServlet.getData(DataServlet.java:387)
```