### PR TITLE
Adds a method to DataApiRequest to turn query optimization on/off.

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/DruidQueryBuilder.java
@@ -414,7 +414,8 @@ public class DruidQueryBuilder {
      * @return true if the optimization can be done, false if it can't
      */
     protected boolean canOptimizeTopN(DataApiRequest apiRequest, TemplateDruidQuery templateDruidQuery) {
-        return apiRequest.getDimensions().size() == 1 &&
+        return apiRequest.optimizeBackendQuery() &&
+                apiRequest.getDimensions().size() == 1 &&
                 apiRequest.getSorts().size() == 1 &&
                 !templateDruidQuery.isNested() &&
                 BardFeatureFlag.TOP_N.isOn() &&
@@ -430,7 +431,8 @@ public class DruidQueryBuilder {
      * @return true if the optimization can be done, false if it can't
      */
     protected boolean canOptimizeTimeSeries(DataApiRequest apiRequest, TemplateDruidQuery templateDruidQuery) {
-        return apiRequest.getDimensions().isEmpty() &&
+        return apiRequest.optimizeBackendQuery() &&
+            apiRequest.getDimensions().isEmpty() &&
                 !templateDruidQuery.isNested() &&
                 apiRequest.getSorts().isEmpty() &&
                 !apiRequest.getCount().isPresent() &&

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequest.java
@@ -391,6 +391,17 @@ public interface DataApiRequest extends ApiRequest {
 
     DataApiRequest withAsyncAfter(long asyncAfter);
 
+    /**
+     * Whether or not to attempt to build an optimal backend query (i.e. topN or timeSeries in the case of Druid) if possible.
+     *
+     * @return True if the backend query built from this request can be safely optimized (i.e. converted into a topN 
+     * or timeseries query when hitting Druid), false if a naive query should be built (i.e. groupBy in the 
+     * case of Druid)
+     */
+    default boolean optimizeBackendQuery() {
+        return true;
+    }
+
     // Builder with methods
 
     @Deprecated

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/utils/TestingDataApiRequestImpl.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/utils/TestingDataApiRequestImpl.groovy
@@ -32,7 +32,8 @@ class TestingDataApiRequestImpl extends DataApiRequestImpl {
                 (PaginationParameters) null,
                 (ResponseFormatType) null,
                 "",
-                Long.MAX_VALUE // asynchAfter
+                Long.MAX_VALUE, // asyncAfter
+                true // Whether or not to try to build the optimal druid query
         )
     }
 }


### PR DESCRIPTION
-- Fili currently will attempt to use the most efficient Druid query
type that can answer the given query. While this is wonderful, it
doesn't play well with attempts to support sending multiple Druid
queries from a single ApiRequest, because it becomes theoretically
possible for a single ApiRequest to create multiple different types of
queries, and keeping track of all those types so that their responses
can be parsed correctly is painful.

-- Therefore, we include a new method on DataApiRequest that indicates
whether or not this request should be optimized, or should generate a
GroupBy query, even if it could be satisfied by a timeseries or topN.
This allows customers to force their query to follow a particular
pattern if they so desire.

-- We also modified DataApiRequestImpl to include a boolean switch that
can be flipped on and off. This was not added to the interface in order
to avoid disrupting customers who aren't concerned with such
functionality.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
