### PR TITLE
change access specifier for LoadTask.setFuture() method to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,8 @@ Current
    * Rationalized dependencies for sample applications
 
 - [Uses `addFactories` rather than `withFactories` in Luthier setup.](https://github.com/yahoo/fili/pull/991)
+
+- [Change the access specifier of LoadTask.setFuture to public](https://github.com/yahoo/fili/pull/1156)
    
 ### Removed:
 

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/application/LoadTask.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/application/LoadTask.java
@@ -110,7 +110,7 @@ public abstract class LoadTask<V> implements Runnable {
      *
      * @param future  The future to associate
      */
-    synchronized void setFuture(ScheduledFuture<?> future) {
+    public synchronized void setFuture(ScheduledFuture<?> future) {
         this.future = future;
     }
 


### PR DESCRIPTION
Fili Query Engine Work - Providing the Dependency Injection without the use of AbstractBinderFactory, we need to access LoadTask.setFuture method from outside the package.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
