### PR TITLE
Fix contains filter behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Current
 -------
 
 ### Fixed:
+- [Fix contains filter behavior](https://github.com/yahoo/fili/pull/998)
+    * When there is a Contains filter applied to a non-cached dimension, it will be translated into a `SeachFilter` instead of `SelectorFilter`.
+    
 - [Fix Presto query on filtering](https://github.com/yahoo/fili/pull/995)
     * When translating from sql query to Presto query, there is no type information available for table columns. To make filtering `WHERE` clauses works in Presto, cast coulmns to varchar before comparing
 - [`MetricUnionAvailability` properly defensively copies availability map](https://github.com/yahoo/fili/pull/997)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Current
 
 ### Fixed:
 - [Fix contains filter behavior](https://github.com/yahoo/fili/pull/998)
-    * When there is a Contains filter applied to a non-cached dimension, it will be translated into a `SeachFilter` instead of `SelectorFilter`.
+    * When there is a Contains filter applied to a non-cached dimension, it will be translated into a `SearchFilter` instead of `SelectorFilter`.
     
 - [Fix Presto query on filtering](https://github.com/yahoo/fili/pull/995)
     * When translating from sql query to Presto query, there is no type information available for table columns. To make filtering `WHERE` clauses works in Presto, cast coulmns to varchar before comparing

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/builders/ConjunctionDruidFilterBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/builders/ConjunctionDruidFilterBuilder.java
@@ -15,6 +15,7 @@ import com.yahoo.bard.webservice.druid.model.dimension.extractionfunction.Extrac
 import com.yahoo.bard.webservice.druid.model.filter.AndFilter;
 import com.yahoo.bard.webservice.druid.model.filter.ExtractionFilter;
 import com.yahoo.bard.webservice.druid.model.filter.Filter;
+import com.yahoo.bard.webservice.druid.model.filter.SearchFilter;
 import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter;
 import com.yahoo.bard.webservice.exception.TooManyDruidFiltersException;
 import com.yahoo.bard.webservice.web.ApiFilter;
@@ -231,6 +232,18 @@ public abstract class ConjunctionDruidFilterBuilder implements DruidFilterBuilde
 
         return rows.stream()
                 .map(finalFilterBuilder::apply)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Given a dimension and its contains filter values, return a list of Contains SearchFilters.
+     * @param dimension the dimension to search for
+     * @param values the contains value
+     * @return the list of SearchFilters
+     */
+    protected List<Filter> buildContainsSearchFilters(Dimension dimension, List<String> values) {
+        return values.stream()
+                .map(value -> new SearchFilter(dimension, SearchFilter.QueryType.Contains, value))
                 .collect(Collectors.toList());
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/builders/DruidOrFilterBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/builders/DruidOrFilterBuilder.java
@@ -47,7 +47,6 @@ public class DruidOrFilterBuilder extends ConjunctionDruidFilterBuilder {
                 normalizedFilter = filter.withOperation(DefaultFilterOperation.in);
             }
 
-
             Filter disjunction = null;
             if (dimension.getSearchProvider() instanceof NoOpSearchProvider &&
                     filter.getOperation() == DefaultFilterOperation.contains) {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/builders/DruidOrFilterBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/builders/DruidOrFilterBuilder.java
@@ -4,6 +4,7 @@ package com.yahoo.bard.webservice.druid.model.builders;
 
 import com.yahoo.bard.webservice.data.dimension.Dimension;
 import com.yahoo.bard.webservice.data.dimension.DimensionRowNotFoundException;
+import com.yahoo.bard.webservice.data.dimension.impl.NoOpSearchProvider;
 import com.yahoo.bard.webservice.druid.model.filter.AndFilter;
 import com.yahoo.bard.webservice.druid.model.filter.Filter;
 import com.yahoo.bard.webservice.druid.model.filter.NotFilter;
@@ -45,10 +46,21 @@ public class DruidOrFilterBuilder extends ConjunctionDruidFilterBuilder {
             if (normalizedFilter.getOperation().equals(DefaultFilterOperation.notin)) {
                 normalizedFilter = filter.withOperation(DefaultFilterOperation.in);
             }
-            Filter disjunction = new OrFilter(buildSelectorFilters(
-                    dimension,
-                    getFilteredDimensionRows(dimension, Collections.singleton(normalizedFilter))
-            ));
+
+
+            Filter disjunction = null;
+            if (dimension.getSearchProvider() instanceof NoOpSearchProvider &&
+                    filter.getOperation() == DefaultFilterOperation.contains) {
+                disjunction = new OrFilter(buildContainsSearchFilters(
+                        dimension,
+                        filter.getValuesList()
+                ));
+            } else {
+                disjunction = new OrFilter(buildSelectorFilters(
+                        dimension,
+                        getFilteredDimensionRows(dimension, Collections.singleton(normalizedFilter))
+                ));
+            }
             orFilters.add(normalizedFilter == filter ? disjunction : new NotFilter(disjunction));
         }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/QueryBuildingTestingResources.groovy
@@ -30,6 +30,7 @@ import com.yahoo.bard.webservice.data.dimension.MapStoreManager
 import com.yahoo.bard.webservice.data.dimension.impl.FlagFromTagDimension
 import com.yahoo.bard.webservice.data.dimension.impl.KeyValueStoreDimension
 import com.yahoo.bard.webservice.data.dimension.impl.LookupDimension
+import com.yahoo.bard.webservice.data.dimension.impl.NoOpSearchProvider
 import com.yahoo.bard.webservice.data.dimension.impl.RegisteredLookupDimension
 import com.yahoo.bard.webservice.data.dimension.impl.ScanSearchProviderManager
 import com.yahoo.bard.webservice.data.metric.LogicalMetric
@@ -71,6 +72,9 @@ class QueryBuildingTestingResources {
 
     // Flag from tag dimension
     public Dimension d14, d15
+
+    // NoOpSearchProvider dimension
+    public Dimension d16
 
     // Logical metrics, numbered for identification
     public LogicalMetric m1, m2, m3, m4, m5, m6
@@ -202,6 +206,7 @@ class QueryBuildingTestingResources {
         d12 = new RegisteredLookupDimension(registeredLookupDimConfig.getAt(1))
         d13 = new RegisteredLookupDimension(registeredLookupDimConfig.getAt(2))
 
+
         dimensionDictionary = new DimensionDictionary()
         dimensionDictionary.addAll([d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13])
 
@@ -240,6 +245,16 @@ class QueryBuildingTestingResources {
 
         dimensionDictionary.add(d14)
         dimensionDictionary.add(d15)
+
+        d16 = new KeyValueStoreDimension(
+                "dim16",
+                "dim16",
+                dimensionFields,
+                MapStoreManager.getInstance("dim16"),
+                new NoOpSearchProvider(1),
+                false
+        )
+        dimensionDictionary.add(d16)
 
         m1 = new LogicalMetric(null, null, "metric1")
         m2 = new LogicalMetric(null, null, "metric2")

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/filterbuilders/ConjunctionDruidFilterBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/filterbuilders/ConjunctionDruidFilterBuilderSpec.groovy
@@ -11,6 +11,7 @@ import com.yahoo.bard.webservice.data.dimension.DimensionRow
 import com.yahoo.bard.webservice.data.dimension.DimensionRowNotFoundException
 import com.yahoo.bard.webservice.druid.model.builders.ConjunctionDruidFilterBuilder
 import com.yahoo.bard.webservice.druid.model.filter.Filter
+import com.yahoo.bard.webservice.druid.model.filter.SearchFilter
 import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter
 import com.yahoo.bard.webservice.web.ApiFilter
 import com.yahoo.bard.webservice.web.apirequest.binders.FilterBinders
@@ -173,6 +174,21 @@ class ConjunctionDruidFilterBuilderSpec extends Specification {
         ["1", "3", "4"]      | _
 
 
+    }
+
+    @Unroll
+    def "buildContainsSearchFilters constructs a list of SearchFilters for #values"() {
+        expect:
+        filterBuilder.buildContainsSearchFilters(resources.d16, values) == getSearchFilters(values)
+
+        where:
+        values              | _
+        []                  | _
+        ['v1', 'v2', 'v3']  | _
+    }
+
+    List<Filter> getSearchFilters(List<String> values) {
+        return values.collect {new SearchFilter(resources.d16, SearchFilter.QueryType.Contains, it)}
     }
 
     TreeSet<DimensionRow> getDimensionRows(List<String> ids) {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/filterbuilders/DruidOrFilterBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/filterbuilders/DruidOrFilterBuilderSpec.groovy
@@ -193,7 +193,6 @@ class DruidOrFilterBuilderSpec extends Specification {
         ApiFilter filter = filterBinders.generateApiFilter(filterString, resources.dimensionDictionary)
 
         when: "We build a single selector filter"
-        //resources.d3 is the ageBracket dimension.
         Filter outerFilter = filterBuilder.buildFilters([(resources.d16): [filter] as Set])
 
         and: "Extract the constructed or-filter"

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/filterbuilders/DruidOrFilterBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/filterbuilders/DruidOrFilterBuilderSpec.groovy
@@ -5,6 +5,7 @@ package com.yahoo.bard.webservice.filterbuilders
 import static com.yahoo.bard.webservice.druid.model.filter.Filter.DefaultFilterType.AND
 import static com.yahoo.bard.webservice.druid.model.filter.Filter.DefaultFilterType.NOT
 import static com.yahoo.bard.webservice.druid.model.filter.Filter.DefaultFilterType.OR
+import static com.yahoo.bard.webservice.druid.model.filter.Filter.DefaultFilterType.SEARCH
 import static com.yahoo.bard.webservice.druid.model.filter.Filter.DefaultFilterType.SELECTOR
 
 import com.yahoo.bard.webservice.data.QueryBuildingTestingResources
@@ -13,6 +14,7 @@ import com.yahoo.bard.webservice.druid.model.builders.DruidOrFilterBuilder
 import com.yahoo.bard.webservice.druid.model.filter.Filter
 import com.yahoo.bard.webservice.druid.model.filter.NotFilter
 import com.yahoo.bard.webservice.druid.model.filter.OrFilter
+import com.yahoo.bard.webservice.druid.model.filter.SearchFilter
 import com.yahoo.bard.webservice.druid.model.filter.SelectorFilter
 import com.yahoo.bard.webservice.web.ApiFilter
 import com.yahoo.bard.webservice.web.apirequest.binders.FilterBinders
@@ -36,43 +38,56 @@ class DruidOrFilterBuilderSpec extends Specification {
     }
 
     def setup() {
-        filterSpecs = [ageIdEq1234 : "ageBracket|id-eq[1,2,3,4]",
-                       ageDescEq1129 : "ageBracket|desc-eq[11-14,14-29]",
-                       ageIdNotin56   : "ageBracket|id-notin[5,6]",
-                       ageDescNotin1429: "ageBracket|desc-notin[14-29]"]
+        filterSpecs = [ageIdEq1234     : "ageBracket|id-eq[1,2,3,4]",
+                       ageDescEq1129   : "ageBracket|desc-eq[11-14,14-29]",
+                       ageIdNotin56    : "ageBracket|id-notin[5,6]",
+                       ageDescNotin1429: "ageBracket|desc-notin[14-29]",
+                       dim16IdContains1: "dim16|id-contains[123,456]"]
 
         apiFilters = [:]
         filterSpecs.each {
             apiFilters.put(it.key, filterBinders.generateApiFilter(it.value, resources.dimensionDictionary))
         }
 
-        Filter ageIdEq1234 = new OrFilter([
-                            new SelectorFilter(resources.d3, "1"),
-                            new SelectorFilter(resources.d3, "2"),
-                            new SelectorFilter(resources.d3, "3"),
-                            new SelectorFilter(resources.d3, "4")
-        ])
-        Filter ageDescEq1129 = new OrFilter([
-                new SelectorFilter(resources.d3, "2"),
-                new SelectorFilter(resources.d3, "3")
-        ])
-        Filter ageIdNotin56 = new NotFilter(new OrFilter([
-                new SelectorFilter(resources.d3, "5"),
-                new SelectorFilter(resources.d3, "6")
-        ]))
-        Filter ageDescNotin1429 = new NotFilter(new OrFilter([
-               new SelectorFilter(resources.d3, "3")
-        ]))
-        druidFilters =  [
-                ageIdEq1234: ageIdEq1234,
-                ageDescEq1129: ageDescEq1129,
-                ageIdNotin56: ageIdNotin56,
+        Filter ageIdEq1234 = new OrFilter(
+                [
+                        new SelectorFilter(resources.d3, "1"),
+                        new SelectorFilter(resources.d3, "2"),
+                        new SelectorFilter(resources.d3, "3"),
+                        new SelectorFilter(resources.d3, "4")
+                ]
+        )
+        Filter ageDescEq1129 = new OrFilter(
+                [
+                        new SelectorFilter(resources.d3, "2"),
+                        new SelectorFilter(resources.d3, "3")
+                ]
+        )
+        Filter ageIdNotin56 = new NotFilter(
+                new OrFilter(
+                        [
+                                new SelectorFilter(resources.d3, "5"),
+                                new SelectorFilter(resources.d3, "6")
+                        ]
+                )
+        )
+        Filter ageDescNotin1429 = new NotFilter(
+                new OrFilter(
+                        [
+                                new SelectorFilter(resources.d3, "3")
+                        ]
+                )
+        )
+        druidFilters = [
+                ageIdEq1234     : ageIdEq1234,
+                ageDescEq1129   : ageDescEq1129,
+                ageIdNotin56    : ageIdNotin56,
                 ageDescNotin1429: ageDescNotin1429
         ]
         filterBuilder = new DruidOrFilterBuilder()
     }
 
-    def "If there are no filters to build, then the the filter builder returns null"(){
+    def "If there are no filters to build, then the the filter builder returns null"() {
         expect:
         filterBuilder.buildFilters([:]) == null
     }
@@ -98,14 +113,14 @@ class DruidOrFilterBuilderSpec extends Specification {
         sF.getValue() == value
 
         where:
-        filterString                      | outerFilterType | orFilterSize   | selectIndex | selectorDimension | value
-        "ageBracket|id-eq[1]"             | OR              | 1              | 0           | "ageBracket"      | "1"
-        "ageBracket|id-in[1]"             | OR              | 1              | 0           | "ageBracket"      | "1"
-        "ageBracket|id-startswith[1]"     | OR              | 1              | 0           | "ageBracket"      | "1"
-        "ageBracket|id-contains[1]"       | OR              | 1              | 0           | "ageBracket"      | "1"
-        "ageBracket|id-notin[1]"          | NOT             | 1              | 0           | "ageBracket"      | "1"
-        "ageBracket|id-eq[1,2,4]"         | OR              | 3              | 2           | "ageBracket"      | "4"
-        "ageBracket|desc-eq[11-14,14-29]" | OR              | 2              | 1           | "ageBracket"      | "3"
+        filterString                      | outerFilterType | orFilterSize | selectIndex | selectorDimension | value
+        "ageBracket|id-eq[1]"             | OR              | 1            | 0           | "ageBracket"      | "1"
+        "ageBracket|id-in[1]"             | OR              | 1            | 0           | "ageBracket"      | "1"
+        "ageBracket|id-startswith[1]"     | OR              | 1            | 0           | "ageBracket"      | "1"
+        "ageBracket|id-contains[1]"       | OR              | 1            | 0           | "ageBracket"      | "1"
+        "ageBracket|id-notin[1]"          | NOT             | 1            | 0           | "ageBracket"      | "1"
+        "ageBracket|id-eq[1,2,4]"         | OR              | 3            | 2           | "ageBracket"      | "4"
+        "ageBracket|desc-eq[11-14,14-29]" | OR              | 2            | 1           | "ageBracket"      | "3"
     }
 
     @Unroll
@@ -123,7 +138,7 @@ class DruidOrFilterBuilderSpec extends Specification {
 
         then:
         outerFilter.type == filterType
-        if (outerFilter.type == OR ) {
+        if (outerFilter.type == OR) {
             assert druidExpected == [outerFilter]
         } else {
             assert filters.containsAll(druidExpected) && druidExpected.containsAll(filters)
@@ -135,7 +150,8 @@ class DruidOrFilterBuilderSpec extends Specification {
         ["ageIdEq1234"]                       | OR         | ["ageIdEq1234"]
         ["ageIdEq1234", "ageDescEq1129"]      | AND        | ["ageIdEq1234", "ageDescEq1129"]
         ["ageIdNotin56"]                      | NOT        | ["ageIdNotin56"]
-        ["ageDescEq1129", "ageDescNotin1429"] | AND        | ["ageDescEq1129", "ageDescNotin1429"]}
+        ["ageDescEq1129", "ageDescNotin1429"] | AND        | ["ageDescEq1129", "ageDescNotin1429"]
+    }
 
 
     @Unroll
@@ -148,9 +164,9 @@ class DruidOrFilterBuilderSpec extends Specification {
 
         Filter outerFilter = filterBuilder.buildFilters(dimFilterMap)
         Filter innerFilter
-        if (outerFilter.type == OR ||  outerFilter.type == AND) {
+        if (outerFilter.type == OR || outerFilter.type == AND) {
             innerFilter = outerFilter.fields[0]
-        } else  if (outerFilter.type == NOT) {
+        } else if (outerFilter.type == NOT) {
             innerFilter = outerFilter.field
         } else {
             innerFilter = null
@@ -161,12 +177,39 @@ class DruidOrFilterBuilderSpec extends Specification {
         innerFilter.type == subfilterType
 
         where:
-        dimensions                  |  apiList                           | filterType | subfilterType
-        [resources.d3]              |  [ "ageIdEq1234"]                  | OR         | SELECTOR
-        [resources.d3]              |  [ "ageIdNotin56"]                 | NOT        | OR
-        [resources.d3]              |  [ "ageIdEq1234", "ageDescEq1129"] | AND        | OR
-        [resources.d2, resources.d3]|  [ "ageIdEq1234"]                  | AND        | OR
-        [resources.d2, resources.d3]|  [ "ageIdNotin56"]                 | AND        | NOT
-        [resources.d2, resources.d3]|  [ "ageIdEq1234", "ageDescEq1129"] | AND        | AND
+        dimensions                   | apiList                          | filterType | subfilterType
+        [resources.d3]               | ["ageIdEq1234"]                  | OR         | SELECTOR
+        [resources.d3]               | ["ageIdNotin56"]                 | NOT        | OR
+        [resources.d3]               | ["ageIdEq1234", "ageDescEq1129"] | AND        | OR
+        [resources.d2, resources.d3] | ["ageIdEq1234"]                  | AND        | OR
+        [resources.d2, resources.d3] | ["ageIdNotin56"]                 | AND        | NOT
+        [resources.d2, resources.d3] | ["ageIdEq1234", "ageDescEq1129"] | AND        | AND
+        [resources.d16]              | ["dim16IdContains1"]             | OR         | SEARCH
+    }
+
+    @Unroll
+    def "#filterString is a #outerFilterType-filter on #searchDimension, with #orFilterSize or-clauses"() {
+        setup:
+        ApiFilter filter = filterBinders.generateApiFilter(filterString, resources.dimensionDictionary)
+
+        when: "We build a single selector filter"
+        //resources.d3 is the ageBracket dimension.
+        Filter outerFilter = filterBuilder.buildFilters([(resources.d16): [filter] as Set])
+
+        and: "Extract the constructed or-filter"
+        OrFilter orFilter = outerFilter.type == NOT ? outerFilter.getField() : outerFilter
+
+
+        then: "The extracted OrFilter has been correctly hydrated"
+        outerFilter.type == outerFilterType
+        orFilter.fields.size() == orFilterSize
+        SearchFilter sF = orFilter.fields.get(selectIndex)
+        sF.getDimension() == resources.dimensionDictionary.findByApiName(searchDimension)
+        sF.getQueryValue() == value
+
+        where:
+        filterString             | outerFilterType | orFilterSize | selectIndex | searchDimension | value
+        "dim16|id-contains[1]"   | OR              | 1            | 0           | "dim16"         | "1"
+        "dim16|id-contains[1,2]" | OR              | 2            | 1           | "dim16"         | "2"
     }
 }


### PR DESCRIPTION
Currently, if we fire a query with a contains filter, there are two cases:
1. If the filter is applied on a cached dimension, it will first look for all matching result and then fire a Druid query that looks for fields equals to those matching result.
2. If the filter is applied on a non-cached dimension, it will directly fire a Druid query that looks for fields equals to the substring in the contains filter. This will usually result in an empty result, which is not what a user would expect. 

This issue also causes the Presto connector to create a SQL query that use `=` instead of `like` for substring contains filter.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
