### PR TITLE
Uses `addFactories` rather than `withFactories` in the BinderFactory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Current
    * Resolved dependecy issues around where properties files were sourced
    * Rationalized dependencies for sample applications
 
-- [Uses `addFactories` rather than `withFactories` in Luthier setup.](https://github.com/yahoo/fili/pull/982)
+- [Uses `addFactories` rather than `withFactories` in Luthier setup.](https://github.com/yahoo/fili/pull/991)
    
 ### Removed:
 

--- a/luthier/src/main/java/com/yahoo/bard/webservice/application/LuthierBinderFactory.java
+++ b/luthier/src/main/java/com/yahoo/bard/webservice/application/LuthierBinderFactory.java
@@ -34,11 +34,11 @@ public class LuthierBinderFactory extends AbstractBinderFactory {
 
         LuthierIndustrialPark.Builder builder = new LuthierIndustrialPark.Builder(resourceDictionaries);
         builder.withGranularityDictionary(granularityDictionary);
-        getDimensionFactories().ifPresent(it -> builder.withFactories(ConceptType.DIMENSION, it));
-        getSearchProviderFactories().ifPresent(it -> builder.withFactories(ConceptType.SEARCH_PROVIDER, it));
-        getKeyValueStoreFactories().ifPresent(it -> builder.withFactories(ConceptType.KEY_VALUE_STORE, it));
-        getMetricMakerFactories().ifPresent(it -> builder.withFactories(ConceptType.METRIC_MAKER, it));
-        getPhysicalTableFactories().ifPresent(it -> builder.withFactories(ConceptType.PHYSICAL_TABLE, it));
+        getDimensionFactories().ifPresent(it -> builder.addFactories(ConceptType.DIMENSION, it));
+        getSearchProviderFactories().ifPresent(it -> builder.addFactories(ConceptType.SEARCH_PROVIDER, it));
+        getKeyValueStoreFactories().ifPresent(it -> builder.addFactories(ConceptType.KEY_VALUE_STORE, it));
+        getMetricMakerFactories().ifPresent(it -> builder.addFactories(ConceptType.METRIC_MAKER, it));
+        getPhysicalTableFactories().ifPresent(it -> builder.addFactories(ConceptType.PHYSICAL_TABLE, it));
         return builder.build();
     }
 


### PR DESCRIPTION
-- In the current behavior, if someone wants to add their own custom
Metric Factory, and they naively overrwidw `getMetricFactories` to
return `Optional.of(<Just-My-Factory>)`, Fili will *drop* all the
current mappings and add just the one the user provided. So if the user
wants to maintain the defaults, they have ot manually add them in
`getMetricFactories`.

This makes the most common use pattern (customers add a few custom
metricMakers or dimension types, but otherwise wants the defaults
available) very cumbersome. It is also, I would argue, very unintuitive.

-- With the new behavior, custom metrics created by the user will be
*added* to the already existing registry. So customers don't have to
worry about losing the defaults because they added a few customs.

If users want to override a default, they can register a
new factory under the same name. If customers really want to drop all
the defaults, well then they can override `getConfigurationLoader`. A
bit cumbersome, but highly unlikely.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
