### PR TITLE
fix fili-presto all time grain support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ pull request if there was one.
 Current
 -------
 ### Fixed:
+- [Fix: Fili-sql druid all time grain query support](https://github.com/yahoo/fili/issues/1140)
 
 - [Fix: Install python to support build tagging on new screwdriver image](https://github.com/yahoo/fili/issues/1132)
 

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/presto/PrestoSqlBackedClient.java
@@ -157,7 +157,7 @@ public class PrestoSqlBackedClient implements SqlBackedClient {
         }
 
         // Extract the timestamp column name.
-        String pat = ".*YEAR\\(\"(.*?)\"\\).*";
+        String pat = ".*WHERE\\s\"(.*?)\"\\s>=.*";
         Pattern pattern = Pattern.compile(pat, Pattern.DOTALL);
         Matcher matcher = pattern.matcher(sqlQuery);
 

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
@@ -12,14 +12,14 @@ class PrestoSqlBackedClientSpec extends Specification {
         expect:
         toPrestoQuery == """SELECT "source", SUBSTRING("datestamp",1,4) AS "\$f23", DAY_OF_YEAR(date_parse("datestamp",'%Y%m%d%H')) AS "\$f24", SUBSTRING("datestamp",9,2) AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" >= '201909011400000' AND "datestamp" <= '201909021400000' AND CAST("comment" AS varchar) <> '1=2====3' AND (CAST("advertiser_id" AS varchar) = '456' OR CAST("advertiser_id" AS varchar) = '123')
+WHERE "datestamp" >= '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) <> '1=2====3' AND (CAST("advertiser_id" AS varchar) = '456' OR CAST("advertiser_id" AS varchar) = '123')
 GROUP BY "source", SUBSTRING("datestamp",1,4), DAY_OF_YEAR(date_parse("datestamp",'%Y%m%d%H')), SUBSTRING("datestamp",9,2)
 ORDER BY SUBSTRING("datestamp",1,4) NULLS FIRST, DAY_OF_YEAR(date_parse("datestamp",'%Y%m%d%H')) NULLS FIRST, SUBSTRING("datestamp",9,2) NULLS FIRST, "source" NULLS FIRST"""
 
         where:
         sqlQuery << ["""SELECT "source", YEAR("datestamp") AS "\$f23", DAYOFYEAR("datestamp") AS "\$f24", HOUR("datestamp") AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" >= '201909011400000' AND "datestamp" <= '201909021400000' AND CAST("comment" AS varchar) <> '1=2====3' AND (CAST("advertiser_id" AS varchar) = '456' OR CAST("advertiser_id" AS varchar) = '123')
+WHERE "datestamp" >= '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) <> '1=2====3' AND (CAST("advertiser_id" AS varchar) = '456' OR CAST("advertiser_id" AS varchar) = '123')
 GROUP BY "source", YEAR("datestamp"), DAYOFYEAR("datestamp"), HOUR("datestamp")
 ORDER BY YEAR("datestamp") NULLS FIRST, DAYOFYEAR("datestamp") NULLS FIRST, HOUR("datestamp") NULLS FIRST, "source" NULLS FIRST"""]
     }

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/PrestoSqlBackedClientSpec.groovy
@@ -12,14 +12,14 @@ class PrestoSqlBackedClientSpec extends Specification {
         expect:
         toPrestoQuery == """SELECT "source", SUBSTRING("datestamp",1,4) AS "\$f23", DAY_OF_YEAR(date_parse("datestamp",'%Y%m%d%H')) AS "\$f24", SUBSTRING("datestamp",9,2) AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) <> '1=2====3' AND (CAST("advertiser_id" AS varchar) = '456' OR CAST("advertiser_id" AS varchar) = '123')
+WHERE "datestamp" >= '201909011400000' AND "datestamp" <= '201909021400000' AND CAST("comment" AS varchar) <> '1=2====3' AND (CAST("advertiser_id" AS varchar) = '456' OR CAST("advertiser_id" AS varchar) = '123')
 GROUP BY "source", SUBSTRING("datestamp",1,4), DAY_OF_YEAR(date_parse("datestamp",'%Y%m%d%H')), SUBSTRING("datestamp",9,2)
 ORDER BY SUBSTRING("datestamp",1,4) NULLS FIRST, DAY_OF_YEAR(date_parse("datestamp",'%Y%m%d%H')) NULLS FIRST, SUBSTRING("datestamp",9,2) NULLS FIRST, "source" NULLS FIRST"""
 
         where:
         sqlQuery << ["""SELECT "source", YEAR("datestamp") AS "\$f23", DAYOFYEAR("datestamp") AS "\$f24", HOUR("datestamp") AS "\$f25", SUM("revenue") AS "revenue"
 FROM "catalog"."schema"."table"
-WHERE "datestamp" > '201909011400000' AND "datestamp" < '201909021400000' AND CAST("comment" AS varchar) <> '1=2====3' AND (CAST("advertiser_id" AS varchar) = '456' OR CAST("advertiser_id" AS varchar) = '123')
+WHERE "datestamp" >= '201909011400000' AND "datestamp" <= '201909021400000' AND CAST("comment" AS varchar) <> '1=2====3' AND (CAST("advertiser_id" AS varchar) = '456' OR CAST("advertiser_id" AS varchar) = '123')
 GROUP BY "source", YEAR("datestamp"), DAYOFYEAR("datestamp"), HOUR("datestamp")
 ORDER BY YEAR("datestamp") NULLS FIRST, DAYOFYEAR("datestamp") NULLS FIRST, HOUR("datestamp") NULLS FIRST, "source" NULLS FIRST"""]
     }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Fix fili-presto all time grain support.
In case of all time grain queries, the translated sql query won't contain the expression `YEAR("timestampColumn")`. Use `WHERE "timestampColumn" >= 'date'` to extract timestamp column instead.