### PR TITLE
Adds a protected method to DruidQueryBuilder to determine query type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ Current
    * Rationalized dependencies for sample applications
 
 - [Uses `addFactories` rather than `withFactories` in Luthier setup.](https://github.com/yahoo/fili/pull/991)
+
+- [Extracts the logic for deciding which Druid query to build in the DruidQueryBuilder protected method for easily overriding.](https://github.com/yahoo/fili/pull/1008)
    
 ### Removed:
 


### PR DESCRIPTION
-- There may be situations where customers of Fili need to tweak the
rules on when Fili does or doesn't optimize a given DataApiRequest into
a topN, timeseries or other query type. However, currently the
optimization code is fairly interwoven, and not particularly isolated.

-- This PR isolates the key logic for determining the query type to
build, and pulls it out into a separate protected method that returns
the query type that Fili should build. Now, if customers need to modify
the rules for what query type to build, they can override the given
protected method.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
