### PR TITLE
Add custom sslcontext support in fili

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -135,6 +135,7 @@ import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.netty.handler.ssl.SslContext;
 import org.glassfish.hk2.api.TypeLiteral;
 import org.glassfish.hk2.utilities.Binder;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -1209,6 +1210,14 @@ public abstract class AbstractBinderFactory implements BinderFactory {
     }
 
     /**
+     * Get a custom configured ssl context.
+     * @return SSL context
+     */
+    protected SslContext getSSLContext() {
+        return null;
+    }
+
+    /**
      * Create a DruidWebService.
      * <p>
      * Provided so subclasses can implement alternative druid web service implementations
@@ -1220,16 +1229,19 @@ public abstract class AbstractBinderFactory implements BinderFactory {
      */
     protected DruidWebService buildDruidWebService(DruidServiceConfig druidServiceConfig, ObjectMapper mapper) {
         Supplier<Map<String, String>> supplier = buildDruidWebServiceHeaderSupplier();
+        SslContext sslContext = getSSLContext();
+
         return DRUID_UNCOVERED_INTERVAL_LIMIT > 0
                 ? new AsyncDruidWebServiceImpl(
                         druidServiceConfig,
                         mapper,
                         supplier,
+                        sslContext,
                         new HeaderNestingJsonBuilderStrategy(
                                 AsyncDruidWebServiceImpl.DEFAULT_JSON_NODE_BUILDER_STRATEGY
                         )
                 )
-                : new AsyncDruidWebServiceImpl(druidServiceConfig, mapper, supplier);
+                : new AsyncDruidWebServiceImpl(druidServiceConfig, mapper, supplier, sslContext);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/client/impl/AsyncDruidWebServiceImpl.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
+import io.netty.handler.ssl.SslContext;
 import org.asynchttpclient.AsyncCompletionHandler;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.AsyncHttpClientConfig;
@@ -109,7 +110,7 @@ public class AsyncDruidWebServiceImpl implements DruidWebService {
     ) {
         this(
                 serviceConfig,
-                initializeWebClient(serviceConfig.getTimeout()),
+                initializeWebClient(serviceConfig.getTimeout(), null),
                 mapper,
                 HashMap::new,
                 DEFAULT_JSON_NODE_BUILDER_STRATEGY
@@ -150,7 +151,32 @@ public class AsyncDruidWebServiceImpl implements DruidWebService {
     ) {
         this(
                 serviceConfig,
-                initializeWebClient(serviceConfig.getTimeout()),
+                initializeWebClient(serviceConfig.getTimeout(), null),
+                mapper,
+                headersToAppend,
+                DEFAULT_JSON_NODE_BUILDER_STRATEGY
+        );
+    }
+
+    /**
+     * Friendly non-DI constructor useful for manual tests.
+     * <p>
+     * This constructor uses default JSON builder, which only uses response body to build the JSON response.
+     *
+     * @param serviceConfig  Configuration for the Druid Service
+     * @param mapper  A shared jackson object mapper resource
+     * @param headersToAppend Supplier for map of headers for Druid requests
+     * @param sslContext Custom Configured SslContext (null if default SSL context has to be used)
+     */
+    public AsyncDruidWebServiceImpl(
+            DruidServiceConfig serviceConfig,
+            ObjectMapper mapper,
+            Supplier<Map<String, String>> headersToAppend,
+            SslContext sslContext
+    ) {
+        this(
+                serviceConfig,
+                initializeWebClient(serviceConfig.getTimeout(), sslContext),
                 mapper,
                 headersToAppend,
                 DEFAULT_JSON_NODE_BUILDER_STRATEGY
@@ -173,7 +199,33 @@ public class AsyncDruidWebServiceImpl implements DruidWebService {
     ) {
         this(
                 serviceConfig,
-                initializeWebClient(serviceConfig.getTimeout()),
+                initializeWebClient(serviceConfig.getTimeout(), null),
+                mapper,
+                headersToAppend,
+                jsonNodeBuilderStrategy
+        );
+    }
+
+
+    /**
+     * Friendly non-DI constructor useful for manual tests.
+     *
+     * @param serviceConfig  Configuration for the Druid Service
+     * @param mapper  A shared jackson object mapper resource
+     * @param headersToAppend Supplier for map of headers for Druid requests
+     * @param jsonNodeBuilderStrategy A function to build JSON nodes from the response
+     * @param sslContext Custom Configured SslContext (null if default SSL context has to be used)
+     */
+    public AsyncDruidWebServiceImpl(
+            DruidServiceConfig serviceConfig,
+            ObjectMapper mapper,
+            Supplier<Map<String, String>> headersToAppend,
+            SslContext sslContext,
+            Function<Response, JsonNode> jsonNodeBuilderStrategy
+    ) {
+        this(
+                serviceConfig,
+                initializeWebClient(serviceConfig.getTimeout(), sslContext),
                 mapper,
                 headersToAppend,
                 jsonNodeBuilderStrategy
@@ -237,10 +289,11 @@ public class AsyncDruidWebServiceImpl implements DruidWebService {
      * Initialize the client config.
      *
      * @param requestTimeout  Timeout to use for the client configuration.
+     * @param sslContext Custom Configured SslContext. (null if default ssl context has to be used)
      *
      * @return the set up client
      */
-    private static AsyncHttpClient initializeWebClient(int requestTimeout) {
+    private static AsyncHttpClient initializeWebClient(int requestTimeout, SslContext sslContext) {
 
         LOG.debug("Druid request timeout: {}ms", requestTimeout);
         List<String> cipherSuites = SYSTEM_CONFIG.getListProperty(SSL_ENABLED_CIPHER_KEY, null);
@@ -249,15 +302,19 @@ public class AsyncDruidWebServiceImpl implements DruidWebService {
                 : cipherSuites.toArray(new String[cipherSuites.size()]);
 
         // Build the configuration
-        AsyncHttpClientConfig config = new DefaultAsyncHttpClientConfig.Builder()
+        DefaultAsyncHttpClientConfig.Builder asyncHttpClientConfigBuilder = new DefaultAsyncHttpClientConfig.Builder()
                 .setReadTimeout(requestTimeout)
                 .setRequestTimeout(requestTimeout)
                 .setConnectTimeout(requestTimeout)
                 .setConnectionTtl(requestTimeout)
                 .setPooledConnectionIdleTimeout(requestTimeout)
                 .setEnabledCipherSuites(enabledCipherSuites)
-                .setFollowRedirect(true)
-                .build();
+                .setFollowRedirect(true);
+
+        if (sslContext != null) {
+            asyncHttpClientConfigBuilder.setSslContext(sslContext);
+        }
+        AsyncHttpClientConfig config = asyncHttpClientConfigBuilder.build();
 
         return new DefaultAsyncHttpClient(config);
     }


### PR DESCRIPTION
User must override getSSLContext method to give their own sslContext. The function should return the object of io.netty.handler.ssl.SslContext. 
`protected SslContext getSSLContext() {
        //create SSL Context here
       if(sslContext.instanceOf(io.netty.handler.ssl.SslContext.class)) 
              return sslContext;
      if(sslContext.instanceOf(javax.net.ssl.SSLContext.class))
              return new JdkSslContext(sslContext, true, ClientAuth.REQUIRE)
     .
     .
     .
     return null
  }`

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
