### PR TITLE
fixed the wikipedia_example's port binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -717,6 +717,7 @@ Added by @mpardesh in https://github.com/yahoo/fili/pull/518
 `ui_druid_broke` and `non_ui_druid_broker` are not used separately anymore. Instead, a single `druid_broker` replaces the two. For backwards compatibility, Fili checks if `druid_broker` is set. If not, Fili uses `non_ui_druid_broker` and then `ui_druid_broker`
 
 Added by @mpardesh in https://github.com/yahoo/fili/pull/489
+Amended by @gab-umich in https://github.com/yahoo/fili/pull/933
 
 Credits
 ---------

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -77,16 +77,12 @@ Next, several configuration files and scripts need to be tweaked:
     you wish to use an in-memory map)
         - (Optional: MDBM) `bard__mdbm_location = dir/to/mdbm` - Note that Fili assumes this directory contains a
         `dimensionCache` folder.
-    - `bard__non_ui_broker = http://url/to/druid/broker`
-    - `bard__ui_broker = http://url/to/druid/broker`
+    - `bard__druid_broker = http://url/to/druid/broker`
     - `bard__druid_coord = http://url/to/druid/coordinator`
+    - `bard__fili_port = [a free port below 65535]`
     
 * [pom.xml][pomXml] -  Find the `fili.version` tag, and update that to point to the desired version of Fili, rather
    than a snapshot. 
