### PR TITLE
[Quick Patch] Package name fix for luthier module

### DIFF
--- a/luthier/src/test/resources/testApplicationConfig.properties
+++ b/luthier/src/test/resources/testApplicationConfig.properties
@@ -2,51 +2,51 @@
 # Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 
 # Application configuration must specify a package name.  This prefix applies to all config properties.
-package_name = luthier
+package_name = bard
 
 moduleDependencies = fili-core
 
 # Version key for the health check to pick up the version
-luthier__version = Test version
+bard__version = Test version
 
-# luthier URLs for the druid nodes
+# bard URLs for the druid nodes
 # the UI and non-UI URLs are deprecated, so please use the druid broker URL
-luthier__druid_broker = http://broker
-luthier__druid_coord = http://coordinator
+bard__druid_broker = http://broker
+bard__druid_coord = http://coordinator
 
 # Flag to enable usage of metadata supplied by the druid coordinator
 # It requires coordinator URL to be set (see setting druid_coord)
-luthier__druid_coordinator_metadata_enabled = false
+bard__druid_coordinator_metadata_enabled = false
 
 # Disabling the druid dimension loader by default
 # When set to true you will also need to populate the list of dimensions using druid_dim_loader_dimensions
-luthier__druid_dimensions_loader_enabled = false
+bard__druid_dimensions_loader_enabled = false
 
 # Resource binder is critical to starting the app
-luthier__resource_binder = com.yahoo.bard.webservice.application.TestBinderFactory
+bard__resource_binder = com.yahoo.bard.webservice.application.TestBinderFactory
 
 # Don't delete, use for testing!
-luthier__sample_default_config = default-config
+bard__sample_default_config = default-config
 
 # Which stores to run tests on; any combination of "memory", "redis" separated by commas.
-luthier__key_value_store_tests = memory,redis
+bard__key_value_store_tests = memory,redis
 
 # Decides whether a mock of Redis client should be used for testing or an actual one.
-luthier__use_real_redis_client = false
+bard__use_real_redis_client = false
 
 # Storage backend for dimensions.  One of "memory", "redis"
-luthier__dimension_backend = memory
+bard__dimension_backend = memory
 
-luthier__redis_namespace = test
+bard__redis_namespace = test
 
 # The channel on which RedisBroadcastChannel can publish/listen to messages
-luthier__redisbroadcastchannel_name = broadcast
+bard__redisbroadcastchannel_name = broadcast
 
 # Don't start Partial data loading during tests
-luthier__druid_seg_loader_timer_delay = 60000
+bard__druid_seg_loader_timer_delay = 60000
 
 # Don't start Druid dimension loading during tests
-luthier__druid_dim_loader_timer_delay = 60000
+bard__druid_dim_loader_timer_delay = 60000
 
 # Data Cache strategy, whose value is one of the following
 # 1. ETag
@@ -67,27 +67,27 @@ luthier__druid_dim_loader_timer_delay = 60000
 druid__query_response_caching_strategy = NoCache
 
 # Whether partial data or volatile data should be cached or not
-luthier__cache_partial_data = false
+bard__cache_partial_data = false
 
 # Lucene index files path
-luthier__lucene_index_path = ./target/tmp/lucene-default/
+bard__lucene_index_path = ./target/tmp/lucene-default/
 
 # Maximum number of druid filters in a Fili-generated Druid query
-luthier__max_num_druid_filters = 10000
+bard__max_num_druid_filters = 10000
 
 # max results without filters
 # Default number of records per-page. This applies ONLY to the dimensions endpoint, NOT to the data endpoint. The
 # data endpoint does not paginate by default.
-luthier__default_per_page = 10000
+bard__default_per_page = 10000
 
 # Intersection reporting enabled or not.
-luthier__intersection_reporting_enabled = false
+bard__intersection_reporting_enabled = false
 
 # Flag to turn on case sensitive keys in keyvalue store
-luthier__case_sensitive_keys_enabled = false
+bard__case_sensitive_keys_enabled = false
 
 # If this flag is set to true, InFilter will be used as the default filter. Else OrFilter will be used as the default filter.
-luthier__default_in_filter_enabled = false
+bard__default_in_filter_enabled = false
 
 # Whether or not to require metrics in queries. Older druid versions require
-luthier__require_metrics_in_query = true
+bard__require_metrics_in_query = true


### PR DESCRIPTION
I messed up and renamed the package_name in the properties config file. Reverted to `bard` from `luthier`. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
