### PR TITLE
Timeout across all druid queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,11 @@ Current
    * Generators based on `DataApiRequestImpl` are not yet implemented.
 
 ### Changed:
+- [Added support for druid timeouts to be cumulatively linked to request start time](https://github.com/yahoo/fili/issues/1119)
+   * Modify RequestLog to support fetching without modification on Timers.
+   * Build TimeRemainingFunction to pull a time delta using the RequestLog start of request.
+   * Add injection constructors for WebServiceSelectorRequestHandler to inject TimeRemainingFunction and support counting down druid timeouts.
+
 - [Moving to open source screwdriver for builds](https://github.com/yahoo/fili/issues/1109)
   * Travis-ci.com was no longer funded, migrated builds onto screwdriver.
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuery.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/druid/model/query/WeightEvaluationQuery.java
@@ -105,7 +105,9 @@ public class WeightEvaluationQuery extends GroupByQuery {
                 Collections.<Aggregation>singletonList(new LongSumAggregation("count", "count")),
                 Collections.<PostAggregation>emptyList(),
                 query.getIntervals(),
-                query.getQueryType() == DefaultQueryType.GROUP_BY ? stripColumnsFromLimitSpec(query) : null
+                query.getQueryType() == DefaultQueryType.GROUP_BY ? stripColumnsFromLimitSpec(query) : null,
+                query.getContext(),
+                false
         );
     }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/RequestLog.java
@@ -240,6 +240,18 @@ public class RequestLog {
     }
 
     /**
+     * Retrieve a stopwatch from the session.
+     *
+     * @param timePhaseName  the name of this stopwatch
+     *
+     * @return The stopwatch or null if it doesn't exist
+     */
+    public static TimedPhase fetchTiming(String timePhaseName) {
+        RequestLog current = RLOG.get();
+        return current.times.get(timePhaseName);
+    }
+
+    /**
      * Stop the most recent stopwatch and start this one.
      * Time is accumulated if the stopwatch is already registered.
      *

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/TimeRemainingFunction.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/TimeRemainingFunction.java
@@ -1,0 +1,28 @@
+// Copyright 2020 Oath Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.logging;
+
+import com.yahoo.bard.webservice.web.filters.BardLoggingFilter;
+
+import java.util.function.Function;
+
+/**
+ * Timeout helper identifies how much time is left given a timeout number.
+ */
+public class TimeRemainingFunction implements Function<Integer, Integer> {
+
+    public static TimeRemainingFunction INSTANCE = new TimeRemainingFunction();
+
+    /**
+     * Calculate timeout remaining based on configured timeout and session start time.
+     *
+     * @param timeout  The max timeout in milliseconds.
+     *
+     * @return The time remaining or zero.
+     */
+    public Integer apply(Integer timeout) {
+        TimedPhase totalTimer =  RequestLog.fetchTiming(BardLoggingFilter.TOTAL_TIMER);
+        long timeSoFarNanos = (totalTimer == null) ? 0 : totalTimer.getActiveDuration();
+        return ((int) Math.max(timeout - (timeSoFarNanos / 1000000), 0));
+    }
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/TimedPhase.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/TimedPhase.java
@@ -89,6 +89,18 @@ public class TimedPhase implements AutoCloseable {
         return duration;
     }
 
+    /**
+     * Return the duration of the timer in nanoseconds.
+     *
+     * @return The duration of the timer in nanoseconds
+     */
+    public long getActiveDuration() {
+        if (isRunning()) {
+            return System.nanoTime() - start;
+        }
+        return duration;
+    }
+
     public String getName() {
         return name;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/WebServiceSelectorRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/WebServiceSelectorRequestHandler.java
@@ -10,6 +10,8 @@ import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.function.Function;
+
 /**
  * The Webservice selector routes requests in one of several ways, described below.
  * <ul>
@@ -20,6 +22,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class WebServiceSelectorRequestHandler extends BaseDataRequestHandler {
 
     private final WebServiceHandlerSelector handlerSelector;
+
+    /**
+     * A function to massage timeouts on requests, often to count down druid timeouts on request absolute time.
+     */
+    private final Function<Integer, Integer> timeoutTransform;
 
     /**
      * Constructor.
@@ -38,7 +45,32 @@ public class WebServiceSelectorRequestHandler extends BaseDataRequestHandler {
                         webService,
                         webserviceNext
                 ),
-                mapper
+                mapper,
+                Function.identity()
+        );
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param webService  UI Web Service
+     * @param webserviceNext  Handler for the UI path
+     * @param mapper  Mapper to use when processing JSON
+     * @param timeoutTransform  Function to map time remaining onto queries being sent to the web service.
+     */
+    public WebServiceSelectorRequestHandler(
+            DruidWebService webService,
+            DataRequestHandler webserviceNext,
+            ObjectMapper mapper,
+            Function<Integer, Integer> timeoutTransform
+    ) {
+        this(
+                new DefaultWebServiceHandlerSelector(
+                        webService,
+                        webserviceNext
+                ),
+                mapper,
+                timeoutTransform
         );
     }
 
@@ -49,8 +81,23 @@ public class WebServiceSelectorRequestHandler extends BaseDataRequestHandler {
      * @param mapper  Mapper to use when processing JSON
      */
     public WebServiceSelectorRequestHandler(WebServiceHandlerSelector handlerSelector, ObjectMapper mapper) {
+        this(handlerSelector, mapper, Function.identity());
+    }
+    /**
+     * Constructor.
+     *
+     * @param handlerSelector  Handler selector to use when selecting a web service
+     * @param mapper  Mapper to use when processing JSON
+     * @param timeoutTransform  Function to map time remaining onto queries being sent to the web service.
+     */
+    public WebServiceSelectorRequestHandler(
+            WebServiceHandlerSelector handlerSelector,
+            ObjectMapper mapper,
+            Function<Integer, Integer> timeoutTransform
+    ) {
         super(mapper);
         this.handlerSelector = handlerSelector;
+        this.timeoutTransform = timeoutTransform;
     }
 
     @Override
@@ -62,13 +109,23 @@ public class WebServiceSelectorRequestHandler extends BaseDataRequestHandler {
     ) {
         WebServiceHandler handler = handlerSelector.select(druidQuery, request, context);
         // Add a timeout to the query if the selected webService is configured with one
-        Integer timeout = handler.getWebService().getTimeout();
         // Add a priority to the query if there is one configured
         Integer priority = handler.getWebService().getServiceConfig().getPriority();
-        QueryContext qc = druidQuery.getContext().withTimeout(timeout).withPriority(priority);
-        if (!qc.isEmpty()) {
-            druidQuery = druidQuery.withContext(qc);
+        QueryContext originalQc = druidQuery.getContext();
+        QueryContext qc = originalQc;
+        Integer configuredTimeout = handler.getWebService().getTimeout();
+        if (configuredTimeout != null) {
+            int timeLeft = timeoutTransform.apply(configuredTimeout);
+            qc = qc.withTimeout(timeLeft);
         }
-        return handler.handleRequest(context, request, druidQuery, response);
+        if (priority != null) {
+            qc = qc.withPriority(priority);
+        }
+
+        DruidAggregationQuery<?> finalQuery = (qc != originalQc) ?
+                druidQuery.withContext(qc) :
+                druidQuery;
+
+        return handler.handleRequest(context, request, finalQuery, response);
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/workflow/DruidWorkflow.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/workflow/DruidWorkflow.java
@@ -11,6 +11,7 @@ import com.yahoo.bard.webservice.data.cache.DataCache;
 import com.yahoo.bard.webservice.data.cache.TupleDataCache;
 import com.yahoo.bard.webservice.data.volatility.VolatileIntervalsService;
 import com.yahoo.bard.webservice.druid.client.DruidWebService;
+import com.yahoo.bard.webservice.logging.TimeRemainingFunction;
 import com.yahoo.bard.webservice.metadata.QuerySigningService;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
 import com.yahoo.bard.webservice.web.handlers.AsyncWebServiceRequestHandler;
@@ -147,7 +148,8 @@ public class DruidWorkflow implements RequestWorkflowProvider {
         handler = new WebServiceSelectorRequestHandler(
                 webService,
                 handler,
-                mapper
+                mapper,
+                TimeRemainingFunction.INSTANCE
          );
 
         //The PaginationRequestHandler adds a mapper to the mapper chain that strips the result set down to just the

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WebServiceSelectorRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WebServiceSelectorRequestHandlerSpec.groovy
@@ -3,12 +3,18 @@
 package com.yahoo.bard.webservice.web.handlers
 
 import com.yahoo.bard.webservice.application.ObjectMappersSuite
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain
 import com.yahoo.bard.webservice.druid.client.DruidServiceConfig
 import com.yahoo.bard.webservice.druid.client.DruidWebService
+import com.yahoo.bard.webservice.druid.model.datasource.DataSource
+import com.yahoo.bard.webservice.druid.model.orderby.LimitSpec
 import com.yahoo.bard.webservice.druid.model.query.GroupByQuery
 import com.yahoo.bard.webservice.druid.model.query.QueryContext
+import com.yahoo.bard.webservice.logging.RequestLog
+import com.yahoo.bard.webservice.logging.TimeRemainingFunction
 import com.yahoo.bard.webservice.web.DataApiRequestTypeIdentifier
 import com.yahoo.bard.webservice.web.apirequest.DataApiRequest
+import com.yahoo.bard.webservice.web.filters.BardLoggingFilter
 import com.yahoo.bard.webservice.web.responseprocessors.ResponseProcessor
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -85,6 +91,83 @@ class WebServiceSelectorRequestHandlerSpec extends Specification {
         5        |  null      | true            | 1
         null     |  1         | true            | 1
         5        |  1         | true            | 1
+    }
 
+    def "Test time function counts down based on total timing"() {
+        setup:
+
+        WebServiceSelectorRequestHandler handler = new WebServiceSelectorRequestHandler(
+                webService,
+                webServiceNext,
+                mapper,
+                TimeRemainingFunction.INSTANCE
+        )
+
+        RequestLog.startTiming(BardLoggingFilter.TOTAL_TIMER)
+        DataSource dataSource = Mock(DataSource)
+        GroupByQuery groupByQuery1 = new GroupByQuery(
+                dataSource,
+                DefaultTimeGrain.DAY,
+                Collections.emptyList(),
+                null,
+                null,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null
+        )
+        Integer timeout = 20000
+        Integer timeSoFar = 0
+        QueryContext latestActualContext = null
+
+        and: "Stubbing"
+        DruidWebService onWebService
+        DataRequestHandler nextHandler = webServiceNext
+        ContainerRequestContext crc = Mock(ContainerRequestContext)
+        crc.getHeaders() >> headerMap
+        headerMap.add(DataApiRequestTypeIdentifier.CLIENT_HEADER_NAME, DataApiRequestTypeIdentifier.CLIENT_HEADER_VALUE)
+        headerMap.add("referer", "http://somewhere")
+
+        onWebService = webService
+        onWebService.getTimeout() >> timeout
+        onWebService.getServiceConfig() >> serviceConfig
+
+        nextHandler
+        rc = new RequestContext(crc, true)
+
+        when:
+        Thread.sleep(1000)
+        handler.handleRequest(rc, request, groupByQuery1, response)
+
+
+        then:
+        1 * nextHandler.handleRequest(rc, request, _, response) >> {
+            arguments ->
+                timeSoFar = (int) (RequestLog.fetchTiming(BardLoggingFilter.TOTAL_TIMER).getActiveDuration() / 1000000)
+                latestActualContext = ((GroupByQuery) arguments[2]).getContext()
+                return true
+        }
+        timeSoFar > 1000
+        timeSoFar < 19000
+        Math.abs(timeout - timeSoFar - latestActualContext.getTimeout() ) < 100
+
+        when:
+        Thread.sleep(2000)
+        handler.handleRequest(rc, request, groupByQuery1, response)
+
+
+        then:
+        1 * nextHandler.handleRequest(rc, request, _, response) >> {
+            arguments ->
+                timeSoFar = (int) (RequestLog.fetchTiming(BardLoggingFilter.TOTAL_TIMER).getActiveDuration() / 1000000)
+                latestActualContext = ((GroupByQuery) arguments[2]).getContext()
+                return true
+        }
+        timeSoFar > 3000
+        timeSoFar < 17000
+        Math.abs(timeout - timeSoFar - latestActualContext.getTimeout() ) < 100
+
+        cleanup:
+        RequestLog.stopTiming(BardLoggingFilter.TOTAL_TIMER)
     }
  }

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/web/handlers/workflow/SqlWorkflow.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/web/handlers/workflow/SqlWorkflow.java
@@ -11,6 +11,7 @@ import com.yahoo.bard.webservice.data.cache.DataCache;
 import com.yahoo.bard.webservice.data.cache.TupleDataCache;
 import com.yahoo.bard.webservice.data.volatility.VolatileIntervalsService;
 import com.yahoo.bard.webservice.druid.client.DruidWebService;
+import com.yahoo.bard.webservice.logging.TimeRemainingFunction;
 import com.yahoo.bard.webservice.metadata.QuerySigningService;
 import com.yahoo.bard.webservice.table.PhysicalTableDictionary;
 import com.yahoo.bard.webservice.web.handlers.AsyncWebServiceRequestHandler;
@@ -143,7 +144,8 @@ public class SqlWorkflow implements RequestWorkflowProvider {
         handler = new WebServiceSelectorRequestHandler(
                 webService,
                 handler,
-                mapper
+                mapper,
+                TimeRemainingFunction.INSTANCE
         );
 
         handler = new SqlRequestHandler(handler, mapper);


### PR DESCRIPTION
Modify RequestLog to support fetching without modification on Timers.
Build TimeRemainingFunction to pull a time delta using the RequestLog start of request.
Add injection constructors for WebServiceSelectorRequestHandler to inject TimeRemainingFunction and support counting down druid timeouts.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
