### PR TITLE
Some cleanup of the recent bugfix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ Current
 
 ### Changed:
 
+- [StreamUtils::orderedSetMerge returns a LinkedHashSet](https://github.com/yahoo/fili/pull/898)
+    * This saves casting in places that expect a LinkedHashSet, and shouldn't affect anybody else using it.
+
 - [Fix security alerts & Dependency version bump](https://github.com/yahoo/fili/pull/882)
     * Checkstyle prior to 8.18 loads external DTDs by default, which can potentially lead to denial of service attacks
       or the leaking of confidential information.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/util/StreamUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/util/StreamUtils.java
@@ -210,7 +210,7 @@ public class StreamUtils {
      *
      * @return A new set containing the values of the original sets
      */
-    public static <T> Set<T> orderedSetMerge(Set<T> a, Set<T> b) {
+    public static <T> LinkedHashSet<T> orderedSetMerge(Set<T> a, Set<T> b) {
         return Stream.concat(a.stream(), b.stream()).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -1316,7 +1316,7 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
                             pathSegment -> dimensionDictionary.findByApiName(pathSegment.getPath()),
                             pathSegment -> bindShowClause(pathSegment, dimensionDictionary),
                             (LinkedHashSet<DimensionField> e, LinkedHashSet<DimensionField> i) ->
-                            (LinkedHashSet<DimensionField>) StreamUtils.orderedSetMerge(e, i),
+                                    StreamUtils.orderedSetMerge(e, i),
                             LinkedHashMap::new
                     ));
         }


### PR DESCRIPTION
-- StreamUtils::orderedSetMerge now returns a LinkedHashSet to save
casting in places that expected a LinkedHashSet. The change should be
save since everybody else using it expects only a Set.

-- Fixes some indentation.