### PR TITLE
If the request context return null uribuilder, do not add pagination links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,8 @@ Current
    * Generators based on `DataApiRequestImpl` are not yet implemented.
 
 ### Changed:
+- [Support for embedded java client usage: made uri builder an optional contract](https://github.com/yahoo/fili/issues/1137)
+
 - [Added support for druid timeouts to be cumulatively linked to request start time](https://github.com/yahoo/fili/issues/1119)
    * Modify RequestLog to support fetching without modification on Timers.
    * Build TimeRemainingFunction to pull a time delta using the RequestLog start of request.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/PaginationMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/PaginationMapper.java
@@ -11,6 +11,7 @@ import com.yahoo.bard.webservice.web.AbstractResponse;
 import com.yahoo.bard.webservice.web.responseprocessors.MappingResponseProcessor;
 import com.yahoo.bard.webservice.web.util.PaginationParameters;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.UriBuilder;
 
 /**
@@ -28,11 +29,11 @@ public class PaginationMapper extends ResultSetMapper {
      *
      * @param paginationParameters  The parameters needed for pagination
      * @param responseProcessor  The API response to which we can add the header links.
-     * @param uriBuilder  The builder for creating the pagination links.
+     * @param uriBuilder  The builder for creating the pagination links. (Optional)
      */
     public PaginationMapper(
-            PaginationParameters paginationParameters,
-            MappingResponseProcessor responseProcessor,
+            @NotNull PaginationParameters paginationParameters,
+            @NotNull MappingResponseProcessor responseProcessor,
             UriBuilder uriBuilder
     ) {
         this.paginationParameters = paginationParameters;

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/PaginationMapper.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/data/metric/mappers/PaginationMapper.java
@@ -50,7 +50,9 @@ public class PaginationMapper extends ResultSetMapper {
     @Override
     public ResultSet map(ResultSet resultSet) {
         Pagination<Result> pages = new AllPagesPagination<>(resultSet, paginationParameters);
-        AbstractResponse.addLinks(pages, uriBuilder, responseProcessor);
+        if (uriBuilder != null) {
+            AbstractResponse.addLinks(pages, uriBuilder, responseProcessor);
+        }
         //uses map for additional flexibility and robustness, even though it is currently a no-op.
         return new ResultSet(map(resultSet.getSchema()), pages.getPageOfData());
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/endpoints/DataServlet.java
@@ -450,6 +450,7 @@ public class DataServlet extends CORSPreflightServlet implements BardConfigResou
             // Accumulate data needed for request processing workflow
             RequestContext context;
             try (TimedPhase timer = RequestLog.startTiming("BuildRequestContext")) {
+                // In embedded contexts, containerRequestContext may be null
                 context = new RequestContext(containerRequestContext, readCache);
             }
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/RequestContext.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/RequestContext.java
@@ -76,6 +76,8 @@ public class RequestContext {
     }
 
     public UriBuilder getUriBuilder() {
-        return containerRequestContext.getUriInfo().getRequestUriBuilder();
+        return containerRequestContext == null
+                ? null
+                : containerRequestContext.getUriInfo().getRequestUriBuilder();
     }
 }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/RequestContext.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/RequestContext.java
@@ -26,7 +26,7 @@ public class RequestContext {
     /**
      * Build a context for a request.
      *
-     * @param containerRequestContext  context from the http request object
+     * @param containerRequestContext  context from the http request object (nullabe in embedded contexts)
      * @param readCache  true if the cache should be checked for a response
      */
     public RequestContext(ContainerRequestContext containerRequestContext, boolean readCache) {

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/metric/mappers/PaginationMapperSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/data/metric/mappers/PaginationMapperSpec.groovy
@@ -220,6 +220,31 @@ class PaginationMapperSpec extends Specification {
         3    | 3           | 2
     }
 
+    @Unroll
+    def "Pagination links should not be added when URIBuilder is null"() {
+        given: "A pagination mapper without URIBuilder"
+        PaginationMapper paginator = new PaginationMapper(
+                new PaginationParameters(rowsPerPage, page),
+                responseProcessor,
+                null
+        )
+        ResultSet testResults = buildResultSet(numPages * rowsPerPage)
+
+        when: "We attempt to extract the desired page"
+        paginator.map(testResults)
+
+        then: "no links should be present"
+        Map<String, URI> bodyLinks = responseProcessor
+                .getResponseContext()[ResponseContextKeys.PAGINATION_LINKS_CONTEXT_KEY.getName()] as Map<String, URI>
+        bodyLinks == null
+
+        where:
+        page | numPages | rowsPerPage
+        1    | 1        | 1
+        1    | 1        | 2
+
+    }
+
 
     String getExpectedErrorMessage(int page, int rowsPerPage, int numPages) {
         "Requested page '$page' with '$rowsPerPage' rows per page, but there are only '$numPages' pages."


### PR DESCRIPTION
Allow creation of RequestContext without containerRequestContext object, and disable pagination links if URIBuilder is null. 
This is helpful to integrate fili with elide since elide does not use ContainerRequestContext both in Spring and Jax-RS. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
