### PR TITLE
Make build work when JAVA_TOOL_OPTIONS is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ pull request if there was one.
 Current
 -------
 ### Fixed:
+- [Fix: Make build work with JAVA_TOOL_OPTIONS](https://github.com/yahoo/fili/pull/1091)
+    * Fixed maven build failure when JAVA_TOOL_OPTIONS was set by reconfiguring ant output
+
 - [Fix: Bad serialization of AllGranularity](https://github.com/yahoo/fili/issues/1093)
     * Change to rollup formatter broke serialization of all timegrain.
 

--- a/fili-core/pom.xml
+++ b/fili-core/pom.xml
@@ -283,6 +283,7 @@
                                     <arg value="${project.basedir}/src/test/resources/avroFilesTesting/sampleData.avsc"/>
                                     <arg value="${project.basedir}/src/test/resources/avroFilesTesting/sampleData.json"/>
                                     <redirector
+                                        logError="true"
                                         output="${project.build.directory}/avro/avroFilesTesting/sampleData.avro"
                                         binaryOutput="true"/>
                                 </java>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This change makes the maven build work when [JAVA_TOOL_OPTIONS](https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars002.html). 

I happened to have `JAVA_TOOL_OPTIONS=-Djava.awt.headless=true` in my environment when building Fili. With this, Java (e.g. AdoptOpenJDK 1.8) dumps a line to stderr on every jvm invocation:
```
Picked up JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
```

The ant task here used to generate an Avro file [redirects stderr to `output`](https://ant.apache.org/manual/Types/redirector.html) unless you direct it somewhere else: 

> Output: Name of a file to which output should be written. If the error stream is not also redirected to a file or property, it will appear in this output.

As-is, the stderr log message about JAVA_TOOL_OPTIONS gets redirected to the top of the Avro file, which results in an obviously invalid Avro file. 

Setting `logError` redirects this message to the console:

> This attribute is used when you wish to see error output in Ant's log and you are redirecting output to a file/property. The error output will not be included in the output file/property.

which fixes things for me.