### PR TITLE
Fix protocol sorts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ Current
     * `MetricUnionAvailability` previously did not create a defensive copy of the `availabilitiesToMetricNames` parameter. This has been fixed.   
 - [Upgrades to netty 4.1.42.45.Final to address CVE-2019-20444 and CVE-2019-20445](https://github.com/yahoo/fili/pull/1006)
 
+- [Fixing sort for protocol metrics] (https://github.com/yahoo/fili/issues/1047)
+    * Created an antlr grammar for Sorts
+    * Fixed integration issues with Havings
+    * Injected dynamic sort building into `BardConfigResources` and `DataApiServlet`
+    * Changed `TestBinderFactory` to support protocol metric tests.
+    * Created `LegacyGenerator` as a bridge interface from the existing constructor based api request impls and the factory based value object usage.
+
 ### Added:
 - [Add `TemplateDruidQueryUtils` class, which contains static utility methods for interacting with `TemplateDruidQuery`](https://github.com/yahoo/fili/pull/1046)
    * Add `repointToNewMetricField` method, which recursively checks a given field for references to a `MetricField` instance

--- a/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/havingparser/Havings.g4
+++ b/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/havingparser/Havings.g4
@@ -8,12 +8,25 @@ havings
     : ( havingComponent ( COMMA havingComponent )* )? EOF;
 
 havingComponent
-    : metric DASH OPERATOR OPEN_BRACKET values CLOSE_BRACKET;
+    : metric DASH operator OPEN_BRACKET havingValues CLOSE_BRACKET;
 
 metric
-    : ID ( OPEN_PARENTHESIS ID EQUALS ID CLOSE_PARENTHESIS )?
+    : metricName ( OPEN_PARENTHESIS params? CLOSE_PARENTHESIS )?
+    ;
+metricName
+    : ID
     ;
 
-values
-    : VALUE ( COMMA VALUE )*
+operator
+    : ID
+    ;
+params
+    : paramValue ( COMMA paramValue )*
+    ;
+paramValue
+    : ID EQUALS VALUE
+    ;
+
+havingValues
+    : HAVING_VALUE ( COMMA HAVING_VALUE )*
     ;

--- a/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/havingparser/HavingsLex.g4
+++ b/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/havingparser/HavingsLex.g4
@@ -2,70 +2,57 @@ lexer grammar HavingsLex;
 
 options { }
 
-tokens { OPERATOR, VALUE, COMMA }
+tokens { OPERATOR, PARAMETER, KEY, VALUE, HAVING_VALUE }
 
-COMMA1 : ',' -> type(COMMA);
-DASH : '-';
-EQUALS: '=';
-DOT: '.' ;
-OPEN_PARENTHESIS : '(';
-CLOSE_PARENTHESIS : ')';
-OPEN_BRACKET : '[' -> pushMode(VALUE_MODE);
+// Reused from metric
+OPEN_PARENTHESIS : '(' -> pushMode(PARAN_MODE);
+CLOSE_PARENTHESIS : ')' ;
+COMMA : ','
+        | ', ';
+DASH: '-';
 
-EQUAL_TO : ( 'equalTo'
-           | 'equals'
-           | 'eq'
-           ) -> type(OPERATOR);
-
-GREATER_THAN : ( 'greaterThan'
-               | 'greater'
-               | 'gt'
-               ) -> type(OPERATOR);
-
-LESSER_THAN : ( 'lessThan'
-              | 'less'
-              | 'lt'
-              ) -> type(OPERATOR);
-
-NOT_EQUAL_TO : ( 'notEqualTo'
-               | 'notEquals'
-               | 'noteq'
-               | 'neq'
-               ) -> type(OPERATOR);
-
-NOT_GREATER_THAN : ( 'notGreaterThan'
-                   | 'notGreater'
-                   | 'notgt'
-                   | 'lte'
-                   ) -> type(OPERATOR);
-
-NOT_LESS_THAN : ( 'notLessThan'
-                | 'notLess'
-                | 'notlt'
-                | 'gte'
-                ) -> type(OPERATOR);
-
-BETWEEN : ( 'between'
-          | 'bet'
-          ) -> type(OPERATOR);
-
-NOT_BETWEEN : ( 'notBetween'
-              | 'nbet'
-              ) -> type(OPERATOR);
+// Numeric value fragments
+fragment DOT: '.' ;
+fragment DIGITS : [0-9] ;
+fragment SCIENTIFIC_NOTATION : [eE] ;
+fragment SIGNS : [+\-] ;
 
 ID : [a-zA-Z0-9_]+;
-fragment DIGITS : [0-9];
-fragment SCIENTIFIC_NOTATION : [eE];
-fragment SIGNS : [+\-];
 
-// values mode
+OPEN_BRACKET : '[' -> pushMode(HAVING_VALUE_MODE);
+// Having Operators
+mode PARAN_MODE;
+COMMA0 : (',' | ', ') -> type(COMMA);
+WS0 : [ \t\n\r]+ -> skip;
+ID2 : [a-zA-Z0-9_]+ -> type(ID);
+EQUALS: '=' -> pushMode(VALUE_MODE);
+
+CLOSE_PARENTHESIS2 : ')' -> type(CLOSE_PARENTHESIS), popMode ;
+
+
 mode VALUE_MODE;
-WS : [ \t\n\r]+ -> skip;
-SIMPLE_VALUE : (  SIGNS? DIGITS+ (DOT DIGITS*)? ( SCIENTIFIC_NOTATION SIGNS? DIGITS+) ?
+WS1 : [ \t\n\r]+ -> skip;
+
+COMMA1 : (',' | ', ') -> type(COMMA);
+
+UNQUOTED_VALUE : [a-zA-Z0-9_]+ -> type(VALUE), popMode;
+
+NUMERIC_VALUE : ((  SIGNS? DIGITS+ (DOT DIGITS*)? ( SCIENTIFIC_NOTATION SIGNS? DIGITS+) ?
                 | SIGNS? DOT DIGITS+ ( SCIENTIFIC_NOTATION SIGNS? DIGITS+ )?
-               ) {setText(getText().trim());} -> type(VALUE);
-//TEXT_VALUE : ID+ -> type(VALUE);
+               ) {setText(getText().trim());} ) -> type(VALUE), popMode;
+
+// end of reused from metric
+// Having specific syntax
+
+// having values mode
+mode HAVING_VALUE_MODE;
+WS2 : [ \t\n\r]+ -> skip;
+
+COMMA2 : ',' -> type(COMMA);
+
+NUMERIC_VALUE1 : (  SIGNS? DIGITS+ (DOT DIGITS*)? ( SCIENTIFIC_NOTATION SIGNS? DIGITS+) ?
+                | SIGNS? DOT DIGITS+ ( SCIENTIFIC_NOTATION SIGNS? DIGITS+ )?
+               ) {setText(getText().trim());} -> type(HAVING_VALUE);
 
 CLOSE_BRACKET : ']' -> popMode;
-COMMA2 : ',' -> type(COMMA);
 

--- a/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/metrics/MetricsLex.g4
+++ b/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/metrics/MetricsLex.g4
@@ -1,20 +1,39 @@
 lexer grammar MetricsLex;
+
 options { }
+
 tokens { OPERATOR, PARAMETER, KEY, VALUE }
-WS : [ \t\n\r]+ -> skip;
-OPEN_PARENTHESIS : '(' ;
+
+OPEN_PARENTHESIS : '(' -> pushMode(PARAN_MODE);
 CLOSE_PARENTHESIS : ')' ;
 COMMA : ',';
-ID : [a-zA-Z0-9_]+;
-EQUALS: '=' -> pushMode(VALUE_MODE);
-// values mode
-mode VALUE_MODE;
-fragment DASH : '-';
+DASH: '-';
+
+// Numeric value fragments
 fragment DOT: '.' ;
-fragment DIGITS : [0-9];
-fragment SCIENTIFIC_NOTATION : [eE];
-fragment SIGNS : [+\-];
+fragment DIGITS : [0-9] ;
+fragment SCIENTIFIC_NOTATION : [eE] ;
+fragment SIGNS : [+\-] ;
+
+ID : [a-zA-Z0-9_]+;
+WS : [ \t\n\r]+ -> skip;
+
+// Having Operators
+mode PARAN_MODE;
+WS0 : [ \t\n\r]+ -> skip;
+COMMA0 : (',' | ',') -> type(COMMA);
+ID2 : [a-zA-Z0-9_]+ -> type(ID);
+EQUALS: '=' -> pushMode(VALUE_MODE);
+
+CLOSE_PARENTHESIS2 : ')' -> type(CLOSE_PARENTHESIS), popMode ;
+
+mode VALUE_MODE;
+WS1 : [ \t\n\r]+ -> skip;
+
+COMMA1 : (',' | ', ') -> type(COMMA);
+
+UNQUOTED_VALUE : [a-zA-Z0-9_]+ -> type(VALUE), popMode;
+
 NUMERIC_VALUE : ((  SIGNS? DIGITS+ (DOT DIGITS*)? ( SCIENTIFIC_NOTATION SIGNS? DIGITS+) ?
                 | SIGNS? DOT DIGITS+ ( SCIENTIFIC_NOTATION SIGNS? DIGITS+ )?
                ) {setText(getText().trim());} ) -> type(VALUE), popMode;
-TEXT_VALUE : ID -> type(VALUE), popMode;

--- a/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/sorts/Sorts.g4
+++ b/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/sorts/Sorts.g4
@@ -1,10 +1,14 @@
-grammar Metrics;
+grammar Sorts;
 
 options {
-    tokenVocab=MetricsLex;
+    tokenVocab=SortsLex;
 }
-metrics
-    : ( metric ( COMMA metric )* )? EOF;
+
+sorts
+    : ( sortsComponent ( COMMA sortsComponent )* )? EOF;
+
+sortsComponent
+    : metric (PIPE orderingValue)?;
 
 metric
     : metricName ( OPEN_PARENTHESIS params? CLOSE_PARENTHESIS )?
@@ -17,4 +21,9 @@ params
     ;
 paramValue
     : ID EQUALS VALUE
+    ;
+
+orderingValue
+    : ASC
+    | DESC
     ;

--- a/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/sorts/SortsLex.g4
+++ b/fili-core/src/main/antlr4/com/yahoo/bard/webservice/web/sorts/SortsLex.g4
@@ -1,0 +1,47 @@
+lexer grammar SortsLex;
+
+options { }
+
+tokens { OPERATOR, VALUE, COMMA, PIPE }
+
+// reused from metric
+WS : [ \t\n\r]+ -> skip;
+OPEN_PARENTHESIS : '(' ;
+CLOSE_PARENTHESIS : ')' ;
+COMMA : ',';
+ID : [a-zA-Z0-9_]+;
+
+EQUALS: '=' -> pushMode(VALUE_MODE);
+
+// Quoted String framents
+fragment ESC : '\\"' | '\\\\' ; // 2 char sequences \" and \\
+fragment QUOTED_STRING : '"' (ESC|.)*? '"' ;
+
+// Numeric value fragments
+fragment DASH : '-' ;
+fragment DOT: '.' ;
+fragment DIGITS : [0-9] ;
+fragment SCIENTIFIC_NOTATION : [eE] ;
+fragment SIGNS : [+\-] ;
+
+PIPE : '|';
+ASC : 'asc'
+    | 'ASC'
+    | 'ascending'
+    | 'ASCENDING' ;
+
+DESC : 'desc'
+    | 'DESC'
+    | 'descending'
+    | 'DESCENDING' ;
+
+mode VALUE_MODE;
+
+UNQUOTED_VALUE : [a-zA-Z0-9_]+ -> type(VALUE), popMode;
+
+QUOTED_VALUE : QUOTED_STRING -> type(VALUE), popMode;
+
+NUMERIC_VALUE : ((  SIGNS? DIGITS+ (DOT DIGITS*)? ( SCIENTIFIC_NOTATION SIGNS? DIGITS+) ?
+                | SIGNS? DOT DIGITS+ ( SCIENTIFIC_NOTATION SIGNS? DIGITS+ )?
+               ) {setText(getText().trim());} ) -> type(VALUE), popMode;
+

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/AbstractBinderFactory.java
@@ -72,6 +72,7 @@ import com.yahoo.bard.webservice.druid.model.builders.DruidFilterBuilder;
 import com.yahoo.bard.webservice.druid.model.builders.DruidHavingBuilder;
 import com.yahoo.bard.webservice.druid.model.builders.DruidInFilterBuilder;
 import com.yahoo.bard.webservice.druid.model.builders.DruidOrFilterBuilder;
+import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn;
 import com.yahoo.bard.webservice.druid.model.query.LookbackQuery;
 import com.yahoo.bard.webservice.druid.util.FieldConverterSupplier;
 import com.yahoo.bard.webservice.druid.util.FieldConverters;
@@ -119,11 +120,13 @@ import com.yahoo.bard.webservice.web.apirequest.MetricsApiRequest;
 import com.yahoo.bard.webservice.web.apirequest.SlicesApiRequest;
 import com.yahoo.bard.webservice.web.apirequest.TablesApiRequest;
 import com.yahoo.bard.webservice.web.apirequest.generator.Generator;
+import com.yahoo.bard.webservice.web.apirequest.generator.LegacyGenerator;
 import com.yahoo.bard.webservice.web.apirequest.generator.having.PerRequestDictionaryHavingGenerator;
 import com.yahoo.bard.webservice.web.apirequest.generator.having.DefaultHavingApiGenerator;
 import com.yahoo.bard.webservice.web.apirequest.generator.having.HavingGenerator;
 import com.yahoo.bard.webservice.web.apirequest.generator.metric.ApiRequestLogicalMetricBinder;
 import com.yahoo.bard.webservice.web.apirequest.generator.metric.ProtocolLogicalMetricGenerator;
+import com.yahoo.bard.webservice.web.apirequest.generator.orderBy.DefaultOrderByGenerator;
 import com.yahoo.bard.webservice.web.apirequest.metrics.ApiMetricAnnotater;
 import com.yahoo.bard.webservice.web.handlers.workflow.DruidWorkflow;
 import com.yahoo.bard.webservice.web.handlers.workflow.RequestWorkflowProvider;
@@ -285,9 +288,6 @@ public abstract class AbstractBinderFactory implements BinderFactory {
 
                 bind(buildDataApiRequestFactory()).to(DataApiRequestFactory.class);
 
-                // Protocol Stuff
-                bindMetricGenerator(this);
-
                 //Initialize the field converter
                 FieldConverterSupplier.setSketchConverter(initializeSketchConverter());
 
@@ -302,6 +302,8 @@ public abstract class AbstractBinderFactory implements BinderFactory {
                 loader.load();
                 bindDictionaries(this);
                 bind(buildHavingGenerator(loader)).to(HavingGenerator.class);
+                // Protocol Stuff
+                bindMetricGenerator(this);
 
                 // Bind the request mappers
                 bindRequestMappers(this);
@@ -433,6 +435,12 @@ public abstract class AbstractBinderFactory implements BinderFactory {
         // The binding used for construction based ApiRequest objects
         binder.bind(protocolLogicalMetricGenerator).to(ApiRequestLogicalMetricBinder.class);
 
+        TypeLiteral<LegacyGenerator<List<OrderByColumn>>> orderByGeneratorType =
+                new TypeLiteral<LegacyGenerator<List<OrderByColumn>>>() { };
+
+        binder.bind(DefaultOrderByGenerator.class)
+                .named(DataApiRequest.ORDER_BY_GENERATOR_NAMESPACE)
+                .to(orderByGeneratorType);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/ResourceDictionaries.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/config/ResourceDictionaries.java
@@ -27,6 +27,26 @@ public class ResourceDictionaries {
         dimension = new DimensionDictionary();
     }
 
+    /**
+     * Constructor.
+     *
+     * @param physical  Physical table dictionary
+     * @param logical  Logical table dictionary
+     * @param metric  Metric dictionary
+     * @param dimension  Dimension dictionary
+     */
+    public ResourceDictionaries(
+            final PhysicalTableDictionary physical,
+            final LogicalTableDictionary logical,
+            final MetricDictionary metric,
+            final DimensionDictionary dimension
+    ) {
+        this.physical = physical;
+        this.logical = logical;
+        this.metric = metric;
+        this.dimension = dimension;
+    }
+
     public PhysicalTableDictionary getPhysicalDictionary() {
         return physical;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/orderby/OrderByColumn.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/orderby/OrderByColumn.java
@@ -2,18 +2,27 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.druid.model.orderby;
 
-import com.yahoo.bard.webservice.data.metric.LogicalMetric;
-import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation;
-import com.yahoo.bard.webservice.druid.model.postaggregation.PostAggregation;
+import static com.yahoo.bard.webservice.druid.model.orderby.OrderByColumnType.UNKNOWN;
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_DIRECTION_INVALID;
 
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.druid.model.MetricField;
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.Locale;
 import java.util.Objects;
 
 /**
  * OrderByColumn class.
  */
 public class OrderByColumn {
-    private final String dimension;
+    public static final SortDirection DEFAULT_DIRECTION = SortDirection.DESC;
+
+    private final String column;
     private final SortDirection direction;
+    private final OrderByColumnType type;
 
     /**
      * Constructor.
@@ -21,33 +30,30 @@ public class OrderByColumn {
      * @param metric  a LogicalMetric
      * @param direction  sort direction
      *
-     * Note: Plan is to remove this LogicalMetric based constructor and have a DruidColumn based constructor.
      */
     public OrderByColumn(LogicalMetric metric, SortDirection direction) {
-        this.dimension = metric.getName();
-        this.direction = direction;
+        this(metric.getName(), direction, OrderByColumnType.METRIC);
     }
 
     /**
      * Constructor.
      *
-     * @param aggregation  an Aggregation
+     * @param metricField  an Aggregation or PostAggregation
      * @param direction  sort direction
      */
-    public OrderByColumn(Aggregation aggregation, SortDirection direction) {
-        this.dimension = aggregation.getName();
-        this.direction = direction;
+    public OrderByColumn(MetricField metricField, SortDirection direction) {
+        this(metricField.getName(), direction, OrderByColumnType.METRIC);
     }
 
     /**
-     * Constructor.
+     * Constructor which accepts generic column with direction. For example: dateTime column is not part of aggregation
+     * or postAggregation. But still allowed to sort the resultSet based on dateTime value.
      *
-     * @param postAggregation  a PostAggregation
+     * @param column  a column needs to be associated with the direction
      * @param direction  sort direction
      */
-    public OrderByColumn(PostAggregation postAggregation, SortDirection direction) {
-        this.dimension = postAggregation.getName();
-        this.direction = direction;
+    public OrderByColumn(String column, String direction) {
+        this(column, parseSortDirection(direction), UNKNOWN);
     }
 
     /**
@@ -58,8 +64,22 @@ public class OrderByColumn {
      * @param direction  sort direction
      */
     public OrderByColumn(String column, SortDirection direction) {
-        this.dimension = column;
+        this(column, direction, UNKNOWN);
+    }
+
+
+    /**
+     * Constructor which accepts generic column with direction. For example: dateTime column is not part of aggregation
+     * or postAggregation. But still allowed to sort the resultSet based on dateTime value.
+     *
+     * @param column  a column needs to be associated with the direction
+     * @param direction  sort direction
+     * @param type The type of column being bound for sorting
+     */
+    public OrderByColumn(String column, SortDirection direction, OrderByColumnType type) {
+        this.column = column;
         this.direction = direction;
+        this.type = type;
     }
 
     /**
@@ -68,7 +88,7 @@ public class OrderByColumn {
      * @return dimension A dimension name, a metric name, an aggregation name or a post aggregation name
      */
     public String getDimension() {
-        return this.dimension;
+        return this.column;
     }
 
     /**
@@ -77,7 +97,47 @@ public class OrderByColumn {
      * @return direction
      */
     public SortDirection getDirection() {
-        return  this.direction;
+        return this.direction;
+    }
+
+    /**
+     * Getter for the column type.
+     *
+     * @return the type of this column
+     */
+    @JsonIgnore
+    public OrderByColumnType getType() {
+        return type;
+    }
+
+    /**
+     * Rewrite the OrderByColumn with a new type.
+     *
+     * @param type The new column type
+     *
+     * @return A modified copy with a different type
+     */
+    public OrderByColumn withType(OrderByColumnType type) {
+        return new OrderByColumn(this.getDimension(), this.getDirection(), type);
+    }
+
+    /**
+     * Bind sort direction request to SortDirection instance.
+     *
+     * @param sortDirection  The string representing the sort direction
+     *
+     * @return Sorting direction. If no direction provided then the default one will be DESC
+     */
+    protected static SortDirection parseSortDirection(String sortDirection) {
+        if (sortDirection == null) {
+            return DEFAULT_DIRECTION;
+        }
+
+        try {
+            return SortDirection.valueOf(sortDirection.toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException ignored) {
+            throw new BadApiRequestException(SORT_DIRECTION_INVALID.format(sortDirection));
+        }
     }
 
     @Override
@@ -88,12 +148,12 @@ public class OrderByColumn {
         OrderByColumn that = (OrderByColumn) o;
 
         return
-                Objects.equals(dimension, that.dimension) &&
+                Objects.equals(column, that.column) &&
                 direction == that.direction;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(dimension, direction);
+        return Objects.hash(column, direction);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/orderby/OrderByColumnType.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/orderby/OrderByColumnType.java
@@ -1,0 +1,15 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.druid.model.orderby;
+
+/**
+ * The type of the column name in the order by Column.
+ */
+public enum OrderByColumnType {
+
+    UNKNOWN,
+    TIME,
+    METRIC,
+    // Unsupported in current parsing
+    DIMENSION
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ApiHaving.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ApiHaving.java
@@ -174,7 +174,7 @@ public class ApiHaving {
 
         //Allows us to parse the values in a streamy way without losing information about the first value that
         //fails to parse.
-        Function<String, Double> toNumber = value -> {
+        Function<String, Double> toDouble = value -> {
             try {
                 return Double.parseDouble(value);
             } catch (NumberFormatException ignored) {
@@ -184,7 +184,7 @@ public class ApiHaving {
         };
 
         try {
-            return stringValues.stream().map(toNumber).collect(Collectors.toCollection(LinkedList::new));
+            return stringValues.stream().map(toDouble).collect(Collectors.toCollection(LinkedList::new));
         } catch (NumberFormatException e) {
             LOG.debug(HAVING_NON_NUMERIC.format(e.getMessage()));
             throw new BadHavingException(HAVING_NON_NUMERIC.format(e.getMessage()));

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ErrorMessageFormat.java
@@ -145,6 +145,8 @@ public enum ErrorMessageFormat implements MessageFormatter {
 
     METRIC_INVALID_WITH_DETAIL("Metric expression '%s' is invalid. (%s)"),
 
+    SORT_INVALID_WITH_DETAIL("Sort expression '%s' is invalid. (%s)"),
+
     METRIC_VALUE_PARSING_ERROR("Unable to %s metric value and its type"),
     GRANULARITY_PARSING_ERROR("No granularity can be parsed from this name: %s"),
     UNKNOWN_TIMEZONE_ID("Unable to recognize the timeZoneId: %s"),

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequest.java
@@ -35,7 +35,12 @@ import javax.ws.rs.core.Response;
  * DataApiRequest Request binds, validates, and models the parts of a request to the data endpoint.
  */
 public interface DataApiRequest extends ApiRequest {
+
     String REQUEST_MAPPER_NAMESPACE = "dataApiRequestMapper";
+    String METRIC_GENERATOR_NAMESPACE = "metric_generator";
+    String ORDER_BY_GENERATOR_NAMESPACE = "order_by_generator";
+
+
     String RATIO_METRIC_CATEGORY = "Ratios";
     String DATE_TIME_STRING = "dateTime";
 
@@ -394,8 +399,8 @@ public interface DataApiRequest extends ApiRequest {
     /**
      * Whether or not to attempt to build an optimal backend query (i.e. topN or timeSeries in the case of Druid) if possible.
      *
-     * @return True if the backend query built from this request can be safely optimized (i.e. converted into a topN 
-     * or timeseries query when hitting Druid), false if a naive query should be built (i.e. groupBy in the 
+     * @return True if the backend query built from this request can be safely optimized (i.e. converted into a topN
+     * or timeseries query when hitting Druid), false if a naive query should be built (i.e. groupBy in the
      * case of Druid)
      */
     default boolean optimizeBackendQuery() {

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DefaultDataApiRequestFactory.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DefaultDataApiRequestFactory.java
@@ -2,6 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.apirequest;
 
+import com.yahoo.bard.webservice.web.apirequest.generator.metric.ProtocolLogicalMetricGenerator;
 import com.yahoo.bard.webservice.web.util.BardConfigResources;
 
 import java.util.List;
@@ -73,6 +74,27 @@ public class DefaultDataApiRequestFactory implements DataApiRequestFactory {
             String page,
             BardConfigResources bardConfigResources
     ) {
+        if (bardConfigResources.getMetricBinder() instanceof ProtocolLogicalMetricGenerator) {
+            return new ProtocolMetricDataApiReqestImpl(
+                    tableName,
+                    granularity,
+                    dimensions,
+                    logicalMetrics,
+                    intervals,
+                    apiFilters,
+                    havings,
+                    sorts,
+                    count,
+                    topN,
+                    format,
+                    downloadFilename,
+                    timeZoneId,
+                    asyncAfter,
+                    perPage,
+                    page,
+                    bardConfigResources
+            );
+        }
         return new DataApiRequestImpl(
                 tableName,
                 granularity,

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/exceptions/BadOrderByException.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/exceptions/BadOrderByException.java
@@ -5,14 +5,14 @@ package com.yahoo.bard.webservice.web.apirequest.exceptions;
 /**
  * Bad having exception is an exception encountered when the having object cannot be built.
  */
-public class BadMetricException extends BadApiRequestException {
+public class BadOrderByException extends BadApiRequestException {
 
     /**
      * Constructor.
      *
      * @param message  Message of the exception
      */
-    public BadMetricException(String message) {
+    public BadOrderByException(String message) {
         super(message);
     }
 
@@ -22,7 +22,7 @@ public class BadMetricException extends BadApiRequestException {
      * @param message  Message of the exception
      * @param cause  Cause of the exception
      */
-    public BadMetricException(String message, Throwable cause) {
+    public BadOrderByException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/LegacyGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/LegacyGenerator.java
@@ -1,0 +1,51 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.generator;
+
+import com.yahoo.bard.webservice.application.AbstractBinderFactory;
+import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
+import com.yahoo.bard.webservice.web.apirequest.DataApiRequest;
+
+/**
+ * Contract for building components of a {@link DataApiRequest} with a constructor pattern. Each
+ * generator has a bind and validate step, where the resource is generated and then validated being added to the
+ * in progress api request.
+ *
+ * <p>To modify how a data api request is built, you must implement this interface for the type of resource you want
+ * to generate. In your {@link AbstractBinderFactory} implementation you must make a named binding for the type of
+ * resource you wish to generate. You can only bind one generator per resource (though different resources may share
+ * a type, such as "count" and "topN"), so your implementation will replace the default generator for that resource.
+ *
+ *
+ * @param <T> The type of the resource this generator builds.
+ */
+public interface LegacyGenerator<T> {
+
+    /**
+     * Generates the resource.
+     *
+     * TODO: document standard exceptions this CAN throw (not necessarily caught exceptions)
+     *
+     * @param request  The request object representing the in progress {@link DataApiRequest}. Previously constructed
+     *                 resources are available through this object.
+     * @param parameter  The request parameter sent by the client.
+     * @param dictionaries  Dictionaries useful in building resources
+     *
+     * @return the generated resource
+     */
+    T bind(DataApiRequest request, String parameter, ResourceDictionaries dictionaries);
+
+    /**
+     * Validates the generated resource (which means it runs AFTER the {@code bind} method. This is intended to check
+     * that the client request is formatted correctly. For example, ensuring that the client requested a positive page
+     * number. This method is intended to help reduce parameter checking in the building section.
+     *
+     * TODO: document standard exceptions this CAN throw (not necessarily caught exceptions)
+     *
+     * @param entity  The resource constructed by the {@code bind}} method
+     * @param request  The request object representing the in progress DataApiRequest
+     * @param parameter  The request parameter sent by the client
+     * @param dictionaries  Dictionaries useful in building resources
+     */
+    void validate(T entity, DataApiRequest request, String parameter, ResourceDictionaries dictionaries);
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/having/DefaultHavingApiGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/having/DefaultHavingApiGenerator.java
@@ -7,6 +7,7 @@ import static com.yahoo.bard.webservice.web.ErrorMessageFormat.HAVING_METRICS_NO
 
 import com.yahoo.bard.webservice.data.config.ConfigurationLoader;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.logging.RequestLog;
 import com.yahoo.bard.webservice.logging.TimedPhase;
 import com.yahoo.bard.webservice.web.ApiHaving;
@@ -32,7 +33,7 @@ public class DefaultHavingApiGenerator implements HavingGenerator {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultHavingApiGenerator.class);
     private static final String COMMA_AFTER_BRACKET_PATTERN = "(?<=]),";
 
-    private final Map<String, LogicalMetric> metricDictionary;
+    private final MetricDictionary metricDictionary;
 
     /**
      * Constructor.
@@ -50,7 +51,7 @@ public class DefaultHavingApiGenerator implements HavingGenerator {
      *
      * @param metricDictionary  Dictionary of metrics for generating APIs
      */
-    public DefaultHavingApiGenerator(Map<String, LogicalMetric> metricDictionary) {
+    public DefaultHavingApiGenerator(MetricDictionary metricDictionary) {
         this.metricDictionary = metricDictionary;
     }
 
@@ -116,7 +117,7 @@ public class DefaultHavingApiGenerator implements HavingGenerator {
      *
      * @return  A replacement metric dictionary
      */
-    public HavingGenerator withMetricDictionary(Map<String, LogicalMetric> metricDictionary) {
+    public HavingGenerator withMetricDictionary(MetricDictionary metricDictionary) {
         return new DefaultHavingApiGenerator(metricDictionary);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/having/HavingGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/having/HavingGenerator.java
@@ -3,6 +3,7 @@
 package com.yahoo.bard.webservice.web.apirequest.generator.having;
 
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.web.ApiHaving;
 
 import java.util.Map;
@@ -14,4 +15,12 @@ import java.util.function.BiFunction;
  */
 public interface HavingGenerator extends BiFunction<String, Set<LogicalMetric>, Map<LogicalMetric, Set<ApiHaving>>> {
 
+    /**
+     * Rebuild this having generator with a custom metric dictionary.
+     *
+     * @param metricDictionary  An alternate dictionary.
+     *
+     * @return  A replacement metric dictionary
+     */
+    HavingGenerator withMetricDictionary(MetricDictionary metricDictionary);
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/having/antlr/AntlrHavingGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/having/antlr/AntlrHavingGenerator.java
@@ -5,13 +5,12 @@ package com.yahoo.bard.webservice.web.apirequest.generator.having.antlr;
 
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.HAVING_INVALID_WITH_DETAIL;
 
-import com.yahoo.bard.webservice.data.config.ConfigurationLoader;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.web.ApiHaving;
 import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
 import com.yahoo.bard.webservice.web.apirequest.exceptions.BadHavingException;
-import com.yahoo.bard.webservice.web.apirequest.generator.having.DefaultHavingApiGenerator;
+import com.yahoo.bard.webservice.web.apirequest.generator.having.HavingGenerator;
 import com.yahoo.bard.webservice.web.havingparser.HavingsLex;
 import com.yahoo.bard.webservice.web.havingparser.HavingsParser;
 
@@ -24,18 +23,18 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-public class AntlrHavingGenerator extends DefaultHavingApiGenerator {
+public class AntlrHavingGenerator implements HavingGenerator {
+
     private static final Logger LOG = LoggerFactory.getLogger(AntlrHavingGenerator.class);
     private final MetricDictionary metricDictionary;
 
     /**
      * Constructor.
      *
-     * @param loader  Connects the resource dictionaries with the loaders..
+     * @param metricDictionary  Connects the resource dictionaries with the loaders..
      */
-    public AntlrHavingGenerator(ConfigurationLoader loader) {
-        super(loader);
-        this.metricDictionary = loader.getMetricDictionary();
+    public AntlrHavingGenerator(MetricDictionary metricDictionary) {
+        this.metricDictionary = metricDictionary;
     }
 
     public Map<LogicalMetric, Set<ApiHaving>> apply(
@@ -69,5 +68,10 @@ public class AntlrHavingGenerator extends DefaultHavingApiGenerator {
         } catch (BadHavingException havingException) {
             throw new BadApiRequestException(havingException.getMessage(), havingException);
         }
+    }
+
+    @Override
+    public AntlrHavingGenerator withMetricDictionary(MetricDictionary metricDictionary) {
+        return new AntlrHavingGenerator(metricDictionary);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/metric/ApiRequestLogicalMetricBinder.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/metric/ApiRequestLogicalMetricBinder.java
@@ -7,6 +7,7 @@ import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.table.LogicalTable;
 import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
 import com.yahoo.bard.webservice.data.time.Granularity;
+import com.yahoo.bard.webservice.web.apirequest.generator.LegacyGenerator;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -14,7 +15,7 @@ import java.util.Set;
 /**
  * A legacy interface to support the metric binding contract for the constructor embedded DataApiRequest builders.
  */
-public interface ApiRequestLogicalMetricBinder {
+public interface ApiRequestLogicalMetricBinder extends LegacyGenerator<LinkedHashSet<LogicalMetric>> {
     /**
      * Extracts the list of metrics from the url metric query string and generates a set of LogicalMetrics.
      * <p>

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/metric/DefaultLogicalMetricGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/metric/DefaultLogicalMetricGenerator.java
@@ -6,10 +6,12 @@ import static com.yahoo.bard.webservice.web.ErrorMessageFormat.METRICS_NOT_IN_TA
 import static com.yahoo.bard.webservice.web.apirequest.DataApiRequestBuilder.RequestResource.LOGICAL_METRICS;
 import static com.yahoo.bard.webservice.web.apirequest.DataApiRequestBuilder.RequestResource.LOGICAL_TABLE;
 
+import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
 import com.yahoo.bard.webservice.data.metric.LogicalMetric;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.time.Granularity;
 import com.yahoo.bard.webservice.table.LogicalTable;
+import com.yahoo.bard.webservice.web.apirequest.DataApiRequest;
 import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
 import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestBuilder;
@@ -25,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -82,6 +85,29 @@ public class DefaultLogicalMetricGenerator
         validateMetrics(entity, builder.getLogicalTableIfInitialized().get());
     }
 
+
+    @Override
+    public LinkedHashSet<LogicalMetric> bind(
+            DataApiRequest request,
+            String parameter,
+            ResourceDictionaries dictionaries
+    ) {
+        return generateLogicalMetrics(
+                Optional.ofNullable(parameter).orElse(""),
+                dictionaries.getMetricDictionary()
+        );
+
+    }
+
+    @Override
+    public void validate(
+            LinkedHashSet<LogicalMetric> entity,
+            DataApiRequest request,
+            String parameter,
+            ResourceDictionaries dictionaries
+    ) {
+        validateMetrics(entity, request.getTable());
+    }
     /**
      * Extracts the list of metrics from the url metric query string and generates a set of LogicalMetrics.
      * <p>

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/metric/antlr/ApiMetricsListListener.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/metric/antlr/ApiMetricsListListener.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 
 public class ApiMetricsListListener extends MetricsBaseListener {
-    //private static final Logger LOG = LoggerFactory.getLogger(ApiMetricsListListener.class);
 
     private final Map<String, LogicalMetric> metrics = new HashMap<>();
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/metric/antlr/ProtocolAntlrApiMetricParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/metric/antlr/ProtocolAntlrApiMetricParser.java
@@ -42,7 +42,6 @@ public class ProtocolAntlrApiMetricParser implements ApiMetricParser {
         ApiMetricsListListener listener = new ApiMetricsListListener();
         MetricsLex lexer = MetricGrammarUtils.getLexer(metricQuery);
         MetricsParser parser = MetricGrammarUtils.getParser(lexer);
-        try {
             try {
                 MetricsParser.MetricsContext tree = parser.metrics();
                 ParseTreeWalker.DEFAULT.walk(listener, tree);
@@ -55,8 +54,5 @@ public class ProtocolAntlrApiMetricParser implements ApiMetricParser {
             List<ApiMetric> generated = listener.getResults();
             LOG.trace("Generated list of metric detail: {}", generated);
             return generated;
-        } catch (BadMetricException metricException) {
-            throw new BadApiRequestException(metricException.getMessage(), metricException);
-        }
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/AntlrOrderByGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/AntlrOrderByGenerator.java
@@ -1,0 +1,19 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.generator.orderBy;
+
+import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn;
+import com.yahoo.bard.webservice.web.apirequest.generator.orderBy.antlr.ProtocolAntlrSortParser;
+
+import java.util.List;
+
+/**
+ * OrderByGenerator that uses SortsListener to parse the api request string.
+ */
+public class AntlrOrderByGenerator extends DefaultOrderByGenerator {
+
+    protected List<OrderByColumn> parseOrderByColumns(String sortsRequest) {
+        ProtocolAntlrSortParser parser = new ProtocolAntlrSortParser();
+        return parser.apply(sortsRequest);
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/AntlrOrderByGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/AntlrOrderByGenerator.java
@@ -12,8 +12,9 @@ import java.util.List;
  */
 public class AntlrOrderByGenerator extends DefaultOrderByGenerator {
 
+    private final ProtocolAntlrSortParser parser = new ProtocolAntlrSortParser();
+
     protected List<OrderByColumn> parseOrderByColumns(String sortsRequest) {
-        ProtocolAntlrSortParser parser = new ProtocolAntlrSortParser();
         return parser.apply(sortsRequest);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/DefaultOrderByGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/DefaultOrderByGenerator.java
@@ -1,0 +1,285 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.generator.orderBy;
+
+import static com.yahoo.bard.webservice.druid.model.orderby.OrderByColumnType.DIMENSION;
+import static com.yahoo.bard.webservice.druid.model.orderby.OrderByColumnType.METRIC;
+import static com.yahoo.bard.webservice.druid.model.orderby.OrderByColumnType.TIME;
+import static com.yahoo.bard.webservice.druid.model.orderby.OrderByColumnType.UNKNOWN;
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.DATE_TIME_SORT_VALUE_INVALID;
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_DIRECTION_INVALID;
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_METRICS_NOT_IN_QUERY_FORMAT;
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_METRICS_NOT_SORTABLE_FORMAT;
+import static com.yahoo.bard.webservice.web.apirequest.DataApiRequest.DATE_TIME_STRING;
+
+import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
+import com.yahoo.bard.webservice.data.dimension.Dimension;
+import com.yahoo.bard.webservice.data.metric.LogicalMetric;
+import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn;
+import com.yahoo.bard.webservice.druid.model.orderby.SortDirection;
+import com.yahoo.bard.webservice.logging.RequestLog;
+import com.yahoo.bard.webservice.logging.TimedPhase;
+import com.yahoo.bard.webservice.web.apirequest.DataApiRequest;
+import com.yahoo.bard.webservice.web.apirequest.DataApiRequestBuilder;
+import com.yahoo.bard.webservice.web.apirequest.RequestParameters;
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
+import com.yahoo.bard.webservice.web.apirequest.generator.Generator;
+import com.yahoo.bard.webservice.web.apirequest.generator.LegacyGenerator;
+import com.yahoo.bard.webservice.web.util.BardConfigResources;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Default generator implementation for binding logical metrics. Binding logical metrics is dependent on the logical
+ * table being queried. Ensure the logical table has been bound before using this class to generate logical metrics.
+ */
+public class DefaultOrderByGenerator implements Generator<List<OrderByColumn>>, LegacyGenerator<List<OrderByColumn>> {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultOrderByGenerator.class);
+
+    @Override
+    public List<OrderByColumn> bind(
+            DataApiRequestBuilder builder,
+            RequestParameters params,
+            BardConfigResources resources
+    ) {
+        return generateBoundOrderByColumns(
+                params.getSorts().orElse(null),
+                builder.getLogicalMetricsIfInitialized(),
+                builder.getDimensionsIfInitialized()
+        );
+    }
+
+    @Override
+    public void validate(
+            final List<OrderByColumn> entity,
+            final DataApiRequestBuilder builder,
+            final RequestParameters params,
+            final BardConfigResources resources
+    ) {
+        validate(
+                entity,
+                params.getSorts().orElse(null),
+                builder.getLogicalMetricsIfInitialized(),
+                builder.getDimensionsIfInitialized()
+        );
+    }
+
+    @Override
+    public List<OrderByColumn> bind(DataApiRequest request, String requestString, ResourceDictionaries dictionaries
+    ) {
+        return generateBoundOrderByColumns(
+                requestString,
+                request.getLogicalMetrics(),
+                request.getDimensions()
+        );
+    }
+
+    @Override
+    public void validate(
+            List<OrderByColumn> entity,
+            DataApiRequest builder,
+            String parameter,
+            ResourceDictionaries dictionaries
+    ) {
+        validate(
+                entity,
+                parameter,
+                builder.getLogicalMetrics(),
+                builder.getDimensions()
+        );
+    }
+
+    /**
+     * Validate used by DataApiRequestImpl.
+     *
+     * @param orderByColumns  the columns generated
+     * @param orderByRequest the original request text
+     * @param selectedMetrics metrics selected in the request
+     * @param selectedDimensions grouping dimensions selected in the request.  (not currently validating)
+     */
+    public void validate(
+            List<OrderByColumn> orderByColumns,
+            String orderByRequest,
+            Set<LogicalMetric> selectedMetrics,
+            Set<Dimension> selectedDimensions
+    ) {
+        // If any sort columns don't match a known selected column, fail the query
+        List<String> unknownColumns = orderByColumns.stream()
+                .filter(orderByColumn -> orderByColumn.getType().equals(UNKNOWN))
+                .map(OrderByColumn::getDimension)
+                .collect(Collectors.toList());
+
+        if (!unknownColumns.isEmpty()) {
+            LOG.debug(SORT_METRICS_NOT_IN_QUERY_FORMAT.logFormat(unknownColumns));
+            throw new BadApiRequestException(SORT_METRICS_NOT_IN_QUERY_FORMAT.format(unknownColumns.toString()));
+        }
+
+        // If any metrics being sorted on don't have a query column (an odd edge case, but it happens)
+        // throw an error.
+        Map<String, LogicalMetric> metricsByName = selectedMetrics.stream()
+                .collect(Collectors.toMap(
+                        LogicalMetric::getName,
+                        x -> x
+                ));
+
+        List<String> noSortableColumn = orderByColumns.stream()
+                .filter(orderByColumn -> orderByColumn.getType().equals(METRIC))
+                .map(OrderByColumn::getDimension)
+                .filter(name -> metricsByName.get(name).getTemplateDruidQuery() == null)
+                .collect(Collectors.toList());
+
+        if (!noSortableColumn.isEmpty()) {
+            LOG.debug(SORT_METRICS_NOT_SORTABLE_FORMAT.logFormat(noSortableColumn.toString()));
+            throw new BadApiRequestException(SORT_METRICS_NOT_SORTABLE_FORMAT.format(noSortableColumn));
+        }
+
+        // The system doesn't support sorting by datetime inside druid so all datetime sorting is done in
+        // fili.  We currently only support sorting on datetime in fili, so it must be the first sorting criteria
+        // or not at all.
+        if (orderByColumns != null && orderByColumns.size() > 1) {
+            if (orderByColumns.stream()
+                    .skip(1)
+                    .anyMatch(column -> column.getType().equals(TIME))) {
+                LOG.debug(DATE_TIME_SORT_VALUE_INVALID.logFormat());
+                throw new BadApiRequestException(DATE_TIME_SORT_VALUE_INVALID.format());
+            }
+        }
+
+    }
+
+    /**
+     * Generates a Set of OrderByColumn associated with selected columns.
+     *
+     * These columns should be associated with one or more selected columns in the fact request.
+     *
+     * @param orderByRequest  api request string for the sort clause
+     * @param selectedMetrics  Set of LogicalMetrics selected in the api request
+     * @param selectedDimensions  Set of grouping dimensions selected in the api request
+     *
+     * @return a List of OrderByColumn whose names are physical column names or "dateTime"
+     *
+     * @throws BadApiRequestException if the sort clause is invalid due to unresolvable logical column names.
+     */
+    public List<OrderByColumn> generateBoundOrderByColumns(
+            String orderByRequest,
+            Set<LogicalMetric> selectedMetrics,
+            Set<Dimension> selectedDimensions
+    ) throws BadApiRequestException {
+        try (TimedPhase timer = RequestLog.startTiming("GeneratingSortColumns")) {
+
+
+            // These requested order by columns are not bound to configuration entities
+            List<OrderByColumn> rawColumns = parseOrderByColumns(orderByRequest);
+
+
+            List<OrderByColumn> typeBoundColumns = new ArrayList<>();
+
+            Map<String, LogicalMetric> metricsByName = selectedMetrics.stream()
+                    .collect(Collectors.toMap(
+                            LogicalMetric::getName,
+                            x -> x
+                    ));
+
+            Map<String, Dimension> dimensionsByName = selectedDimensions.stream()
+                    .collect(Collectors.toMap(
+                            Dimension::getApiName,
+                            x -> x
+                    ));
+
+            // Associate each column with a type determined using the column name
+            for (OrderByColumn column : rawColumns) {
+                OrderByColumn result = bindOrderByColumn(metricsByName, dimensionsByName, column);
+                typeBoundColumns.add(result);
+            }
+            return typeBoundColumns;
+        }
+    }
+
+    /**
+     * Method to convert sort list to column and direction map.
+     *
+     * This results in unbound order by requests with no specified type.
+     *
+     * @param sortsRequest  String of sort columns
+     *
+     * @return LinkedHashMap of columns and their direction. Using LinkedHashMap to preserve the order
+     */
+    protected List<OrderByColumn> parseOrderByColumns(String sortsRequest) {
+        if (sortsRequest == null || sortsRequest.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<OrderByColumn> result = Arrays.stream(sortsRequest.split(","))
+                .map(e -> Arrays.asList(e.split("\\|")))
+                .map(e -> new OrderByColumn(e.get(0), parseSortDirection(e)))
+                .collect(Collectors.toList());
+        return result;
+    }
+
+    /**
+     * Extract valid sort direction.
+     *
+     * @param columnWithDirection  Column and its sorting direction
+     *
+     * @return Sorting direction. If no direction provided then the default one will be DESC
+     */
+    protected SortDirection parseSortDirection(List<String> columnWithDirection) {
+        if (columnWithDirection.size() < 2) {
+            return SortDirection.DESC;
+        }
+        String normalized = columnWithDirection.get(1).toUpperCase(Locale.ENGLISH);
+        Optional<SortDirection> direction = Arrays.<SortDirection>stream(SortDirection.values())
+                .filter(s -> normalized.startsWith(s.name()))
+                .findFirst();
+
+        if (direction.isPresent()) {
+            return direction.get();
+        }
+
+        String sortDirectionName = columnWithDirection.get(1);
+        LOG.debug(SORT_DIRECTION_INVALID.logFormat(sortDirectionName));
+        throw new BadApiRequestException(SORT_DIRECTION_INVALID.format(sortDirectionName));
+    }
+
+    /**
+     * Bind a request order by column to a selected request column.
+     *
+     * @param metricsByName Metrics by column name
+     * @param dimensionsByName  Dimensions by apiName
+     * @param column The unbound parsed column.
+     *
+     * @return A column bound to Time, Metric, Dimension or Unknown if no columns match
+     */
+    protected OrderByColumn bindOrderByColumn(
+            Map<String, LogicalMetric> metricsByName,
+            Map<String, Dimension> dimensionsByName,
+            OrderByColumn column
+    ) {
+        OrderByColumn result;
+        if (column.getDimension().equals(DATE_TIME_STRING)) {
+            result = column.withType(TIME);
+        } else if (metricsByName.containsKey(column.getDimension())) {
+            result = column.withType(METRIC);
+        } else if (dimensionsByName.containsKey(column.getDimension())) {
+
+            Dimension d = dimensionsByName.get(column.getDimension());
+            String physicalName = d.getKey().getName();
+            result = new OrderByColumn(physicalName, column.getDirection(), DIMENSION);
+        } else {
+            result = column;
+            // This is probably an error, but we'll let validate sort it out
+        }
+        return result;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/OrderByColumnParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/OrderByColumnParser.java
@@ -1,0 +1,14 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.generator.orderBy;
+
+import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn;
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadOrderByException;
+
+import java.util.List;
+
+public interface OrderByColumnParser {
+    List<OrderByColumn> apply(
+            String orderByQuery
+    ) throws BadOrderByException;
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/antlr/ProtocolAntlrSortParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/antlr/ProtocolAntlrSortParser.java
@@ -1,0 +1,68 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.generator.orderBy.antlr;
+
+
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_INVALID_WITH_DETAIL;
+
+import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn;
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadOrderByException;
+import com.yahoo.bard.webservice.web.sorts.SortsLex;
+import com.yahoo.bard.webservice.web.sorts.SortsParser;
+
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parser that reads a string and uses ANTLR to extract logical representatons of sort columns.
+ */
+public class ProtocolAntlrSortParser {
+    private static final Logger LOG = LoggerFactory.getLogger(ProtocolAntlrSortParser.class);
+
+    /**
+     * Constructor.
+     */
+    public ProtocolAntlrSortParser() {
+    }
+
+
+    /**
+     * Transform a text string into a protocol metric compliant order by column.
+     *
+     * @param orderByQuery  The request parameter
+     *
+     * @return A list of order by columns (not bound to type yet)
+     *
+     * @throws BadApiRequestException if the string cannot be parsed.
+     */
+    public List<OrderByColumn> apply(
+            String orderByQuery
+    ) throws BadApiRequestException {
+        LOG.trace("Sorts query: {}", orderByQuery);
+
+        if (orderByQuery == null || "".equals(orderByQuery)) {
+            return Collections.emptyList();
+        }
+
+        SortsListListener listener = new SortsListListener();
+        SortsLex lexer = SortsGrammarUtils.getLexer(orderByQuery);
+        SortsParser parser = SortsGrammarUtils.getParser(lexer);
+        try {
+            SortsParser.SortsContext tree = parser.sorts();
+            ParseTreeWalker.DEFAULT.walk(listener, tree);
+        } catch (ParseCancellationException parseException) {
+            LOG.debug(SORT_INVALID_WITH_DETAIL.logFormat(orderByQuery, parseException.getMessage()));
+            throw new BadOrderByException(
+                    SORT_INVALID_WITH_DETAIL.format(orderByQuery, parseException.getMessage()),
+                    parseException.getCause()
+            );
+        }
+        return listener.getResults();
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/antlr/ProtocolAntlrSortParser.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/antlr/ProtocolAntlrSortParser.java
@@ -23,14 +23,8 @@ import java.util.List;
  * Parser that reads a string and uses ANTLR to extract logical representatons of sort columns.
  */
 public class ProtocolAntlrSortParser {
+
     private static final Logger LOG = LoggerFactory.getLogger(ProtocolAntlrSortParser.class);
-
-    /**
-     * Constructor.
-     */
-    public ProtocolAntlrSortParser() {
-    }
-
 
     /**
      * Transform a text string into a protocol metric compliant order by column.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/antlr/SortsGrammarUtils.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/antlr/SortsGrammarUtils.java
@@ -1,0 +1,28 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.generator.orderBy.antlr;
+
+import com.yahoo.bard.webservice.web.apirequest.generator.having.ExceptionErrorListener;
+import com.yahoo.bard.webservice.web.sorts.SortsLex;
+import com.yahoo.bard.webservice.web.sorts.SortsParser;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+
+public class SortsGrammarUtils {
+
+    public static SortsLex getLexer(String sortQuery) {
+        ANTLRInputStream input = new ANTLRInputStream(sortQuery);
+        SortsLex lexer = new SortsLex(input);
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(ExceptionErrorListener.INSTANCE);
+        return lexer;
+    }
+    public static SortsParser getParser(SortsLex lexer) {
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        SortsParser parser = new SortsParser(tokens);
+        parser.removeErrorListeners();
+        parser.addErrorListener(ExceptionErrorListener.INSTANCE);
+        return parser;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/antlr/SortsListListener.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/antlr/SortsListListener.java
@@ -1,0 +1,35 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.generator.orderBy.antlr;
+
+import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn;
+import com.yahoo.bard.webservice.web.sorts.SortsBaseListener;
+import com.yahoo.bard.webservice.web.sorts.SortsParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SortsListListener extends SortsBaseListener {
+
+    private List<OrderByColumn> results = new ArrayList<>();
+
+    private Exception error = null;
+
+    /**
+     *  Constructor.
+     */
+    public SortsListListener() {
+    }
+
+    @Override
+    public void exitSortsComponent(final SortsParser.SortsComponentContext ctx) {
+        String columnName = ctx.metric().getText();
+        String orderValue = ctx.orderingValue().getText();
+        OrderByColumn sort = new OrderByColumn(columnName, orderValue);
+        results.add(sort);
+    }
+
+    public List<OrderByColumn> getResults() {
+        return results;
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
@@ -26,6 +26,7 @@ import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery;
 import com.yahoo.bard.webservice.data.metric.TemplateDruidQueryMerger;
 import com.yahoo.bard.webservice.data.time.GranularityParser;
 import com.yahoo.bard.webservice.druid.model.builders.DruidFilterBuilder;
+import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn;
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 import com.yahoo.bard.webservice.druid.model.query.DruidQuery;
 import com.yahoo.bard.webservice.exception.DataExceptionHandler;
@@ -42,6 +43,7 @@ import com.yahoo.bard.webservice.web.ResponseFormatResolver;
 import com.yahoo.bard.webservice.web.apirequest.ApiRequest;
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequest;
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestFactory;
+import com.yahoo.bard.webservice.web.apirequest.generator.LegacyGenerator;
 import com.yahoo.bard.webservice.web.apirequest.generator.having.HavingGenerator;
 import com.yahoo.bard.webservice.web.apirequest.generator.metric.ApiRequestLogicalMetricBinder;
 import com.yahoo.bard.webservice.web.handlers.DataRequestHandler;
@@ -118,6 +120,7 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
     private final DateTimeFormatter dateTimeFormatter;
 
     private final ApiRequestLogicalMetricBinder metricBinder;
+    private final LegacyGenerator<List<OrderByColumn>> orderByGenerator;
 
     private final GranularityParser granularityParser;
 
@@ -140,7 +143,6 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
 
     /**
      * Constructor.
-     *
      * @param resourceDictionaries  Dictionary holder
      * @param druidQueryBuilder  A builder for converting API Requests into Druid Queries
      * @param templateDruidQueryMerger  A helper to merge TemplateDruidQueries together
@@ -156,14 +158,15 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
      * @param asynchronousWorkflowsBuilder  The factory for building the asynchronous workflow
      * @param preResponseStoredNotifications  The broadcast channel responsible for notifying other Bard processes
      * @param httpResponseMaker  The factory for building HTTP responses
-     * that a query has been completed and its results stored in the
+* that a query has been completed and its results stored in the
      * @param formatResolver  The formatResolver for determining correct response format
      * @param dataApiRequestFactory A factory to build dataApiRequests
-     * {@link com.yahoo.bard.webservice.async.preresponses.stores.PreResponseStore}
+* {@link com.yahoo.bard.webservice.async.preresponses.stores.PreResponseStore}
      * @param responseProcessorFactory  Builds the object that performs post processing on a Druid response
      * @param exceptionHandler  Injects custom logic for handling exceptions thrown during request processing
      * @param dateTimeFormatter  date time formatter
      * @param metricBinder  A binder to build logical metrics
+     * @param orderByGenerator  A factory to bind and validate sort clauses
      */
     @Inject
     public DataServlet(
@@ -187,7 +190,8 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
             ResponseProcessorFactory responseProcessorFactory,
             DataExceptionHandler exceptionHandler,
             DateTimeFormatter dateTimeFormatter,
-            ApiRequestLogicalMetricBinder metricBinder
+            ApiRequestLogicalMetricBinder metricBinder,
+            @Named(DataApiRequest.ORDER_BY_GENERATOR_NAMESPACE) LegacyGenerator<List<OrderByColumn>> orderByGenerator
     ) {
         this.resourceDictionaries = resourceDictionaries;
         this.druidQueryBuilder = druidQueryBuilder;
@@ -211,6 +215,7 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
         this.exceptionHandler = exceptionHandler;
         this.dateTimeFormatter = dateTimeFormatter;
         this.metricBinder = metricBinder;
+        this.orderByGenerator = orderByGenerator;
 
         LOG.trace(
                 "Initialized with ResourceDictionaries: {} \n\n" +

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/BardConfigResources.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/util/BardConfigResources.java
@@ -7,14 +7,19 @@ import com.yahoo.bard.webservice.data.dimension.DimensionDictionary;
 import com.yahoo.bard.webservice.data.metric.MetricDictionary;
 import com.yahoo.bard.webservice.data.time.GranularityParser;
 import com.yahoo.bard.webservice.druid.model.builders.DruidFilterBuilder;
+import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn;
 import com.yahoo.bard.webservice.table.LogicalTableDictionary;
 import com.yahoo.bard.webservice.util.DateTimeFormatterFactory;
+import com.yahoo.bard.webservice.web.apirequest.generator.LegacyGenerator;
 import com.yahoo.bard.webservice.web.apirequest.generator.having.HavingGenerator;
 import com.yahoo.bard.webservice.web.apirequest.generator.metric.ApiRequestLogicalMetricBinder;
 import com.yahoo.bard.webservice.web.apirequest.generator.metric.DefaultLogicalMetricGenerator;
+import com.yahoo.bard.webservice.web.apirequest.generator.orderBy.DefaultOrderByGenerator;
 
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
+
+import java.util.List;
 
 /**
  * Configuration used in the java servlet interface.
@@ -100,5 +105,14 @@ public interface BardConfigResources {
      */
     default ApiRequestLogicalMetricBinder getMetricBinder() {
         return new DefaultLogicalMetricGenerator();
+    }
+
+    /**
+     * The factory to parse and bind order by expressions.
+     *
+     * @return a function to conform apiMetrics according to business requirements.
+     */
+    default LegacyGenerator<List<OrderByColumn>> getOrderByGenerator() {
+        return new DefaultOrderByGenerator();
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/DruidQueryBuilderSpec.groovy
@@ -110,7 +110,7 @@ class DruidQueryBuilderSpec extends Specification {
         } ) as Map<String, ApiFilter>
 
         LogicalMetric metric = new LogicalMetricImpl(tdq, null, (LogicalMetricInfo) lmi1)
-        LinkedHashSet<OrderByColumn> orderByColumns = [new OrderByColumn(metric, SortDirection.DESC)]
+        LinkedHashSet<OrderByColumn> orderByColumns = [new OrderByColumn(lmi1.name, SortDirection.DESC)]
         limitSpec = new LimitSpec(orderByColumns)
         topNMetric = new TopNMetric("m1", SortDirection.DESC)
     }
@@ -357,10 +357,7 @@ class DruidQueryBuilderSpec extends Specification {
         apiRequest = Mock(DataApiRequest)
 
         apiRequest.getTopN() >> Optional.of(5)
-        apiRequest.getSorts() >> ([new OrderByColumn(
-                new LogicalMetricImpl(null, null, lmi1),
-                SortDirection.DESC
-        )] as Set)
+        apiRequest.getSorts() >> ([new OrderByColumn(lmi1.name, SortDirection.DESC)] as Set)
         apiRequest.havings >> havingMap
         apiRequest.optimizeBackendQuery() >> canOptimize
 
@@ -386,10 +383,7 @@ class DruidQueryBuilderSpec extends Specification {
         apiRequest = Mock(DataApiRequest)
         apiRequest.dimensions >> ([resources.d1, resources.d2] as Set)
         apiRequest.topN >> Optional.of(5)
-        apiRequest.sorts >> ([new OrderByColumn(
-                new LogicalMetricImpl(null, null, (LogicalMetricInfo) lmi1),
-                SortDirection.DESC
-        )] as Set)
+        apiRequest.sorts >> ([new OrderByColumn(lmi1.name, SortDirection.DESC)] as Set)
 
         initDefault(apiRequest)
 
@@ -405,22 +399,8 @@ class DruidQueryBuilderSpec extends Specification {
         apiRequest = Mock(DataApiRequest)
         apiRequest.topN >> Optional.of(5)
         apiRequest.sorts >> ([
-                new OrderByColumn(
-                        new LogicalMetricImpl(
-                                (TemplateDruidQuery) null,
-                                (ResultSetMapper) null,
-                                (LogicalMetricInfo) lmi1
-                        ),
-                        SortDirection.DESC
-                ),
-                new OrderByColumn(
-                        new LogicalMetricImpl(
-                                (TemplateDruidQuery) null,
-                                (ResultSetMapper) null,
-                                (LogicalMetricInfo) lmi2
-                        ),
-                        SortDirection.ASC
-                )
+                new OrderByColumn(lmi1.name, SortDirection.DESC),
+                new OrderByColumn(lmi2.name, SortDirection.ASC)
         ] as Set)
 
         initDefault(apiRequest)
@@ -438,8 +418,8 @@ class DruidQueryBuilderSpec extends Specification {
         apiRequest.dimensions >> ([resources.d1, resources.d2] as Set)
         apiRequest.topN >> Optional.of(5)
         apiRequest.sorts >> ([
-                new OrderByColumn(new LogicalMetricImpl(tdq, null, lmi1), SortDirection.ASC),
-                new OrderByColumn(new LogicalMetricImpl(tdq, null, lmi2), SortDirection.DESC)
+                new OrderByColumn(lmi1.name, SortDirection.ASC),
+                new OrderByColumn(lmi2.name, SortDirection.DESC)
         ] as Set)
 
         initDefault(apiRequest)
@@ -488,10 +468,10 @@ class DruidQueryBuilderSpec extends Specification {
         apiRequest.sorts >> {
             nSorts > 1 ?
                     [
-                            new OrderByColumn(new LogicalMetricImpl(tdq, null, lmi1), SortDirection.DESC),
-                            new OrderByColumn(new LogicalMetricImpl(tdq, null, lmi2), SortDirection.ASC)
+                            new OrderByColumn(lmi1.name, SortDirection.DESC),
+                            new OrderByColumn(lmi2.name, SortDirection.ASC)
                     ] as Set :
-                    [new OrderByColumn(new LogicalMetricImpl(null, null, "m1"), SortDirection.DESC)] as Set
+                    [new OrderByColumn("m1", SortDirection.DESC)] as Set
         }
         apiRequest.havings >> havingMap
         apiRequest.queryHaving >> { DefaultDruidHavingBuilder.INSTANCE.buildHavings(havingMap) }
@@ -534,7 +514,7 @@ class DruidQueryBuilderSpec extends Specification {
 
         apiRequest.sorts >> {
             nSorts > 0 ?
-                    [new OrderByColumn(new LogicalMetricImpl(null, null, "m1"), SortDirection.DESC)] as Set :
+                    [new OrderByColumn("m1", SortDirection.DESC)] as Set :
                     [] as Set
         }
         apiRequest.havings >> havingMap

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuerySpec.groovy
@@ -36,6 +36,7 @@ import com.yahoo.bard.webservice.web.apirequest.DataApiRequest
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
 import com.yahoo.bard.webservice.web.apirequest.generator.having.DefaultHavingApiGenerator
 import com.yahoo.bard.webservice.web.apirequest.generator.metric.DefaultLogicalMetricGenerator
+import com.yahoo.bard.webservice.web.apirequest.generator.orderBy.DefaultOrderByGenerator
 import com.yahoo.bard.webservice.web.endpoints.DataServlet
 
 import org.joda.time.Interval
@@ -86,6 +87,7 @@ class WeightEvaluationQuerySpec extends Specification {
         dataServlet.getHavingApiGenerator() >> new DefaultHavingApiGenerator(configurationLoader)
         dataServlet.getGranularityParser() >> new StandardGranularityParser()
         dataServlet.getMetricBinder() >> new DefaultLogicalMetricGenerator()
+        dataServlet.getOrderByGenerator() >> new DefaultOrderByGenerator()
 
         builder = new DruidQueryBuilder(
                 jtb.configurationLoader.logicalTableDictionary,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestSortSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/DataApiRequestSortSpec.groovy
@@ -26,91 +26,25 @@ class DataApiRequestSortSpec extends Specification {
         jtb.tearDown()
     }
 
-    def "If dateTime is not the first value in the sort list, then throw an error"() {
-        setup:
-        String expectedMessage = ErrorMessageFormat.DATE_TIME_SORT_VALUE_INVALID.format()
-
-        when:
-        new TestingDataApiRequestImpl().bindDateTimeSortColumn(
-                ["xyz":SortDirection.DESC, "dateTime":SortDirection.DESC]
-        )
-
-        then:
-        Exception e = thrown(BadApiRequestException)
-        e.getMessage() == expectedMessage
-    }
-
-    @Unroll
-    def "Validate the sort column and direction map from #sortString string"() {
-        expect:
-        new TestingDataApiRequestImpl().bindToColumnDirectionMap(sortString) == expected
-
-        where:
-        sortString                        | expected
-        "dateTime"                        | ["dateTime":SortDirection.DESC] as Map
-        "dateTime|ASC"                    | ["dateTime":SortDirection.ASC] as Map
-        "dateTimexyz|DESC"                | ["dateTimexyz":SortDirection.DESC] as Map
-        "xyz,dateTime,abc"                | ["xyz":SortDirection.DESC,"dateTime":SortDirection.DESC, "abc":SortDirection.DESC] as Map
-        "xyz,dateTime|DESC,abc"           | ["xyz":SortDirection.DESC,"dateTime":SortDirection.DESC, "abc":SortDirection.DESC] as Map
-        "xyz|DESC,dateTime|DESC,abc|ASC"  | ["xyz":SortDirection.DESC,"dateTime":SortDirection.DESC, "abc":SortDirection.ASC] as Map
-        "xyz|DESC,dateTime,abc|DESC"      | ["xyz":SortDirection.DESC,"dateTime":SortDirection.DESC, "abc":SortDirection.DESC] as Map
-        "xyz|DESC,dateTime"               | ["xyz":SortDirection.DESC,"dateTime":SortDirection.DESC] as Map
-        ""                                | null
-        "dinga"                           | ["dinga":SortDirection.DESC] as Map
-
-    }
-
-    @Unroll
-    def "Generate dateTime sort column from columnDirection map #columnDirection"() {
-        expect:
-        new TestingDataApiRequestImpl().bindDateTimeSortColumn(columnDirection) == expected
-
-        where:
-        columnDirection                                                                          | expected
-        ["dateTime":SortDirection.DESC] as Map                                                   | Optional.of(new OrderByColumn("dateTime", SortDirection.DESC))
-        ["dateTime":SortDirection.ASC] as Map                                                    | Optional.of(new OrderByColumn("dateTime", SortDirection.ASC))
-        ["dateTimexyz":SortDirection.DESC] as Map                                                | Optional.empty()
-        ["dateTime":SortDirection.DESC, "abc":SortDirection.DESC] as Map                         | Optional.of(new OrderByColumn("dateTime", SortDirection.DESC))
-        null                                                                                     | Optional.empty()
-        ["dinga":SortDirection.DESC] as Map                                                      | Optional.empty()
-    }
-
-    @Unroll
-    def "Remove dateTime sort column from columnDirection map #columnDirection"() {
-        expect:
-        new TestingDataApiRequestImpl().removeDateTimeSortColumn(columnDirection) == expected
-
-        where:
-        columnDirection                                                                          | expected
-        ["dateTime":SortDirection.DESC] as Map                                                   | [:]
-        ["dateTime":SortDirection.ASC] as Map                                                    | [:]
-        ["dateTimexyz":SortDirection.DESC] as Map                                                | ["dateTimexyz":SortDirection.DESC] as Map
-        ["xyz":SortDirection.DESC,"dateTime":SortDirection.DESC, "abc":SortDirection.DESC] as Map| ["xyz":SortDirection.DESC,"abc":SortDirection.DESC] as Map
-        null                                                                                     | null
-        ["dinga":SortDirection.DESC] as Map                                                      | ["dinga":SortDirection.DESC] as Map
-    }
-
-    @Unroll
-    def "Check dateTime column is first in the sort column map #columnDirection "() {
-        expect:
-        new TestingDataApiRequestImpl().isDateTimeFirstSortField(columnDirection) == expected
-
-        where:
-        columnDirection                                                                          | expected
-        ["dateTime":SortDirection.DESC] as Map                                                   | true
-        ["dateTime":SortDirection.ASC] as Map                                                    | true
-        ["dateTimexyz":SortDirection.DESC] as Map                                                | false
-        ["xyz":SortDirection.DESC,"dateTime":SortDirection.DESC, "abc":SortDirection.DESC] as Map| false
-        null                                                                                     | false
-        ["dinga":SortDirection.DESC] as Map                                                      | false
-    }
-
     def "Successful execution if dateTime is first field in the sort list"() {
         when:
         javax.ws.rs.core.Response r = jtb.getHarness().target("data/shapes/day/")
                 .queryParam("metrics","height")
                 .queryParam("dateTime","2014-09-01%2F2014-09-10")
                 .queryParam("sort","dateTime|DESC,height|ASC")
+                .request().get()
+
+        then:
+        r.getStatus() == 200
+    }
+
+
+    def "Successful execution if no dateTime in the sort list"() {
+        when:
+        javax.ws.rs.core.Response r = jtb.getHarness().target("data/shapes/day/")
+                .queryParam("metrics","height")
+                .queryParam("dateTime","2014-09-01%2F2014-09-10")
+                .queryParam("sort","height|ASC")
                 .request().get()
 
         then:
@@ -127,5 +61,19 @@ class DataApiRequestSortSpec extends Specification {
 
         then:
         r.getStatus() == 200
+    }
+
+    def "Error if dateTime is not the first sort field in the sort list"() {
+        when:
+        String expectedMessage = ErrorMessageFormat.DATE_TIME_SORT_VALUE_INVALID.format()
+        javax.ws.rs.core.Response r = jtb.getHarness().target("data/shapes/day/")
+                .queryParam("metrics","height")
+                .queryParam("dateTime","2014-09-01%2F2014-09-10")
+                .queryParam("sort","height|ASC,dateTime|DESC")
+                .request().get()
+
+        then:
+        (String) r.readEntity(String.class).contains(expectedMessage)
+        r.getStatus() == 400
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/generator/metric/antlr/ProtocolAntlrApiMetricParserSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/generator/metric/antlr/ProtocolAntlrApiMetricParserSpec.groovy
@@ -16,6 +16,7 @@ class ProtocolAntlrApiMetricParserSpec extends Specification {
     def "Parser produces correct value for single metric"() {
         expect:
         generator.apply(text) == [new ApiMetric(text.replace(" ", ""), metric, params)]
+
         where:
         text                         | metric  | params
         "two ( )"                    | "two"   | [:]

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/DefaultOrderByGeneratorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/generator/orderBy/DefaultOrderByGeneratorSpec.groovy
@@ -1,0 +1,225 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.generator.orderBy
+
+import static com.yahoo.bard.webservice.druid.model.orderby.OrderByColumnType.DIMENSION
+import static com.yahoo.bard.webservice.druid.model.orderby.OrderByColumnType.METRIC
+import static com.yahoo.bard.webservice.druid.model.orderby.OrderByColumnType.TIME
+import static com.yahoo.bard.webservice.druid.model.orderby.SortDirection.ASC
+import static com.yahoo.bard.webservice.druid.model.orderby.SortDirection.DESC
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.DATE_TIME_SORT_VALUE_INVALID
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_METRICS_NOT_IN_QUERY_FORMAT
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.SORT_METRICS_NOT_SORTABLE_FORMAT
+
+import com.yahoo.bard.webservice.data.dimension.Dimension
+import com.yahoo.bard.webservice.data.dimension.DimensionField
+import com.yahoo.bard.webservice.data.metric.LogicalMetric
+import com.yahoo.bard.webservice.data.metric.LogicalMetricImpl
+import com.yahoo.bard.webservice.data.metric.TemplateDruidQuery
+import com.yahoo.bard.webservice.druid.model.aggregation.Aggregation
+import com.yahoo.bard.webservice.druid.model.aggregation.LongSumAggregation
+import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn
+import com.yahoo.bard.webservice.web.apirequest.DataApiRequestBuilder
+import com.yahoo.bard.webservice.web.apirequest.RequestParameters
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException
+import com.yahoo.bard.webservice.web.util.BardConfigResources
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultOrderByGeneratorSpec extends Specification {
+
+    TemplateDruidQuery templateDruidQuery = Mock(TemplateDruidQuery)
+    Aggregation xyzAggregation = new LongSumAggregation("xyz", "foo")
+    LogicalMetric logicalMetric = new LogicalMetricImpl(templateDruidQuery, null, "xyz")
+    LogicalMetric noTDQLogicalMetric = new LogicalMetricImpl(null, null, "noTDQ")
+
+    Dimension sampleDimension = Mock(Dimension)
+    LinkedHashSet<Dimension> selectedDimensions = [sampleDimension] as LinkedHashSet
+
+    def setup() {
+        templateDruidQuery.getMetricField(_) >> xyzAggregation
+        // Create the test web container to test the resources
+        DimensionField dimensionField = Mock(DimensionField)
+        sampleDimension.getKey() >> dimensionField
+        dimensionField.getName() >> "fieldName"
+        sampleDimension.getApiName() >> "dim1"
+    }
+
+    def cleanup() {
+    }
+
+    DefaultOrderByGenerator generator = new DefaultOrderByGenerator()
+
+    @Unroll
+    def "Bind parses the metric string #sortString correctly"() {
+        setup:
+        List<String> metricFields = ["xyz", "abc", "dateTimexyz", "dinga"]
+        Set<LogicalMetric> logicalMetrics = metricFields.collect() {
+            Aggregation a = new LongSumAggregation(it, it + "_field")
+            TemplateDruidQuery tdq = new TemplateDruidQuery([a], [])
+            new LogicalMetricImpl(tdq, null, (String) it)
+        } as Set<LogicalMetric>
+
+
+        DataApiRequestBuilder dataApiRequestBuilder = Mock(DataApiRequestBuilder)
+        RequestParameters requestParameters = Mock(RequestParameters)
+        BardConfigResources configResources = Mock(BardConfigResources)
+        requestParameters.getSorts() >> Optional.of(sortString)
+
+        dataApiRequestBuilder.getLogicalMetricsIfInitialized() >> logicalMetrics
+        dataApiRequestBuilder.getDimensionsIfInitialized() >> selectedDimensions
+
+        List<OrderByColumn> orderByColumnList = generator.bind(dataApiRequestBuilder, requestParameters, configResources)
+
+        expect:
+        expected.eachWithIndex{ def entry, int i ->
+            OrderByColumn column = orderByColumnList.get(i)
+            assert entry.getAt(0) == column.getDimension()
+            assert entry.getAt(1) == column.getDirection()
+            assert entry.getAt(2) == column.getType()
+        } || ( (List) expected).isEmpty()
+
+        where:
+        sortString                       | expected
+        // empty set
+        ""                               | []
+        //date time every direction
+        "dateTime"                       | [["dateTime", DESC, TIME]]
+        "dateTime|ASC"                   | [["dateTime", ASC, TIME]]
+        "dateTime|DESC"                  | [["dateTime", DESC, TIME]]
+
+        // simple metric
+        "xyz"                            | [["xyz", DESC, METRIC]]
+        "xyz|ascending"                  | [["xyz", ASC, METRIC]]
+        "xyz|descen"                     | [["xyz", DESC, METRIC]]
+        // simple dimension maps to keyfield in binding phase
+        "dim1"                           | [["fieldName", DESC, DIMENSION]]
+
+        // dateTime not being used as a string match
+        "dateTimexyz|DESC"               | [["dateTimexyz", DESC, METRIC]]
+
+        // Three metrics, internal date time not resulting in an error here
+        "xyz,dateTime,abc"               | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME], ["abc", DESC, METRIC]]
+        // interior directions parse
+        "xyz,dateTime|DESC,abc"          | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME], ["abc", DESC, METRIC]]
+        "xyz|desc,dateTime|DESC,abc|ASC" | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME], ["abc", ASC, METRIC]]
+        "xyz|DESC,dateTime,abc|DESC"     | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME], ["abc", DESC, METRIC]]
+        "xyz|DESC,dateTime"              | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME]]
+    }
+
+    @Unroll
+    def "Validation fails for #rule"() {
+        LinkedHashSet metrics = [logicalMetric, noTDQLogicalMetric]
+
+        List<OrderByColumn> orderByColumnList = generator.generateBoundOrderByColumns(sortString, metrics, selectedDimensions)
+
+        DataApiRequestBuilder dataApiRequestBuilder = Mock(DataApiRequestBuilder)
+
+        RequestParameters requestParameters = Mock(RequestParameters)
+        BardConfigResources configResources = Mock(BardConfigResources)
+        requestParameters.getSorts() >> Optional.of(sortString)
+        dataApiRequestBuilder.getLogicalMetricsIfInitialized() >> metrics
+
+        when:
+        generator.validate(orderByColumnList, dataApiRequestBuilder, requestParameters, configResources)
+
+        then:
+        Exception e = thrown(BadApiRequestException)
+        e.getMessage() == errorMessage
+
+        where:
+        sortString               | errorMessage                                       | rule
+        "xyz|desc,dateTime|desc" | DATE_TIME_SORT_VALUE_INVALID.format()              | "Date time follows other fields"
+        "xyz|desc,unknown"       | SORT_METRICS_NOT_IN_QUERY_FORMAT.format(["unknown"]) | "No selected metric"
+        "xyz|desc,noTDQ"         | SORT_METRICS_NOT_SORTABLE_FORMAT.format(["noTDQ"])   | "No fact column to sort"
+    }
+
+    @Unroll
+    def "Parsing sort direction parses #columns into #direction"() {
+        expect:
+        generator.parseSortDirection(columns) == direction
+
+        where:
+        columns               | direction
+        ["foo"]               | DESC
+        ["foo", "DESC"]       | DESC
+        ["foo", "ASC"]        | ASC
+        ["foo", "DESCENDING"] | DESC
+        ["foo", "ASCENDING"]  | ASC
+        ["foo", "desc"]       | DESC
+        ["foo", "asc"]        | ASC
+        ["foo", "descending"] | DESC
+        ["foo", "ascending"]  | ASC
+    }
+
+    @Unroll
+    def "Parsing #sortString results in the expected unbound columns"() {
+        setup:
+
+        expect:
+        List<OrderByColumn> orderByColumnList = generator.parseOrderByColumns(sortString)
+        orderByColumnList.collectEntries() { [(it.dimension) :it.direction] } == expected
+
+        where:
+        sortString                       | expected
+        "dateTime"                       | ["dateTime": DESC] as Map
+        "dateTime|ASC"                   | ["dateTime": ASC] as Map
+        "dateTimexyz|DESC"               | ["dateTimexyz": DESC] as Map
+        "xyz,dateTime,abc"               | ["xyz": DESC, "dateTime": DESC, "abc": DESC] as Map
+        "xyz,dateTime|DESC,abc"          | ["xyz": DESC, "dateTime": DESC, "abc": DESC] as Map
+        "xyz|DESC,dateTime|DESC,abc|ASC" | ["xyz": DESC, "dateTime": DESC, "abc": ASC] as Map
+        "xyz|DESC,dateTime,abc|DESC"     | ["xyz": DESC, "dateTime": DESC, "abc": DESC] as Map
+        "xyz|DESC,dateTime"              | ["xyz": DESC, "dateTime": DESC] as Map
+        ""                               | [:]
+        "unconfigured"                   | ["unconfigured": DESC] as Map
+        "dim"                            | ["dim": DESC] as Map
+    }
+
+    @Unroll
+    def "Generate and bind #sortString results in correct logical column, direction and type from "() {
+        setup:
+        List<String> metricFields = ["xyz", "abc", "dateTimexyz", "dinga"]
+        LinkedHashSet<LogicalMetric> logicalMetrics = metricFields.collect() {
+            Aggregation a = new LongSumAggregation(it, it + "_field")
+            TemplateDruidQuery tdq = new TemplateDruidQuery([a], [])
+            new LogicalMetricImpl(tdq, null, (String) it)
+        } as Set<LogicalMetric>
+        List<OrderByColumn> orderByColumnList = generator.generateBoundOrderByColumns(sortString, logicalMetrics, selectedDimensions)
+
+        expect:
+        expected.eachWithIndex{ def entry, int i ->
+            OrderByColumn column = orderByColumnList.get(i)
+            assert entry.getAt(0) == column.getDimension()
+            assert entry.getAt(1) == column.getDirection()
+            assert entry.getAt(2) == column.getType()
+        } || ( (List) expected).isEmpty()
+
+        where:
+        sortString                       | expected
+        // empty set
+        ""                               | []
+        //date time every direction
+        "dateTime"                       | [["dateTime", DESC, TIME]]
+        "dateTime|ASC"                   | [["dateTime", ASC, TIME]]
+        "dateTime|DESC"                  | [["dateTime", DESC, TIME]]
+
+        // simple metric
+        "xyz"                            | [["xyz", DESC, METRIC]]
+        "xyz|ascending"                  | [["xyz", ASC, METRIC]]
+        "xyz|descen"                     | [["xyz", DESC, METRIC]]
+        // simple dimension maps to keyfield in binding phase
+        "dim1"                           | [["fieldName", DESC, DIMENSION]]
+
+        // dateTime not being used as a string match
+        "dateTimexyz|DESC"               | [["dateTimexyz", DESC, METRIC]]
+
+        // Three metrics, internal date time not resulting in an error here
+        "xyz,dateTime,abc"               | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME], ["abc", DESC, METRIC]]
+        // interior directions parse
+        "xyz,dateTime|DESC,abc"          | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME], ["abc", DESC, METRIC]]
+        "xyz|desc,dateTime|DESC,abc|ASC" | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME], ["abc", ASC, METRIC]]
+        "xyz|DESC,dateTime,abc|DESC"     | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME], ["abc", DESC, METRIC]]
+        "xyz|DESC,dateTime"              | [["xyz", DESC, METRIC], ["dateTime", DESC, TIME]]
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/utils/TestingDataApiRequestImpl.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/utils/TestingDataApiRequestImpl.groovy
@@ -2,12 +2,17 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.bard.webservice.web.apirequest.utils
 
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.DATE_TIME_SORT_VALUE_INVALID
+import static com.yahoo.bard.webservice.web.ErrorMessageFormat.DATE_TIME_SORT_VALUE_INVALID
+
 import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.model.builders.DruidOrFilterBuilder
 import com.yahoo.bard.webservice.druid.model.orderby.OrderByColumn
+import com.yahoo.bard.webservice.druid.model.orderby.SortDirection
 import com.yahoo.bard.webservice.table.LogicalTable
 import com.yahoo.bard.webservice.web.ResponseFormatType
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestImpl
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException
 import com.yahoo.bard.webservice.web.filters.ApiFilters
 import com.yahoo.bard.webservice.web.util.PaginationParameters
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/BaseDataServletComponentSpec.groovy
@@ -300,9 +300,6 @@ abstract class BaseDataServletComponentSpec extends Specification {
 
         // Make the call
         Response response = httpCall.request().headers(additionalApiRequestHeaders).get()
-        if (response.status != 200) {
-            LOG.trace("***  *** Response status: ${response.status}: ${response.readEntity(String)}")
-        }
         response
     }
 

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DefaultBuilderCheckSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/DefaultBuilderCheckSpec.groovy
@@ -8,10 +8,14 @@ import com.yahoo.bard.webservice.application.JerseyTestBinder
 import com.yahoo.bard.webservice.data.dimension.BardDimensionField
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 
+import org.junit.Ignore
+
 import spock.lang.Specification
 
 import javax.ws.rs.core.Response
 
+// This capability will be disabled and replaced by a new protocol metric Impl
+@Ignore
 class DefaultBuilderCheckSpec extends Specification {
     boolean intersectionReportingState
     JerseyTestBinder jtb

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
@@ -416,7 +416,7 @@ class ErrorDataServletSpec extends Specification {
     }
 
     def "Bad sort metric fails"() {
-        String message = SORT_METRICS_UNDEFINED.format("[bad, worse]")
+        String message = SORT_METRICS_NOT_IN_QUERY_FORMAT.format("[bad, worse]")
 
         String jsonFailure =
                 """{"status":400,

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ProtocolSingleMetricHavingFakeProtocolDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ProtocolSingleMetricHavingFakeProtocolDataServletSpec.groovy
@@ -1,0 +1,99 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.endpoints
+
+class ProtocolSingleMetricHavingFakeProtocolDataServletSpec extends BaseDataServletComponentSpec {
+
+    @Override
+    Class<?>[] getResourceClasses() {
+        [DataServlet.class]
+    }
+
+    @Override
+    String getTarget() {
+        return "data/shapes/week/color"
+    }
+
+    @Override
+    Map<String, List<String>> getQueryParams() {
+        [
+                "metrics" : ["width(fakeProtocol=dayAvg)"],
+                "dateTime": ["2014-06-02%2F2014-06-09"],
+                "having": ["width(fakeProtocol=dayAvg)-gt[10]"]
+        ]
+    }
+
+    @Override
+    String getExpectedApiResponse() {
+        """{
+            "rows": [
+                {
+                    "color|desc": "",
+                    "color|id": "Bar",
+                    "dateTime": "2014-06-02 00:00:00.000",
+                    "width(fakeProtocol=dayAvg)": 11
+                },
+                {
+                    "color|desc": "",
+                    "color|id": "Baz",
+                    "dateTime": "2014-06-02 00:00:00.000",
+                    "width(fakeProtocol=dayAvg)": 12
+                }
+            ]
+        }"""
+    }
+
+    @Override
+    String getExpectedDruidQuery() {
+        """{
+                "aggregations": [
+                    {
+                        "fieldName": "width",
+                        "name": "width(fakeProtocol=dayAvg)",
+                        "type": "longSum"
+                    }
+                ],
+                "dataSource": {
+                    "name": "color_shapes",
+                    "type": "table"
+                },
+                "dimensions": [
+                    "color"
+                ],
+                "granularity": ${getTimeGrainString("week")},
+                "having": {
+                    "aggregation": "width(fakeProtocol=dayAvg)",
+                    "type": "greaterThan",
+                    "value": 10
+                },
+                "intervals": [
+                    "2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"
+                ],
+                "postAggregations": [],
+                "queryType": "groupBy",
+                "context": {}
+        }"""
+    }
+
+    @Override
+    String getFakeDruidResponse() {
+        """[
+              {
+                "version" : "v1",
+                "timestamp" : "2014-06-02T00:00:00.000Z",
+                "event" : {
+                  "color" : "Bar",
+                  "width(fakeProtocol=dayAvg)" : 11
+                }
+              },
+              {
+                "version" : "v1",
+                "timestamp" : "2014-06-02T00:00:00.000Z",
+                "event" : {
+                  "color" : "Baz",
+                  "width(fakeProtocol=dayAvg)" : 12
+                }
+              }
+            ]"""
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ProtocolSingleMetricHavingReaggProtocolDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ProtocolSingleMetricHavingReaggProtocolDataServletSpec.groovy
@@ -1,0 +1,136 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.endpoints
+
+class ProtocolSingleMetricHavingReaggProtocolDataServletSpec extends BaseDataServletComponentSpec {
+
+    @Override
+    Class<?>[] getResourceClasses() {
+        [DataServlet.class]
+    }
+
+    @Override
+    String getTarget() {
+        return "data/shapes/week/color"
+    }
+
+    @Override
+    Map<String, List<String>> getQueryParams() {
+        [
+                "metrics" : ["width(reagg=dayAvg)"],
+                "dateTime": ["2014-06-02%2F2014-06-09"],
+                "having": ["width(reagg=dayAvg)-gt[10]"]
+        ]
+    }
+
+    @Override
+    String getExpectedApiResponse() {
+        """{
+            "rows": [
+                {
+                    "color|desc": "",
+                    "color|id": "Bar",
+                    "dateTime": "2014-06-02 00:00:00.000",
+                    "width(reagg=dayAvg)": 11
+                },
+                {
+                    "color|desc": "",
+                    "color|id": "Baz",
+                    "dateTime": "2014-06-02 00:00:00.000",
+                    "width(reagg=dayAvg)": 12
+                }
+            ]
+        }"""
+    }
+
+    @Override
+    String getExpectedDruidQuery() {
+        """{
+        "aggregations": [{
+                             "fieldName": "one",
+                             "name": "count",
+                             "type": "longSum"
+                         }, {
+                             "fieldName": "width",
+                             "name": "width",
+                             "type": "longSum"
+                         }],
+        "context": {},
+        "dataSource": {
+        "query": {
+            "aggregations": [{
+                                 "fieldName": "width",
+                                 "name": "width",
+                                 "type": "longSum"
+                             }],
+            "context": {},
+            "dataSource": {
+                "name": "color_shapes",
+                "type": "table"
+            },
+            "dimensions": ["color"],
+            "granularity": {
+                "period": "P1D",
+                "timeZone": "UTC",
+                "type": "period"
+            },
+            "intervals": ["2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"],
+            "postAggregations": [{
+                                     "name": "one",
+                                     "type": "constant",
+                                     "value": 1.0
+                                 }],
+            "queryType": "groupBy"
+        },
+        "type": "query"
+    },
+        "dimensions": ["color"],
+        "granularity": {
+        "period": "P1W",
+        "timeZone": "UTC",
+        "type": "period"
+    },
+        "having": {
+        "aggregation": "width(reagg=dayAvg)",
+        "type": "greaterThan",
+        "value": 10.0
+    },
+        "intervals": ["2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"],
+        "postAggregations": [{
+                                 "fields": [{
+                                                "fieldName": "count",
+                                                "type": "fieldAccess"
+                                            }, {
+                                                "fieldName": "width",
+                                                "type": "fieldAccess"
+                                            }],
+                                 "fn": "/",
+                                 "name": "width(reagg=dayAvg)",
+                                 "type": "arithmetic"
+                             }],
+        "queryType": "groupBy"
+}"""
+    }
+
+    @Override
+    String getFakeDruidResponse() {
+        """[
+              {
+                "version" : "v1",
+                "timestamp" : "2014-06-02T00:00:00.000Z",
+                "event" : {
+                  "color" : "Bar",
+                  "width(reagg=dayAvg)" : 11
+                }
+              },
+              {
+                "version" : "v1",
+                "timestamp" : "2014-06-02T00:00:00.000Z",
+                "event" : {
+                  "color" : "Baz",
+                  "width(reagg=dayAvg)" : 12
+                }
+              }
+            ]"""
+    }
+}

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ProtocolSingleMetricSortFakeProtocolDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ProtocolSingleMetricSortFakeProtocolDataServletSpec.groovy
@@ -1,0 +1,99 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.endpoints
+
+class ProtocolSingleMetricSortFakeProtocolDataServletSpec extends BaseDataServletComponentSpec {
+
+    @Override
+    Class<?>[] getResourceClasses() {
+        [DataServlet.class]
+    }
+
+    @Override
+    String getTarget() {
+        return "data/shapes/week/color"
+    }
+
+    @Override
+    Map<String, List<String>> getQueryParams() {
+        [
+                "metrics" : ["width(fakeProtocol=dayAvg)"],
+                "dateTime": ["2014-06-02%2F2014-06-09"],
+                "sort": ["width(fakeProtocol=dayAvg)"]
+        ]
+    }
+
+    @Override
+    String getExpectedApiResponse() {
+        """{
+            "rows": [
+                {
+                    "color|desc": "",
+                    "color|id": "Bar",
+                    "dateTime": "2014-06-02 00:00:00.000",
+                    "width(fakeProtocol=dayAvg)": 11
+                },
+                {
+                    "color|desc": "",
+                    "color|id": "Baz",
+                    "dateTime": "2014-06-02 00:00:00.000",
+                    "width(fakeProtocol=dayAvg)": 12
+                }
+            ]
+        }"""
+    }
+
+    @Override
+    String getExpectedDruidQuery() {
+        """{
+                "aggregations": [
+                    {
+                        "fieldName": "width",
+                        "name": "width(fakeProtocol=dayAvg)",
+                        "type": "longSum"
+                    }
+                ],
+                "dataSource": {
+                    "name": "color_shapes",
+                    "type": "table"
+                },
+                "dimensions": [
+                    "color"
+                ],
+                "granularity": ${getTimeGrainString("week")},
+                "limitSpec": {
+                    "columns": [{
+                    "dimension": "width(fakeProtocol=dayAvg)",
+                    "direction": "DESC"}
+                ], "type": "default"},
+                "intervals": [
+                    "2014-06-02T00:00:00.000Z/2014-06-09T00:00:00.000Z"
+                ],
+                "postAggregations": [],
+                "queryType": "groupBy",
+                "context": {}
+        }"""
+    }
+
+    @Override
+    String getFakeDruidResponse() {
+        """[
+              {
+                "version" : "v1",
+                "timestamp" : "2014-06-02T00:00:00.000Z",
+                "event" : {
+                  "color" : "Bar",
+                  "width(fakeProtocol=dayAvg)" : 11
+                }
+              },
+              {
+                "version" : "v1",
+                "timestamp" : "2014-06-02T00:00:00.000Z",
+                "event" : {
+                  "color" : "Baz",
+                  "width(fakeProtocol=dayAvg)" : 12
+                }
+              }
+            ]"""
+    }
+}

--- a/fili-core/src/test/java/com/yahoo/bard/webservice/application/JerseyTestBinder.java
+++ b/fili-core/src/test/java/com/yahoo/bard/webservice/application/JerseyTestBinder.java
@@ -78,6 +78,8 @@ public class JerseyTestBinder {
 
     public TestDimensions testDimensions = new TestDimensions();
 
+    public boolean wasStarted = false;
+
     /**
      * Constructor that will auto-start.
      *
@@ -226,6 +228,7 @@ public class JerseyTestBinder {
     public void start() {
         try {
             new StartHarness().startHarness();
+            wasStarted = true;
         } catch (Exception e) {
             throw (e instanceof IllegalStateException) ? (IllegalStateException) e : new IllegalStateException(e);
         }


### PR DESCRIPTION
Preliminary work to make sorting work on ProtocolMetrics

1- Create an external single-stream parser for default metrics.  Unimplemented would be to replace the existing partialcompile, build date time, build not date time interaction with
call the external loader that builds date time and not date time in a single list and the pops dateTime off the front if it exists.
2- Create grammar to support existing addendums to the protocol metric grammar for parsing protocol sorts.
3- Next step is to subclass the singlestream parser to build it's stream of Logical OrderByCoulmns from a grammer rather than a split on comma.