### PR TITLE
COUNT(*) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Current
 -------
 
 ### Added:
+- [Add COUNT(\*) support in fili-sql](https://github.com/yahoo/fili/pull/992)
+   * When there is a `count` metric that uses `countMaker`, it will be translated into a COUNT(\*) in SQL query.
+   
 - [Add Presto support](https://github.com/yahoo/fili/pull/986)
    * Fili now can connect to Presto servers.
    * Fixed Druid metadata deserialization issue with the newer druid-api-0.12.1.

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/DruidQueryToSqlConverter.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/DruidQueryToSqlConverter.java
@@ -437,7 +437,6 @@ public class DruidQueryToSqlConverter {
                             sqlAggregation.getSqlAggFunction(),
                             false,
                             null,
-                            // TODO: Investigate why ApiToFieldMapper doesn't work here
                             sqlAggregation.getSqlAggregationAsName(),
                             builder.field(sqlAggregation.getSqlAggregationFieldName())
                     );

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/SqlResultSetProcessor.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/SqlResultSetProcessor.java
@@ -241,6 +241,8 @@ public class SqlResultSetProcessor {
                                         return Long::parseLong;
                                     } else if (aggType.contains("double")) {
                                         return Double::parseDouble;
+                                    } else if (aggType.contains("count")) {
+                                        return Long::parseLong;
                                     }
                                     return null;
                                 }

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/aggregation/DefaultSqlAggregationType.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/aggregation/DefaultSqlAggregationType.java
@@ -43,6 +43,6 @@ public enum DefaultSqlAggregationType implements SqlAggregationType {
 
     @Override
     public SqlAggregation getSqlAggregation(Aggregation aggregation, ApiToFieldMapper apiToFieldMapper) {
-        return new SqlAggregation(apiToFieldMapper.apply(aggregation.getFieldName()), sqlAggFunction);
+        return new SqlAggregation(aggregation.getName(), aggregation.getFieldName(), sqlAggFunction);
     }
 }

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/aggregation/DefaultSqlAggregationType.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/aggregation/DefaultSqlAggregationType.java
@@ -17,7 +17,8 @@ import java.util.Set;
 public enum DefaultSqlAggregationType implements SqlAggregationType {
     SUM(SqlStdOperatorTable.SUM, "longSum", "doubleSum"),
     MIN(SqlStdOperatorTable.MIN, "longMin", "doubleMin"),
-    MAX(SqlStdOperatorTable.MAX, "longMax", "doubleMax");
+    MAX(SqlStdOperatorTable.MAX, "longMax", "doubleMax"),
+    COUNT(SqlStdOperatorTable.COUNT, "count");
     // todo avg
 
     private final Set<String> validDruidAggregations;

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/aggregation/SqlAggregation.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/aggregation/SqlAggregation.java
@@ -9,15 +9,18 @@ import org.apache.calcite.sql.SqlAggFunction;
  */
 public class SqlAggregation {
     private final String fieldName;
+    private final String name;
     private final SqlAggFunction sqlAggFunction;
 
     /**
      * Constructor.
      *
+     * @param name The api name of the field being aggregated on.
      * @param fieldName  The name of the field being aggregated on.
      * @param sqlAggFunction  The sql aggregation to be done on the field.
      */
-    public SqlAggregation(String fieldName, SqlAggFunction sqlAggFunction) {
+    public SqlAggregation(String name, String fieldName, SqlAggFunction sqlAggFunction) {
+        this.name = name;
         this.fieldName = fieldName;
         this.sqlAggFunction = sqlAggFunction;
     }
@@ -28,7 +31,7 @@ public class SqlAggregation {
      * @return the alias name for the aggregation.
      */
     public String getSqlAggregationAsName() {
-        return getSqlAggregationFieldName();
+        return name;
     }
 
     /**

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/DruidQueryToSqlConverterSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/DruidQueryToSqlConverterSpec.groovy
@@ -48,7 +48,7 @@ class DruidQueryToSqlConverterSpec extends Specification {
                 getDimensions(dimensions.collect { API_PREPEND + it }),
                 null,
                 null,
-                [sum(API_PREPEND + ADDED), sum(API_PREPEND + DELETED)],
+                [sum(ADDED), sum(DELETED)],
                 [],
                 [interval(START, END)],
                 limitSpec

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/builders/Aggregator.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/builders/Aggregator.groovy
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.sql.builders
 
+import com.yahoo.bard.webservice.druid.model.aggregation.CountAggregation
 import com.yahoo.bard.webservice.druid.model.aggregation.DoubleMaxAggregation
 import com.yahoo.bard.webservice.druid.model.aggregation.DoubleMinAggregation
 import com.yahoo.bard.webservice.druid.model.aggregation.DoubleSumAggregation
@@ -33,5 +34,9 @@ class Aggregator {
 
     public static LongMinAggregation longMin(String name) {
         return new LongMinAggregation(name, name)
+    }
+
+    public static CountAggregation count() {
+        return new CountAggregation("count")
     }
 }

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/evaluator/HavingEvaluatorSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/evaluator/HavingEvaluatorSpec.groovy
@@ -80,11 +80,11 @@ class HavingEvaluatorSpec extends Specification {
         sql.contains(expectedHavingSql)
         where: "we have"
         having                                               | aggregations                           | expectedHavingSql
-        gt(API + ADDED, ONE)                                 | [sum(API + ADDED)]                     | "HAVING SUM(`${ADDED}`) > 1"
-        lt(API + DELETED, ONE)                               | [sum(API + DELETED)]                   | "HAVING SUM(`${DELETED}`) < 1"
-        equal(API + DELETED, ONE)                            | [sum(API + DELETED), sum(API + ADDED)] | "HAVING SUM(`${DELETED}`) = 1"
-        or(equal(API + DELETED, ONE), lt(API + ADDED, TWO))  | [max(API + DELETED), min(API + ADDED)] | "HAVING MAX(`${DELETED}`) = 1 OR MIN(`${ADDED}`) < 2"
-        and(equal(API + DELETED, ONE), lt(API + ADDED, TWO)) | [max(API + DELETED), min(API + ADDED)] | "HAVING MAX(`${DELETED}`) = 1 AND MIN(`${ADDED}`) < 2"
+        gt(ADDED, ONE)                                 | [sum(ADDED)]                     | "HAVING SUM(`${ADDED}`) > 1"
+        lt(DELETED, ONE)                               | [sum(DELETED)]                   | "HAVING SUM(`${DELETED}`) < 1"
+        equal(DELETED, ONE)                            | [sum(DELETED), sum(ADDED)] | "HAVING SUM(`${DELETED}`) = 1"
+        or(equal(DELETED, ONE), lt(ADDED, TWO))  | [max(DELETED), min(ADDED)] | "HAVING MAX(`${DELETED}`) = 1 OR MIN(`${ADDED}`) < 2"
+        and(equal(DELETED, ONE), lt(ADDED, TWO)) | [max(DELETED), min(ADDED)] | "HAVING MAX(`${DELETED}`) = 1 AND MIN(`${ADDED}`) < 2"
 
     }
 

--- a/fili-sql/src/test/java/com/yahoo/bard/webservice/database/Database.java
+++ b/fili-sql/src/test/java/com/yahoo/bard/webservice/database/Database.java
@@ -54,6 +54,7 @@ public class Database {
     public static final String DELTA = "delta";
     public static final String ID = "ID";
     public static final String METRO_CODE = "metroCode";
+    public static final String COUNT = "count";
 
     /**
      * Gets an in memory database with the {@link WikitickerEntry} from the example data.


### PR DESCRIPTION
Add COUNT(\*) support.
When there is a `count` metric with `countMaker`, it will be translated into a COUNT(\*) in SQL query.
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
