### PR TITLE
Upgrades jackson-databind to 2.9.9.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <version.spring>[5.1.2,)</version.spring>
         <version.groovy>2.4.15</version.groovy>
         <version.jackson>2.9.9</version.jackson>
+        <version.jackson-databind>2.9.9.1</version.jackson-databind>
 
         <version.gmavenplus.plugin>1.6.3</version.gmavenplus.plugin>
         <version.guava>21.0</version.guava>
@@ -377,7 +378,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.jackson}</version>
+                <version>${version.jackson-databind}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>


### PR DESCRIPTION
-- This addresses security vulnerability:
https://github.com/yahoo/fili/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open.

-- Unfortunately, because this version was only released by for
the data-bind component, we had to introduce another version variable
for just jackson-databind, so there is a risk of the jackson versions
getting out of sync. The next time we upgrade Jackson, we should
remove this additional version variable, to bring all the components
back in sync.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
