### PR TITLE
Upgrades to Jackson 2.9.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ Current
 
 ### Changed:
 
+- [Upgrade to Jackson 2.9.9](https://github.com/yahoo/fili/pull/912)
+    * Addresses https://nvd.nist.gov/vuln/detail/CVE-2019-12086, a new vulnerability in jackson databind. 
+
 - [Made Filter Construction more flexible](https://github.com/yahoo/fili/issues/893)
     * Changed FilterBinder.INSTANCE from final to static with accessors
     * Refactored FilterBinders to support chain-of-responsibility FilterFactory

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 
         <version.spring>[5.1.2,)</version.spring>
         <version.groovy>2.4.15</version.groovy>
-        <version.jackson>2.9.8</version.jackson>
+        <version.jackson>2.9.9</version.jackson>
 
         <version.gmavenplus.plugin>1.6.3</version.gmavenplus.plugin>
         <version.guava>21.0</version.guava>


### PR DESCRIPTION
-- Addresses the security vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2019-12086