### PR TITLE
Fix or caluse for filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ pull request if there was one.
 
 Current
 -------
-
+### Fixed:
+- [Fix_OR_logic_for_presto_support](https://github.com/yahoo/fili/pull/999)
+    * We use to split the filter clause by ` AND `and then cast each field to varchar before comparison. Add split or ` OR ` as well to support Presto better
 ### Fixed:
 - [Fix contains filter behavior](https://github.com/yahoo/fili/pull/998)
     * When there is a Contains filter applied to a non-cached dimension, it will be translated into a `SearchFilter` instead of `SelectorFilter`.

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
@@ -218,7 +218,7 @@ public class PrestoSqlBackedClient implements SqlBackedClient {
             }
         }
         whereClause = whereClause.substring(5);
-        String[] filterClauses = whereClause.split(" AND ");
+        String[] filterClauses = whereClause.split(" AND | OR ");
         String fieldName;
         String fieldValue;
         String filterClause;

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
@@ -15,14 +15,14 @@ class PrestoSqlBackedClientSpec extends Specification {
         expect:
         toPrestoQuery == """SELECT "source", SUBSTRING(datestamp,1,4) AS "\$f23", DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) AS "\$f24", SUBSTRING(datestamp,9,2) AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) <> "1=2====3" AND CAST("advertiser_id" AS varchar) = "456"
+WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) <> "1=2====3" AND CAST("advertiser_id" AS varchar) = "456" OR CAST("advertiser_id" AS varchar) = "123"
 GROUP BY "source", SUBSTRING(datestamp,1,4), DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')), SUBSTRING(datestamp,9,2)
 ORDER BY SUBSTRING(datestamp,1,4) NULLS FIRST, DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) NULLS FIRST, SUBSTRING(datestamp,9,2) NULLS FIRST, "source" NULLS FIRST"""
 
         where:
         sqlQuery << ["""SELECT "source", YEAR("datestamp") AS "\$f23", DAYOFYEAR("datestamp") AS "\$f24", HOUR("datestamp") AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '2019-09-01 14:00:00.0' AND "datestamp" < '2019-09-02 14:00:00.0' AND "comment" <> "1=2====3" AND "advertiser_id" = "456"
+WHERE "datestamp" > '2019-09-01 14:00:00.0' AND "datestamp" < '2019-09-02 14:00:00.0' AND "comment" <> "1=2====3" AND "advertiser_id" = "456" OR "advertiser_id" = "123"
 GROUP BY "source", YEAR("datestamp"), DAYOFYEAR("datestamp"), HOUR("datestamp")
 ORDER BY YEAR("datestamp") NULLS FIRST, DAYOFYEAR("datestamp") NULLS FIRST, HOUR("datestamp") NULLS FIRST, "source" NULLS FIRST"""]
     }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The solution to different types of presto tables is that we add the cast to string before comparing. In the previous PR (https://github.com/yahoo/fili/pull/995), we split the filter clause by ` AND `. In fact, ` OR ` should also be considered. Fix this issue in this PR.

git issue: https://github.com/yahoo/fili/issues/1000
