### PR TITLE
Making Response Formats easier to extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ Current
    * Generators based on `DataApiRequestImpl` are not yet implemented.
 
 ### Changed:
+- [Added extension capabilities to the default parsing of formats](https://github.com/yahoo/fili/issues/1077)
+   * Added static map for response formats to `DefaultResponseFormatGenerator`
+   * Added unit test for `DefaultResponseFormatGenerator`
 
 - [Updated dependency code](https://github.com/yahoo/fili/issues/1066)
    * Removed expired suppressions

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/DefaultResponseFormatGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/DefaultResponseFormatGenerator.java
@@ -5,12 +5,11 @@ package com.yahoo.bard.webservice.web.apirequest.generator;
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.ACCEPT_FORMAT_INVALID;
 
 import com.yahoo.bard.webservice.MessageFormatter;
-import com.yahoo.bard.webservice.web.ErrorMessageFormat;
-import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
 import com.yahoo.bard.webservice.web.DefaultResponseFormatType;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequestBuilder;
 import com.yahoo.bard.webservice.web.apirequest.RequestParameters;
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
 import com.yahoo.bard.webservice.web.util.BardConfigResources;
 
 import org.slf4j.Logger;
@@ -89,7 +88,9 @@ public class DefaultResponseFormatGenerator implements Generator<ResponseFormatT
      * @return the response format.
      */
     public static ResponseFormatType generateResponseFormat(String format) {
-        ResponseFormatType formatType = RESPONSE_FORMAT_TYPE_MAP.get(format.toUpperCase(Locale.ENGLISH));
+        ResponseFormatType formatType = format == null ?
+                DefaultResponseFormatType.JSON :
+                RESPONSE_FORMAT_TYPE_MAP.get(format.toUpperCase(Locale.ENGLISH));
         if (formatType == null) {
             LOG.error(errorMessageFormat.logFormat(format));
             throw new BadApiRequestException(errorMessageFormat.format(format));

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/DefaultResponseFormatGenerator.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/generator/DefaultResponseFormatGenerator.java
@@ -4,6 +4,8 @@ package com.yahoo.bard.webservice.web.apirequest.generator;
 
 import static com.yahoo.bard.webservice.web.ErrorMessageFormat.ACCEPT_FORMAT_INVALID;
 
+import com.yahoo.bard.webservice.MessageFormatter;
+import com.yahoo.bard.webservice.web.ErrorMessageFormat;
 import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException;
 import com.yahoo.bard.webservice.web.DefaultResponseFormatType;
 import com.yahoo.bard.webservice.web.ResponseFormatType;
@@ -14,7 +16,10 @@ import com.yahoo.bard.webservice.web.util.BardConfigResources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Default generator implementation for binding {@link ResponseFormatType}. Only recognizes response formats from the
@@ -23,6 +28,32 @@ import java.util.Locale;
 public class DefaultResponseFormatGenerator implements Generator<ResponseFormatType> {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultResponseFormatType.class);
+
+    private static final Map<String, ResponseFormatType> RESPONSE_FORMAT_TYPE_MAP;
+    private static MessageFormatter errorMessageFormat = ACCEPT_FORMAT_INVALID;
+
+    static {
+        RESPONSE_FORMAT_TYPE_MAP = new ConcurrentHashMap();
+        Arrays.stream(DefaultResponseFormatType.values())
+                .forEach(defaultResponseFormatType -> RESPONSE_FORMAT_TYPE_MAP.put(
+                        defaultResponseFormatType.name(),
+                        defaultResponseFormatType
+                ));
+    }
+
+    public static void addFormatType(String name, ResponseFormatType type) {
+        RESPONSE_FORMAT_TYPE_MAP.put(name.toUpperCase(Locale.ENGLISH), type);
+    }
+
+    public static ResponseFormatType removeFormatType(String name) {
+        return RESPONSE_FORMAT_TYPE_MAP.remove(name.toUpperCase(Locale.ENGLISH));
+    }
+
+    public static MessageFormatter setMessageFormatter(MessageFormatter messageFormatter) {
+        MessageFormatter previous = errorMessageFormat;
+        errorMessageFormat = messageFormatter;
+        return previous;
+    }
 
     @Override
     public ResponseFormatType bind(
@@ -58,13 +89,11 @@ public class DefaultResponseFormatGenerator implements Generator<ResponseFormatT
      * @return the response format.
      */
     public static ResponseFormatType generateResponseFormat(String format) {
-        try {
-            return format == null ?
-                    DefaultResponseFormatType.JSON :
-                    DefaultResponseFormatType.valueOf(format.toUpperCase(Locale.ENGLISH));
-        } catch (IllegalArgumentException e) {
-            LOG.error(ACCEPT_FORMAT_INVALID.logFormat(format), e);
-            throw new BadApiRequestException(ACCEPT_FORMAT_INVALID.format(format));
+        ResponseFormatType formatType = RESPONSE_FORMAT_TYPE_MAP.get(format.toUpperCase(Locale.ENGLISH));
+        if (formatType == null) {
+            LOG.error(errorMessageFormat.logFormat(format));
+            throw new BadApiRequestException(errorMessageFormat.format(format));
         }
+        return formatType;
     }
 }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/generator/DefaultResponseFormatGeneratorSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/apirequest/generator/DefaultResponseFormatGeneratorSpec.groovy
@@ -1,0 +1,115 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest.generator
+
+import static com.yahoo.bard.webservice.web.DefaultResponseFormatType.CSV
+import static com.yahoo.bard.webservice.web.DefaultResponseFormatType.JSON
+import static com.yahoo.bard.webservice.web.DefaultResponseFormatType.JSONAPI
+
+import com.yahoo.bard.webservice.MessageFormatter
+import com.yahoo.bard.webservice.web.DefaultResponseFormatType
+import com.yahoo.bard.webservice.web.ErrorMessageFormat
+import com.yahoo.bard.webservice.web.ResponseFormatType
+import com.yahoo.bard.webservice.web.apirequest.DataApiRequestBuilder
+import com.yahoo.bard.webservice.web.apirequest.RequestParameters
+import com.yahoo.bard.webservice.web.apirequest.exceptions.BadApiRequestException
+import com.yahoo.bard.webservice.web.util.BardConfigResources
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Tests for the default response format generation
+ */
+class DefaultResponseFormatGeneratorSpec extends Specification {
+
+    DefaultResponseFormatGenerator generator = new DefaultResponseFormatGenerator()
+
+    @Unroll
+    def "Bind binds #formatName to #formatType"() {
+        expect:
+        DefaultResponseFormatGenerator.generateResponseFormat(formatName) == formatType
+
+        where:
+        formatName | formatType
+        "json"     | JSON
+        "JSON"     | JSON
+        "jSon"     | JSON
+        "jsonapi"  | JSONAPI
+        "csv"      | CSV
+    }
+
+    // Testing static methods
+
+    def "Bind binds a custom report format type"() {
+        setup:
+        ResponseFormatType test = Mock(ResponseFormatType)
+        DefaultResponseFormatGenerator.addFormatType("test", test)
+
+        expect:
+        DefaultResponseFormatGenerator.generateResponseFormat("test") == test
+
+        cleanup:
+        DefaultResponseFormatGenerator.removeFormatType("test")
+    }
+
+    def "Bind fails on undefined format type"() {
+        setup:
+        String errorMessage = ErrorMessageFormat.ACCEPT_FORMAT_INVALID.format("test");
+
+        when:
+        ResponseFormatType format = DefaultResponseFormatGenerator.generateResponseFormat("test")
+
+        then:
+        Exception e = thrown(BadApiRequestException)
+        e.getMessage().endsWith(errorMessage)
+    }
+
+    def "Custom formatter is respected"() {
+        setup:
+        MessageFormatter formatter = Mock(MessageFormatter)
+        formatter.format(_) >> "test"
+        formatter.logFormat(_) >> "test"
+        MessageFormatter old = DefaultResponseFormatGenerator.setMessageFormatter(formatter)
+
+        when:
+        ResponseFormatType format = DefaultResponseFormatGenerator.generateResponseFormat("test")
+
+        then:
+        Exception e = thrown(BadApiRequestException)
+        e.getMessage().endsWith("test")
+
+        cleanup:
+        DefaultResponseFormatGenerator.setMessageFormatter(old)
+    }
+
+    // Testing non-static methods
+    def "Validate does nothing"() {
+        setup:
+        ResponseFormatType entity = Mock(ResponseFormatType)
+        DataApiRequestBuilder builder = Mock(DataApiRequestBuilder)
+        RequestParameters params = Mock(RequestParameters)
+        BardConfigResources resources = Mock(BardConfigResources)
+
+        when:
+        generator.validate(entity, builder, params, resources)
+
+        then:
+        0 * _._
+    }
+
+    def "Bind binds a response format"() {
+        setup:
+        DataApiRequestBuilder builder = Mock(DataApiRequestBuilder)
+        RequestParameters params = Mock(RequestParameters)
+        BardConfigResources resources = Mock(BardConfigResources)
+
+        when:
+        ResponseFormatType type = generator.bind(builder, params, resources)
+
+        then:
+        type == DefaultResponseFormatType.CSV
+        1 * params.getFormat() >> Optional.of("csv")
+        0 * _._
+    }
+}


### PR DESCRIPTION
Adding dictionary to accept additional response formats.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
