### PR TITLE
fix filter clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ pull request if there was one.
 Current
 -------
 
+### Fixed:
+- [Fix Presto query on filtering](https://github.com/yahoo/fili/pull/995)
+    * When translating from sql query to Presto query, there is no type information available for table columns. To make filtering `WHERE` clauses works in Presto, cast coulmns to varchar before comparing  
+
 ### Added:
 - [Add COUNT(\*) support in fili-sql](https://github.com/yahoo/fili/pull/992)
    * When there is a `count` metric that uses `countMaker`, it will be translated into a COUNT(\*) in SQL query.

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
@@ -232,10 +232,10 @@ public class PrestoSqlBackedClient implements SqlBackedClient {
             filterClause = filterClauses[i];
             equalIndex = filterClause.indexOf("=");
             notEqualIndex = filterClause.indexOf("<>");
-            if (equalIndex != -1 && (notEqualIndex == -1 || equalIndex < notEqualIndex)){
+            if (equalIndex != -1 && (notEqualIndex == -1 || equalIndex < notEqualIndex)) {
                 comparatorIndex = equalIndex;
                 comparator = "=";
-            } else if (notEqualIndex != -1 && (equalIndex == -1 || notEqualIndex < equalIndex)){
+            } else if (notEqualIndex != -1 && (equalIndex == -1 || notEqualIndex < equalIndex)) {
                 comparatorIndex = notEqualIndex;
                 comparator = "<>";
             } else {

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
@@ -228,9 +228,9 @@ public class PrestoSqlBackedClient implements SqlBackedClient {
             filterClause = filterClauses[i];
             if (filterClauses[i].contains("=")) {
                 equalSignIndex = filterClause.indexOf("=");
-                fieldName = filterClause.substring(0, equalSignIndex).trim().replace("\"", "");
+                fieldName = filterClause.substring(0, equalSignIndex).trim();
                 fieldValue = filterClause.substring(equalSignIndex + 1).trim();
-                filterClauseFixed = String.format("(CAST %s AS varchar) = %s", fieldName, fieldValue);
+                filterClauseFixed = String.format("CAST(%s AS varchar) = %s", fieldName, fieldValue);
                 fixFilterPrestoQuery = fixFilterPrestoQuery.replace(filterClause, filterClauseFixed);
             }
         }

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
@@ -232,14 +232,14 @@ public class PrestoSqlBackedClient implements SqlBackedClient {
             filterClause = filterClauses[i];
             equalIndex = filterClause.indexOf("=");
             notEqualIndex = filterClause.indexOf("<>");
-            if (equalIndex == -1 && notEqualIndex == -1) {
-                continue;
-            } else if (equalIndex == -1 || (notEqualIndex != -1 && notEqualIndex < equalIndex)) {
+            if (equalIndex != -1 && (notEqualIndex == -1 || equalIndex < notEqualIndex)){
+                comparatorIndex = equalIndex;
+                comparator = "=";
+            } else if (notEqualIndex != -1 && (equalIndex == -1 || notEqualIndex < equalIndex)){
                 comparatorIndex = notEqualIndex;
                 comparator = "<>";
             } else {
-                comparatorIndex = equalIndex;
-                comparator = "=";
+                continue;
             }
             fieldName = filterClause.substring(0, comparatorIndex).trim();
             fieldValue = filterClause.substring(comparatorIndex + comparator.length()).trim();

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
@@ -15,14 +15,14 @@ class PrestoSqlBackedClientSpec extends Specification {
         expect:
         toPrestoQuery == """SELECT "source", SUBSTRING(datestamp,1,4) AS "\$f23", DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) AS "\$f24", SUBSTRING(datestamp,9,2) AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) = "1=2====3" AND CAST("advertiser_id" AS varchar) = "456"
+WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) <> "1=2====3" AND CAST("advertiser_id" AS varchar) = "456"
 GROUP BY "source", SUBSTRING(datestamp,1,4), DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')), SUBSTRING(datestamp,9,2)
 ORDER BY SUBSTRING(datestamp,1,4) NULLS FIRST, DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) NULLS FIRST, SUBSTRING(datestamp,9,2) NULLS FIRST, "source" NULLS FIRST"""
 
         where:
         sqlQuery << ["""SELECT "source", YEAR("datestamp") AS "\$f23", DAYOFYEAR("datestamp") AS "\$f24", HOUR("datestamp") AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '2019-09-01 14:00:00.0' AND "datestamp" < '2019-09-02 14:00:00.0' AND "comment" = "1=2====3" AND "advertiser_id" = "456"
+WHERE "datestamp" > '2019-09-01 14:00:00.0' AND "datestamp" < '2019-09-02 14:00:00.0' AND "comment" <> "1=2====3" AND "advertiser_id" = "456"
 GROUP BY "source", YEAR("datestamp"), DAYOFYEAR("datestamp"), HOUR("datestamp")
 ORDER BY YEAR("datestamp") NULLS FIRST, DAYOFYEAR("datestamp") NULLS FIRST, HOUR("datestamp") NULLS FIRST, "source" NULLS FIRST"""]
     }

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
@@ -15,14 +15,14 @@ class PrestoSqlBackedClientSpec extends Specification {
         expect:
         toPrestoQuery == """SELECT "source", SUBSTRING(datestamp,1,4) AS "\$f23", DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) AS "\$f24", SUBSTRING(datestamp,9,2) AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000'
+WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND (CAST comment AS varchar) = "1=2====3" AND (CAST advertiser_id AS varchar) = "456"
 GROUP BY "source", SUBSTRING(datestamp,1,4), DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')), SUBSTRING(datestamp,9,2)
 ORDER BY SUBSTRING(datestamp,1,4) NULLS FIRST, DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) NULLS FIRST, SUBSTRING(datestamp,9,2) NULLS FIRST, "source" NULLS FIRST"""
 
         where:
         sqlQuery << ["""SELECT "source", YEAR("datestamp") AS "\$f23", DAYOFYEAR("datestamp") AS "\$f24", HOUR("datestamp") AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '2019-09-01 14:00:00.0' AND "datestamp" < '2019-09-02 14:00:00.0'
+WHERE "datestamp" > '2019-09-01 14:00:00.0' AND "datestamp" < '2019-09-02 14:00:00.0' AND "comment" = "1=2====3" AND "advertiser_id" = "456"
 GROUP BY "source", YEAR("datestamp"), DAYOFYEAR("datestamp"), HOUR("datestamp")
 ORDER BY YEAR("datestamp") NULLS FIRST, DAYOFYEAR("datestamp") NULLS FIRST, HOUR("datestamp") NULLS FIRST, "source" NULLS FIRST"""]
     }

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
@@ -15,7 +15,7 @@ class PrestoSqlBackedClientSpec extends Specification {
         expect:
         toPrestoQuery == """SELECT "source", SUBSTRING(datestamp,1,4) AS "\$f23", DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) AS "\$f24", SUBSTRING(datestamp,9,2) AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND (CAST comment AS varchar) = "1=2====3" AND (CAST advertiser_id AS varchar) = "456"
+WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) = "1=2====3" AND CAST("advertiser_id" AS varchar) = "456"
 GROUP BY "source", SUBSTRING(datestamp,1,4), DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')), SUBSTRING(datestamp,9,2)
 ORDER BY SUBSTRING(datestamp,1,4) NULLS FIRST, DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) NULLS FIRST, SUBSTRING(datestamp,9,2) NULLS FIRST, "source" NULLS FIRST"""
 


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Fili Presto support is problematic for filtering clauses. Currently all fields related to filtering is assumed to be of varchar type. All additional step to add casting upon query generation.
