### PR TITLE
This version prevented deployment.

### DIFF
--- a/luthier/pom.xml
+++ b/luthier/pom.xml
@@ -21,7 +21,6 @@
         <checkstyle.config.location>../checkstyle-style.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>../checkstyle-suppressions.xml</checkstyle.suppressions.location>
         <skipLuthierTests>true</skipLuthierTests>
-        <version.fili>0.12-SNAPSHOT</version.fili>
     </properties>
 
     <licenses>


### PR DESCRIPTION
The script that bumps the fili version was changing the parent pom but not the child.  There was no need to try to set the version in the submodule, so removed it to unbreak deploy.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
