### PR TITLE
address the suitation where () is used in where filter clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ pull request if there was one.
 Current
 -------
 ### Fixed:
-- [Further fix_OR_logic_for_presto_support](https://github.com/yahoo/fili/pull/1000)
+- [Further fix_OR_logic_for_presto_support](https://github.com/yahoo/fili/pull/1002)
     * The `()` are used to enforce precedence of the logical where claus. Address the situation where `()`s are used for Presto support 
 - [Fix_OR_logic_for_presto_support](https://github.com/yahoo/fili/pull/999)
     * We use to split the filter clause by ` AND `and then cast each field to varchar before comparison. Add split or ` OR ` as well to support Presto better

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ pull request if there was one.
 Current
 -------
 ### Fixed:
+- [Further fix_OR_logic_for_presto_support](https://github.com/yahoo/fili/pull/1000)
+    * The `()` are used to enforce precedence of the logical where claus. Address the situation where `()`s are used for Presto support 
 - [Fix_OR_logic_for_presto_support](https://github.com/yahoo/fili/pull/999)
     * We use to split the filter clause by ` AND `and then cast each field to varchar before comparison. Add split or ` OR ` as well to support Presto better
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ pull request if there was one.
 
 Current
 -------
-### Fixed:
-- [Further fix_OR_logic_for_presto_support](https://github.com/yahoo/fili/pull/1002)
-    * The `()` are used to enforce precedence of the logical where claus. Address the situation where `()`s are used for Presto support 
-- [Fix_OR_logic_for_presto_support](https://github.com/yahoo/fili/pull/999)
+### Fixed: 
+- [Fix_OR_logic_for_presto_support](https://github.com/yahoo/fili/pull/999 and https://github.com/yahoo/fili/pull/1002)
     * We use to split the filter clause by ` AND `and then cast each field to varchar before comparison. Add split or ` OR ` as well to support Presto better
+    * Add support to use of `()` in the filter clause
 ### Fixed:
 - [Fix contains filter behavior](https://github.com/yahoo/fili/pull/998)
     * When there is a Contains filter applied to a non-cached dimension, it will be translated into a `SearchFilter` instead of `SelectorFilter`.

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
@@ -23,6 +23,8 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
@@ -218,7 +220,17 @@ public class PrestoSqlBackedClient implements SqlBackedClient {
             }
         }
         whereClause = whereClause.substring(5);
-        String[] filterClauses = whereClause.split(" AND | OR ");
+        String[] andClauses = whereClause.split(" AND ");
+        ArrayList<String> filterClauses = new ArrayList<>();
+        for (String andClause : andClauses) {
+            if (andClause.charAt(0) == '(') {
+                andClause = andClause.substring(1);
+            }
+            if (andClause.charAt(andClause.length() - 1) == ')') {
+                andClause = andClause.substring(0, andClause.length() - 1);
+            }
+            filterClauses.addAll(Arrays.asList(andClause.split(" OR ")));
+        }
         String fieldName;
         String fieldValue;
         String filterClause;
@@ -228,8 +240,8 @@ public class PrestoSqlBackedClient implements SqlBackedClient {
         int comparatorIndex;
         // could be either <> or =
         String comparator;
-        for (int i = 2; i < filterClauses.length; i++) {
-            filterClause = filterClauses[i];
+        for (int i = 2; i < filterClauses.size(); i++) {
+            filterClause = filterClauses.get(i);
             equalIndex = filterClause.indexOf("=");
             notEqualIndex = filterClause.indexOf("<>");
             if (equalIndex != -1 && (notEqualIndex == -1 || equalIndex < notEqualIndex)) {

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
@@ -221,7 +222,7 @@ public class PrestoSqlBackedClient implements SqlBackedClient {
         }
         whereClause = whereClause.substring(5);
         String[] andClauses = whereClause.split(" AND ");
-        ArrayList<String> filterClauses = new ArrayList<>();
+        List<String> filterClauses = new ArrayList<>();
         for (String andClause : andClauses) {
             if (andClause.charAt(0) == '(') {
                 andClause = andClause.substring(1);

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
@@ -15,14 +15,14 @@ class PrestoSqlBackedClientSpec extends Specification {
         expect:
         toPrestoQuery == """SELECT "source", SUBSTRING(datestamp,1,4) AS "\$f23", DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) AS "\$f24", SUBSTRING(datestamp,9,2) AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) <> "1=2====3" AND CAST("advertiser_id" AS varchar) = "456" OR CAST("advertiser_id" AS varchar) = "123"
+WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) <> '1=2====3' AND (CAST("advertiser_id" AS varchar) = '456' OR CAST("advertiser_id" AS varchar) = '123')
 GROUP BY "source", SUBSTRING(datestamp,1,4), DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')), SUBSTRING(datestamp,9,2)
 ORDER BY SUBSTRING(datestamp,1,4) NULLS FIRST, DAY_OF_YEAR(date_parse(SUBSTRING (datestamp,1,10),'%Y%m%d%H')) NULLS FIRST, SUBSTRING(datestamp,9,2) NULLS FIRST, "source" NULLS FIRST"""
 
         where:
         sqlQuery << ["""SELECT "source", YEAR("datestamp") AS "\$f23", DAYOFYEAR("datestamp") AS "\$f24", HOUR("datestamp") AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '2019-09-01 14:00:00.0' AND "datestamp" < '2019-09-02 14:00:00.0' AND "comment" <> "1=2====3" AND "advertiser_id" = "456" OR "advertiser_id" = "123"
+WHERE "datestamp" > '2019-09-01 14:00:00.0' AND "datestamp" < '2019-09-02 14:00:00.0' AND "comment" <> '1=2====3' AND ("advertiser_id" = '456' OR "advertiser_id" = '123')
 GROUP BY "source", YEAR("datestamp"), DAYOFYEAR("datestamp"), HOUR("datestamp")
 ORDER BY YEAR("datestamp") NULLS FIRST, DAYOFYEAR("datestamp") NULLS FIRST, HOUR("datestamp") NULLS FIRST, "source" NULLS FIRST"""]
     }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The current implementation of adding cast before comparison does not handle the presence of `()` in the logical filter expression (for example `WHERE ... AND (... OR ...)` will cause the program to result a wrong Presto query). Fix this problem in this PR.

Git issue: https://github.com/yahoo/fili/issues/1000