### PR TITLE
Makes NoMatchFoundException a RuntimeException.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Current
    * Generators based on `DataApiRequestImpl` are not yet implemented.
 
 ### Changed:
+- [Makes NoMatchFoundException a RuntimeException.](https://github.com/yahoo/fili/pull/1004)
+    - By making NoMatchFoundException a RuntimeException, it can be used in places other than
+        the DataServlet without losing the nice error message provided by the `FiliDataExceptionHandler`.
 - [Extracted `DataSourceConstraint` into an interface](https://github.com/yahoo/fili/issues/996)
    * `DataSourceConstraint` is now an interface.
     - Migration path documented in the linked issue.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/NoMatchFoundException.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/table/resolver/NoMatchFoundException.java
@@ -5,7 +5,7 @@ package com.yahoo.bard.webservice.table.resolver;
 /**
  * An exception for PhysicalTableMatchers when they return no matches.
  */
-public class NoMatchFoundException extends Exception {
+public class NoMatchFoundException extends RuntimeException {
     /**
      * Constructor.
      *


### PR DESCRIPTION
-- Currently, NoMatchFoundException is a checked Exception. At one
point, this may have been what we wanted. However, ever since we
introduced the `DataExceptionHandler` class, Fili already
handles the NoMatchFoundException by default at the top level, so
there's no need for callers to explicitly handle it. They can just let
it bubble up the callstack.

-- As of right now, it doesn't matter because the NoMatchFoundException
is only thrown in the DataServlet. However, one customer is trying to
build a Druid Query in a RequestHandler. While building a Druid Query,
it's possible that `NoMatchFoundException` will be thrown. However, we
can't just it bubble up because it's a checked exception, and
`RequestHandler.handle` doesn't throw `NoMatchFoundException`. We
can't wrap it in a RuntimeException either, because in that case
the FiliDataExceptionHandler won't recognize it as a
`NoMatchFoundException` and therefore won't print a user-friendly error
message.

-- Therefore, we make `NoMatchFoundException` a RuntimeException.
Not only don't we *have* to handle `NoMatchFoundException` at
the place where it's thrown (since by default it's handled higher up
the callstack), but it also inhibits composability.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
