### PR TITLE
Don't trim stack trace when running unit tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -675,6 +675,7 @@
                         <includes>
                             <include>%regex[.*Spec.*]</include>
                         </includes>
+                        <trimStackTrace>false</trimStackTrace>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
-- Turns out, stack traces are kinda useful when debugging.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
