### PR TITLE
Change metric binder injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ Current
    * Generators based on `DataApiRequestImpl` are not yet implemented.
 
 ### Changed:
+- [Added parameter for `ApiRequestLogicalMetricBinder` to the core binding constructor on `DataApiRequestImpl`](https://github.com/yahoo/fili/pull/1034)
+   * `BardConfigResources` has a method for providing an instance of `ApiRequestLogicalMetricBind`
+    - Existing delegating constructors that take `BardConfigResources` have their public contracts unchanged
+   * `DefaultLogicalMetricBinder` is the default implementation of this interface.
+    - `BardConfigResources#getMetricBinder` is defaulted to return a new instance of this class.
+    
 - [Extracted `DataSourceConstraint` into an interface](https://github.com/yahoo/fili/issues/996)
    * `DataSourceConstraint` is now an interface.
     - Migration path documented in the linked issue.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -70,7 +70,8 @@ public abstract class ApiRequestImpl implements ApiRequest {
 
     // hardcoding this for now to the old behavior so injection can be based on the protocol binder without changing
     // this code.
-    protected ApiRequestLogicalMetricBinder metricBinder = new DefaultLogicalMetricGenerator();
+    protected static final ApiRequestLogicalMetricBinder DEFAULT_METRIC_BINDER = new DefaultLogicalMetricGenerator();
+    protected ApiRequestLogicalMetricBinder metricBinder = DEFAULT_METRIC_BINDER;
 
     /**
      * Parses the API request URL and generates the API request object.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestImpl.java
@@ -70,7 +70,7 @@ public abstract class ApiRequestImpl implements ApiRequest {
 
     // hardcoding this for now to the old behavior so injection can be based on the protocol binder without changing
     // this code.
-    ApiRequestLogicalMetricBinder metricBinder = new DefaultLogicalMetricGenerator();
+    protected ApiRequestLogicalMetricBinder metricBinder = new DefaultLogicalMetricGenerator();
 
     /**
      * Parses the API request URL and generates the API request object.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -192,6 +192,7 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
                 count,
                 topN,
                 format,
+                null,
                 timeZoneId,
                 asyncAfter,
                 perPage,
@@ -376,8 +377,7 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
             DateTimeZone systemTimeZone,
             GranularityParser granularityParser,
             DruidFilterBuilder druidFilterBuilder,
-            HavingGenerator havingGenerator,
-            ApiRequestLogicalMetricBinder metricBinder
+            HavingGenerator havingGenerator
     ) throws BadApiRequestException {
         this(
                 tableName,
@@ -403,7 +403,7 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
                 granularityParser,
                 druidFilterBuilder,
                 havingGenerator,
-                metricBinder
+                ApiRequestImpl.DEFAULT_METRIC_BINDER
         );
     }
 
@@ -445,6 +445,8 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
      * @param granularityParser A tool to process granularities
      * @param druidFilterBuilder A function to build druid filters from Api Filters
      * @param havingGenerator A function to create havings
+     * @param metricBinder  Class that parses the input metric query string and binds the requested metric names to the
+     *                      materialized LogicalMetrics.
      *
      * @throws BadApiRequestException in the following scenarios:
      * <ol>

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequestImpl.java
@@ -44,16 +44,17 @@ import com.yahoo.bard.webservice.util.StreamUtils;
 import com.yahoo.bard.webservice.util.TableUtils;
 import com.yahoo.bard.webservice.web.ApiFilter;
 import com.yahoo.bard.webservice.web.ApiHaving;
-import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
 import com.yahoo.bard.webservice.web.DefaultFilterOperation;
 import com.yahoo.bard.webservice.web.DimensionFieldSpecifierKeywords;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 import com.yahoo.bard.webservice.web.MetricParser;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
 import com.yahoo.bard.webservice.web.apirequest.generator.IntervalBinders;
 import com.yahoo.bard.webservice.web.apirequest.generator.filter.FilterBinders;
 import com.yahoo.bard.webservice.web.apirequest.generator.filter.FilterGenerator;
 import com.yahoo.bard.webservice.web.apirequest.generator.having.HavingGenerator;
+import com.yahoo.bard.webservice.web.apirequest.generator.metric.ApiRequestLogicalMetricBinder;
 import com.yahoo.bard.webservice.web.filters.ApiFilters;
 import com.yahoo.bard.webservice.web.util.BardConfigResources;
 import com.yahoo.bard.webservice.web.util.PaginationParameters;
@@ -201,7 +202,8 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
                 bardConfigResources.getSystemTimeZone(),
                 bardConfigResources.getGranularityParser(),
                 bardConfigResources.getFilterBuilder(),
-                bardConfigResources.getHavingApiGenerator()
+                bardConfigResources.getHavingApiGenerator(),
+                bardConfigResources.getMetricBinder()
         );
     }
 
@@ -294,7 +296,8 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
                 bardConfigResources.getSystemTimeZone(),
                 bardConfigResources.getGranularityParser(),
                 bardConfigResources.getFilterBuilder(),
-                bardConfigResources.getHavingApiGenerator()
+                bardConfigResources.getHavingApiGenerator(),
+                bardConfigResources.getMetricBinder()
         );
     }
 
@@ -373,7 +376,8 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
             DateTimeZone systemTimeZone,
             GranularityParser granularityParser,
             DruidFilterBuilder druidFilterBuilder,
-            HavingGenerator havingGenerator
+            HavingGenerator havingGenerator,
+            ApiRequestLogicalMetricBinder metricBinder
     ) throws BadApiRequestException {
         this(
                 tableName,
@@ -398,7 +402,8 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
                 systemTimeZone,
                 granularityParser,
                 druidFilterBuilder,
-                havingGenerator
+                havingGenerator,
+                metricBinder
         );
     }
 
@@ -478,7 +483,8 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
             DateTimeZone systemTimeZone,
             GranularityParser granularityParser,
             DruidFilterBuilder druidFilterBuilder,
-            HavingGenerator havingGenerator
+            HavingGenerator havingGenerator,
+            ApiRequestLogicalMetricBinder metricBinder
     ) throws BadApiRequestException {
         super(formatRequest, downloadFilename, asyncAfterRequest, perPage, page);
 
@@ -501,6 +507,7 @@ public class DataApiRequestImpl extends ApiRequestImpl implements DataApiRequest
         // At least one logical metric is required
         this.filterBuilder = druidFilterBuilder;  // required for intersection metrics to work
 
+        this.metricBinder = metricBinder;
         this.logicalMetrics = bindLogicalMetrics(logicalMetricsRequest, table, metricDictionary, dimensionDictionary);
         validateLogicalMetrics(logicalMetricsRequest, logicalMetrics, table, metricDictionary);
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ProtocolMetricDataApiReqestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ProtocolMetricDataApiReqestImpl.java
@@ -18,7 +18,6 @@ import com.yahoo.bard.webservice.table.LogicalTable;
 import com.yahoo.bard.webservice.web.ApiHaving;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
 import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
-import com.yahoo.bard.webservice.web.apirequest.generator.metric.ApiRequestLogicalMetricBinder;
 import com.yahoo.bard.webservice.web.filters.ApiFilters;
 import com.yahoo.bard.webservice.web.util.BardConfigResources;
 import com.yahoo.bard.webservice.web.util.PaginationParameters;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ProtocolMetricDataApiReqestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ProtocolMetricDataApiReqestImpl.java
@@ -212,7 +212,7 @@ public class ProtocolMetricDataApiReqestImpl extends DataApiRequestImpl {
      * @return set of bound metric objects
      * @throws BadApiRequestException if the metric dictionary returns a null or if the apiMetricQuery is invalid.
      */
-
+    @Override
     protected LinkedHashSet<LogicalMetric> bindLogicalMetrics(
             String apiMetricExpression,
             LogicalTable logicalTable,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ProtocolMetricDataApiReqestImpl.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ProtocolMetricDataApiReqestImpl.java
@@ -43,8 +43,6 @@ public class ProtocolMetricDataApiReqestImpl extends DataApiRequestImpl {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataApiRequestImpl.class);
 
-    private final ApiRequestLogicalMetricBinder metricBinder;
-
     /**
      * Parses the API request URL and generates the Api Request object.
      *
@@ -130,7 +128,6 @@ public class ProtocolMetricDataApiReqestImpl extends DataApiRequestImpl {
                 page,
                 bardConfigResources
         );
-        metricBinder = bardConfigResources.getMetricBinder();
     }
 
     /**

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
@@ -35,6 +35,7 @@ import com.yahoo.bard.webservice.table.resolver.DefaultPhysicalTableResolver
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequest
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
 import com.yahoo.bard.webservice.web.apirequest.generator.having.DefaultHavingApiGenerator
+import com.yahoo.bard.webservice.web.apirequest.generator.metric.DefaultLogicalMetricGenerator
 import com.yahoo.bard.webservice.web.endpoints.DataServlet
 
 import org.joda.time.Interval
@@ -84,6 +85,7 @@ class WeightEvaluationQuerySpec extends Specification {
         dataServlet.getFilterBuilder() >> new DruidOrFilterBuilder()
         dataServlet.getHavingApiGenerator() >> new DefaultHavingApiGenerator(configurationLoader)
         dataServlet.getGranularityParser() >> new StandardGranularityParser()
+        dataServlet.getMetricBinder() >> new DefaultLogicalMetricGenerator()
 
         builder = new DruidQueryBuilder(
                 jtb.configurationLoader.logicalTableDictionary,


### PR DESCRIPTION
core issue: https://github.com/yahoo/fili/issues/1014

This PR enables injecting a metric binder into DataApiRequestImpl instances and subclasses, which is required for servicing protocol metrics.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
