### PR TITLE
Adds key-specific expiration to DataCache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Current
 
 ### Added:
 
+- [Add support to DataCache for key-specific expirations](https://github.com/yahoo/fili/pull/911)
+    * Adds a new method `boolean set(String key, T value, int expiration)` that allows customers to
+    to set the expiration date for a key when it is being added to the cache.
+    * The default implementation delegates to `boolean set(String key, T value)` (so throwing away the
+    expiration), so this won't affect any customers who have their own `DataCache`.
+    * The memcache-backed implementation implements the new `set`, and the old `set` delegates to it,
+    passing in the configured `EXPIRATION` constant. 
+
 - [Add config parameter to control lookback on druid dimension loader](https://github.com/yahoo/fili/issues/908)
     * Add config parameter: bard__druid_dim_loader_lookback_period to control window of time used in loading. 
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/DataCache.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/DataCache.java
@@ -2,6 +2,8 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.cache;
 
+import org.joda.time.DateTime;
+
 import java.io.Serializable;
 
 /**
@@ -41,16 +43,13 @@ public interface DataCache<T extends Serializable> {
      *
      * @param key  the key under which this object should be added.
      * @param value  the object to store
-     * @param expiration The expiration time, it may either be Unix time (number of seconds since January 1, 1970, as
-     * a 32-bit value), or a number of seconds starting from current time. In the latter case, this number of seconds
-     * may not exceed 60*60*24*30 (number of seconds in 30 days); if the number sent by a client is larger than that,
-     * the server will consider it to be real Unix time value rather than an offset from current time.
+     * @param expiration The date on which this key should expire
      *
      * @return a boolean representing success of this operation
      * @throws IllegalStateException in the rare circumstance where queue is too
      * full to accept any more requests
      */
-    default boolean set(String key, T value, int expiration) throws IllegalStateException {
+    default boolean set(String key, T value, DateTime expiration) throws IllegalStateException {
         return set(key, value);
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/DataCache.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/DataCache.java
@@ -34,6 +34,27 @@ public interface DataCache<T extends Serializable> {
     boolean set(String key, T value) throws IllegalStateException;
 
     /**
+     * Put a value on a key in a data cache with the specified expiration.
+     *
+     * By default, this method throws away the expiration.
+     *
+     *
+     * @param key  the key under which this object should be added.
+     * @param value  the object to store
+     * @param expiration The expiration time, it may either be Unix time (number of seconds since January 1, 1970, as
+     * a 32-bit value), or a number of seconds starting from current time. In the latter case, this number of seconds
+     * may not exceed 60*60*24*30 (number of seconds in 30 days); if the number sent by a client is larger than that,
+     * the server will consider it to be real Unix time value rather than an offset from current time.
+     *
+     * @return a boolean representing success of this operation
+     * @throws IllegalStateException in the rare circumstance where queue is too
+     * full to accept any more requests
+     */
+    default boolean set(String key, T value, int expiration) throws IllegalStateException {
+        return set(key, value);
+    }
+
+    /**
      * Removes all of the mappings from this cache.
      */
     void clear();

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/MemDataCache.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/MemDataCache.java
@@ -83,10 +83,15 @@ public class MemDataCache<T extends Serializable> implements DataCache<T> {
 
     @Override
     public boolean set(String key, T value) throws IllegalStateException {
+        return set(key, value, EXPIRATION);
+    }
+
+    @Override
+    public boolean set(String key, T value, int expiration) throws IllegalStateException {
         try {
             // Omitting null checking for key since it should be rare.
             // An exception will be thrown by the memcached client.
-            return client.set(key, EXPIRATION, value).get();
+            return client.set(key, expiration, value).get();
         } catch (Exception e) {
             LOG.warn("set failed {} {}", key, e.toString());
             throw new IllegalStateException(e);

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/MemDataCache.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/cache/MemDataCache.java
@@ -6,6 +6,7 @@ import com.yahoo.bard.webservice.config.SystemConfig;
 import com.yahoo.bard.webservice.config.SystemConfigException;
 import com.yahoo.bard.webservice.config.SystemConfigProvider;
 
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,15 +84,36 @@ public class MemDataCache<T extends Serializable> implements DataCache<T> {
 
     @Override
     public boolean set(String key, T value) throws IllegalStateException {
-        return set(key, value, EXPIRATION);
+        return setInSeconds(key, value, EXPIRATION);
     }
 
     @Override
-    public boolean set(String key, T value, int expiration) throws IllegalStateException {
+    public boolean set(String key, T value, DateTime expiration) throws IllegalStateException {
+        return setInSeconds(key, value, (int) (expiration.getMillis() / 1000L));
+    }
+
+    /**
+     * Assigns the specified value to the specified key.
+     *
+     * @param key  the key under which this object should be added.
+     * @param value  the object to store
+     * @param expirationInSeconds The expiration time in seconds. Memcached
+     * uses the actual value sent, and it may either be Unix time (number of
+     * seconds since January 1, 1970, as a 32-bit value), or a number of
+     * seconds starting from current time. In the latter case, this number of
+     * seconds may not exceed 60*60*24*30 (number of seconds in 30 days); if
+     * the number sent by a client is larger than that, the server will
+     * consider it to be real Unix time value rather than an offset from
+     * current time.
+     *
+     * @return a boolean representing success of this operation
+     * @throws IllegalStateException if we fail to add the key-value to the cache because of an error
+     */
+    private boolean setInSeconds(String key, T value, int expirationInSeconds) throws IllegalStateException {
         try {
             // Omitting null checking for key since it should be rare.
             // An exception will be thrown by the memcached client.
-            return client.set(key, expiration, value).get();
+            return client.set(key, expirationInSeconds, value).get();
         } catch (Exception e) {
             LOG.warn("set failed {} {}", key, e.toString());
             throw new IllegalStateException(e);

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/data/cache/TestDataCache.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/data/cache/TestDataCache.java
@@ -2,13 +2,17 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.data.cache;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.joda.time.DateTime;
+
 import java.util.LinkedHashMap;
 
 /**
  * Hashmap backed data cache.
  */
 public class TestDataCache implements DataCache<HashDataCache.Pair<String, String>> {
-    LinkedHashMap<String, HashDataCache.Pair<String, String>> cache = new LinkedHashMap<>();
+    LinkedHashMap<String, Pair<DateTime, HashDataCache.Pair<String, String>>> cache = new LinkedHashMap<>();
 
     static boolean cacheEnabled = true;
 
@@ -25,15 +29,32 @@ public class TestDataCache implements DataCache<HashDataCache.Pair<String, Strin
         if (key == null || key.isEmpty() || key.length() > 100) {
             throw new IllegalStateException();
         }
-        return cache.get(key);
+        Pair<DateTime, HashDataCache.Pair<String, String>> result = cache.get(key);
+        if (result == null) {
+            return null;
+        }
+        DateTime expiration = result.getLeft();
+        if (expiration != null && new DateTime().isAfter(expiration)) {
+            cache.remove(key);
+            return null;
+        }
+        return result.getRight();
     }
 
     @Override
     public boolean set(String key, HashDataCache.Pair<String, String> value) throws IllegalStateException {
+        return set(key, value, null);
+    }
+
+    @Override
+    public boolean set(
+            String key,
+            HashDataCache.Pair<String, String> value, DateTime expiration
+    ) throws IllegalStateException {
         if (!cacheEnabled) {
             throw new IllegalStateException("cache disabled");
         }
-        cache.put(key, value);
+        cache.put(key, new ImmutablePair<>(expiration, value));
         return Boolean.TRUE;
     }
 }


### PR DESCRIPTION
-- We have a few customers who would like to be able to set different
expiration times for different values in Fili's response cache. This
PR adds a new method to the DataCache interface
`boolean set(String key, T value, int expiration)` that allows people
to set the expiration for the specified key at cache insertion time.
The default implementation drops the expiration, so customers who have
their own DataCache implementation will be unaffected.

-- We also implmenet the method in `MemDataCache` and delegate the
old `set(String key, T value)` to it, using the configured
`EXPIRATION` as the expiration time.