### PR TITLE
The previous fix may have been insufficient if the result set uses zo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ Current
    * set default day of year to th 7th to guarantee correct calendar year resolution
    * added utility to `DruidAggregationQuery` to simplify mocking
 
+- [Update to fix for weekly rounding time grain on sql](https://github.com/yahoo/fili/issues/1221)
+  *  Moved from equality to acceptance.
 
 - [Made unstable rate limit test more stable](https://github.com/yahoo/fili/issues/1217)
    * Made sure shared state was cleared more accurately between runs.

--- a/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/helper/SqlTimeConverter.java
+++ b/fili-sql/src/main/java/com/yahoo/bard/webservice/sql/helper/SqlTimeConverter.java
@@ -11,11 +11,11 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.SECOND;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.WEEK;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.YEAR;
 
-import com.yahoo.bard.webservice.data.time.DefaultTimeGrain;
-import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
 import com.yahoo.bard.webservice.data.time.AllGranularity;
-import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
+import com.yahoo.bard.webservice.data.time.DefaultTimeGrain;
 import com.yahoo.bard.webservice.data.time.Granularity;
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain;
+import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery;
 
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlDatePartFunction;
@@ -214,7 +214,7 @@ public class SqlTimeConverter {
             throw new UnsupportedOperationException("Can't parse dateTime for if no times were grouped on.");
         }
 
-        int startDay = (DefaultTimeGrain.WEEK.equals(druidQuery.getGranularity())) ? 7 : 1;
+        int startDay = (druidQuery.getGranularity().satisfiedBy(DefaultTimeGrain.WEEK)) ? 7 : 1;
         MutableDateTime mutableDateTime = new MutableDateTime(0, 1, startDay, 0, 0, 0, 0, timeZone);
 
 

--- a/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/helper/SqlTimeConverterSpec.groovy
+++ b/fili-sql/src/test/groovy/com/yahoo/bard/webservice/sql/helper/SqlTimeConverterSpec.groovy
@@ -5,6 +5,8 @@ package com.yahoo.bard.webservice.sql.helper
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.WEEK
 import static org.joda.time.DateTimeZone.UTC
 
+import com.yahoo.bard.webservice.data.time.TimeGrain
+import com.yahoo.bard.webservice.data.time.ZonedTimeGrain
 import com.yahoo.bard.webservice.druid.model.query.DruidAggregationQuery
 
 import org.joda.time.DateTime
@@ -18,6 +20,25 @@ class SqlTimeConverterSpec extends Specification {
         DruidAggregationQuery druidQuery = Mock(DruidAggregationQuery)
         druidQuery.getTimeZone() >> UTC
         druidQuery.getGranularity() >> WEEK
+
+        SqlTimeConverter converter = new SqlTimeConverter()
+        String[] fields = Arrays.asList(year.toString(), week.toString()).toArray()
+
+
+        expect:
+        converter.getIntervalStart(0, fields, druidQuery).equals(time)
+
+        where:
+        time                            | year | week
+        new DateTime("2021-12-06", UTC) | 2021 | 49
+    }
+
+    def "GetIntervalStart with week of year and year on weekyears starting the prior year (zoned query)"() {
+        setup:
+        DruidAggregationQuery druidQuery = Mock(DruidAggregationQuery)
+        TimeGrain utcWeek = new ZonedTimeGrain(WEEK, UTC)
+        druidQuery.getTimeZone() >> UTC
+        druidQuery.getGranularity() >> utcWeek
 
         SqlTimeConverter converter = new SqlTimeConverter()
         String[] fields = Arrays.asList(year.toString(), week.toString()).toArray()


### PR DESCRIPTION
…ned timegrains.  this should address that.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
