### PR TITLE
Add missing argument to error message in RequestLog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ pull request if there was one.
 Current
 -------
 ### Fixed: 
+- [Adds missing argument to format string in a rarely used error path in RequestLog](https://github.com/yahoo/fili/pull/1031)
 - [Fix bug where some Aggregation model types were incorrectly reporting precision](https://github.com/yahoo/fili/pull/1017)
     * CardinalityAggregation, LongMaxAggregation, and LongMinAggregation were incorrectly reporting their precision as
       floating point by not overriding the Aggregation#isFloatingPoint method to return "false".  

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -342,7 +342,7 @@ public class RequestLog {
 
         LogInfo logInfo = requestLog.info.get(cls.getSimpleName());
         if (logInfo == null) {
-            String message = ErrorMessageFormat.RESOURCE_RETRIEVAL_FAILURE.format(cls.getSimpleName());
+            String message = ErrorMessageFormat.RESOURCE_RETRIEVAL_FAILURE.format(cls.getSimpleName(), requestLog);
             LOG.error(message);
             throw new IllegalStateException(message);
         }


### PR DESCRIPTION
Apparently, there was a small bug in a infrequently used error path in the RequestLog, where the error message's format string expected two arguments, but we were only passing it one.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.