-
-Note that both `bard__non_ui_broker` and `bard__ui_broker` are set to the same broker URL. These parameters are 
-artifacts of the project Fili was spun out of. Eventually, these two settings will be generalized into something useful
-for other projects. For now, you can safely treat them as if they were the same.
 
 Build and Deploy the WAR
 ------------------------

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
@@ -48,7 +48,7 @@ class ErrorDataServletSpec extends Specification {
 
     private static final SystemConfig systemConfig = SystemConfigProvider.getInstance()
 
-    private static final String DRUID_URL_SETTING = systemConfig.getPackageVariableName("non_ui_druid_broker")
+    private static final String DRUID_URL_SETTING = systemConfig.getPackageVariableName("druid_broker")
 
     @Shared boolean topNStatus
     static String saveDruidURL

--- a/fili-generic-example/README.md
+++ b/fili-generic-example/README.md
@@ -30,12 +30,17 @@ Note that this was last tested using [version 0.9.1](https://github.com/yahoo/fi
 - Note that if your setup is different you can adjust it by changing the default parameters below
 
     ```bash
+    # cd fili
+    # mvn install
     mvn -pl fili-generic-example exec:java -Dbard__fili_port=9998 \
     -Dbard__druid_coord=http://localhost:8081/druid/coordinator/v1 \
-    -Dbard__druid_broker=http://localhost:8082/druid/v2 \
+    -Dbard__druid_broker=http://localhost:8082/druid/v2
     ```
 
 From another window, run a test query against the default druid data.
+
+_(Make sure the ports in the following commands matches the `-Dbard__fili_port` argument
+if you customized it in the previous step)_
 
 ## Example Queries
 

--- a/fili-generic-example/src/test/resources/testApplicationConfig.properties
+++ b/fili-generic-example/src/test/resources/testApplicationConfig.properties
@@ -3,8 +3,7 @@
 # Version key for the health check to pick up the version
 bard__version=Test version
 # Test URLs for the brokers
-bard__ui_druid_broker=http://ui-broker
-bard__non_ui_druid_broker=http://nonui-broker
+bard__druid_broker=http://broker
 #Test URL for the coordinator
 bard__druid_coord=http://coordinator
 # Resource binder is critical to starting the app

--- a/fili-wikipedia-example/README.md
+++ b/fili-wikipedia-example/README.md
@@ -20,8 +20,16 @@ This example is an entirely self contained example that provides a Fili applicat
     mvn install
     mvn -pl fili-wikipedia-example exec:java
     ```
+    - Note that if your setup is different you can adjust it by changing the default parameters below
+        ```bash
+        # cd fili
+        # mvn install
+        mvn -pl fili-generic-example exec:java -Dbard__fili_port=9998 \
+        -Dbard__druid_coord=http://localhost:8081/druid/coordinator/v1 \
+        -Dbard__druid_broker=http://localhost:8082/druid/v2 \
+        ```
     From another window, run a test query against the default druid data:
-
+    _(Make sure the port matches the `-Dbard__fili_port` argument if you customized it in the previous step)_
     ```bash
     curl "http://localhost:9998/v1/data/wikipedia/hour/?metrics=deleted&dateTime=2015-09-12/PT2H" -H "Content-Type: application/json" | python -m json.tool
     ```

--- a/fili-wikipedia-example/README.md
+++ b/fili-wikipedia-example/README.md
@@ -20,15 +20,16 @@ This example is an entirely self contained example that provides a Fili applicat
     mvn install
     mvn -pl fili-wikipedia-example exec:java
     ```
-    - Note that if your setup is different you can adjust it by changing the default parameters below
-        ```bash
-        # cd fili
-        # mvn install
-        mvn -pl fili-generic-example exec:java -Dbard__fili_port=9998 \
-        -Dbard__druid_coord=http://localhost:8081/druid/coordinator/v1 \
-        -Dbard__druid_broker=http://localhost:8082/druid/v2 \
-        ```
+- Note that if your setup is different you can adjust it by changing the default parameters below
+    ```bash
+    # cd fili
+    # mvn install
+    mvn -pl fili-generic-example exec:java -Dbard__fili_port=9998 \
+    -Dbard__druid_coord=http://localhost:8081/druid/coordinator/v1 \
+    -Dbard__druid_broker=http://localhost:8082/druid/v2
+    ```
     From another window, run a test query against the default druid data:
+
     _(Make sure the port matches the `-Dbard__fili_port` argument if you customized it in the previous step)_
     ```bash
     curl "http://localhost:9998/v1/data/wikipedia/hour/?metrics=deleted&dateTime=2015-09-12/PT2H" -H "Content-Type: application/json" | python -m json.tool

--- a/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/application/WikiMain.java
+++ b/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/application/WikiMain.java
@@ -4,6 +4,8 @@ package com.yahoo.wiki.webservice.application;
 
 import com.yahoo.bard.webservice.application.HealthCheckServletContextListener;
 import com.yahoo.bard.webservice.application.MetricServletContextListener;
+import com.yahoo.bard.webservice.config.SystemConfig;
+import com.yahoo.bard.webservice.config.SystemConfigProvider;
 import com.yahoo.bard.webservice.data.config.dimension.DimensionConfig;
 import com.yahoo.wiki.webservice.data.config.dimension.WikiDimensions;
 
@@ -37,6 +39,8 @@ import javax.servlet.DispatcherType;
  */
 public class WikiMain {
     private static final Logger LOG = LoggerFactory.getLogger(WikiMain.class);
+    private static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
+    private static final String FILI_PORT = SYSTEM_CONFIG.getPackageVariableName("fili_port");
 
     /**
      * Makes the dimensions passthrough.
@@ -82,7 +86,7 @@ public class WikiMain {
      * @throws Exception if the server fails to start or crashes
      */
     public static void main(String[] args) throws Exception {
-        int port = 9998;
+        int port = SYSTEM_CONFIG.getIntProperty(FILI_PORT);
 
         Server server = new Server(port);
         ServletContextHandler servletContextHandler = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);

--- a/fili-wikipedia-example/src/main/resources/applicationConfig.properties
+++ b/fili-wikipedia-example/src/main/resources/applicationConfig.properties
@@ -8,9 +8,8 @@ moduleDependencies = fili
 
 bard__version = Local Mode
 bard__resource_binder=com.yahoo.wiki.webservice.application.WikiBinderFactory
+bard__druid_broker=http://localhost:8082/druid/v2
 
-bard__non_ui_druid_broker=http://localhost:8082/druid/v2
-bard__ui_druid_broker=http://localhost:8082/druid/v2
 bard__druid_coord=http://localhost:8081/druid/coordinator/v1
 bard__fili_port=9998
 

--- a/fili-wikipedia-example/src/main/resources/applicationConfig.properties
+++ b/fili-wikipedia-example/src/main/resources/applicationConfig.properties
@@ -12,6 +12,7 @@ bard__resource_binder=com.yahoo.wiki.webservice.application.WikiBinderFactory
 bard__non_ui_druid_broker=http://localhost:8082/druid/v2
 bard__ui_druid_broker=http://localhost:8082/druid/v2
 bard__druid_coord=http://localhost:8081/druid/coordinator/v1
+bard__fili_port=9998
 
 # Use memory for the default dimension backing store
 bard__dimension_backend=memory

--- a/fili-wikipedia-example/src/test/resources/testApplicationConfig.properties
+++ b/fili-wikipedia-example/src/test/resources/testApplicationConfig.properties
@@ -5,8 +5,7 @@
 bard__version = Test version
 
 # Test URLs for the brokers
-bard__ui_druid_broker = http://ui-broker
-bard__non_ui_druid_broker = http://nonui-broker
+bard__druid_broker = http://broker
 #Test URL for the coordinator
 bard__druid_coord = http://coordinator
 


### PR DESCRIPTION
Fixes #930

Used the same approach as in generic_example. Now wikipedia example will have dependency on `com.yahoo.bard.webservice.config.SystemConfig`.

Also brought the documentation up to date with this change.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
