### PR TITLE
Expanding and cleaning up weight check metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Current
 
 ### Added:
 
+-[Cleaner weight check fields and names](https://github.com/yahoo/fili/issues/1239)
+
 -[Total sketches and correct total lines in LogBlock](https://github.com/yahoo/fili/issues/1239)
   * Fixed total lines calculation
   * Added total sketch calculation

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/logging/blocks/BardQueryInfo.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/logging/blocks/BardQueryInfo.java
@@ -26,9 +26,10 @@ public class BardQueryInfo implements LogInfo {
     public static final String FACT_PUT_ERRORS = "factCachePutErrors";
     public static final String FACT_PUT_TIMEOUTS = "factCachePutTimeouts";
 
-    public static final String WEIGHT_CHECK_RAW_SKETCHES = "weightCheckRawSketches";
-    public static final String WEIGHT_CHECK_RAW_LINES = "weightCheckRawLines";
-    public static final String WEIGHT_CHECK_TOTAL_SKETCHES = "weightCheckTotalSketches";
+    public static final String WEIGHT_CHECK_LINES_OUTPUT = "weightCheckLinesOutput";
+    public static final String WEIGHT_CHECK_SKETCHES_OUTPUT = "weightCheckSketchesOutput";
+    public static final String WEIGHT_CHECK_SCANNED_LINES = "weightCheckLinesScanned";
+    public static final String WEIGHT_CHECK_SKETCHES_SCANNED = "weightCheckSketchesScanned";
 
     private final String type;
     private final AtomicLong weightCheckCount = new AtomicLong();
@@ -38,9 +39,10 @@ public class BardQueryInfo implements LogInfo {
     private final AtomicLong factPutTimeoutsCount = new AtomicLong();
     private final Map<String, BardCacheInfo> cacheStatsMap = new TreeMap<>();
 
-    private final AtomicLong rawSketches = new AtomicLong();
-    private final AtomicLong rawLines = new AtomicLong();
-    private final AtomicLong totalSketches = new AtomicLong();
+    private final AtomicLong sketchesScanned = new AtomicLong();
+    private final AtomicLong linesScanned = new AtomicLong();
+    private final AtomicLong sketchesOutput = new AtomicLong();
+    private final AtomicLong linesOutput = new AtomicLong();
 
     /**
      * Constructor.
@@ -68,9 +70,10 @@ public class BardQueryInfo implements LogInfo {
                 AbstractMap.SimpleImmutableEntry::getValue
         )));
         if (weightCheckCount.get() > 0) {
-            counters.put(WEIGHT_CHECK_RAW_SKETCHES, rawSketches);
-            counters.put(WEIGHT_CHECK_RAW_LINES, rawLines);
-            counters.put(WEIGHT_CHECK_TOTAL_SKETCHES, totalSketches);
+            counters.put(WEIGHT_CHECK_LINES_OUTPUT, linesOutput);
+            counters.put(WEIGHT_CHECK_SKETCHES_OUTPUT, sketchesOutput);
+            counters.put(WEIGHT_CHECK_SCANNED_LINES, linesScanned);
+            counters.put(WEIGHT_CHECK_SKETCHES_SCANNED, sketchesScanned);
         }
         return counters;
     }
@@ -115,30 +118,38 @@ public class BardQueryInfo implements LogInfo {
     }
 
     /**
-     * Increments the count of raw sketches.
+     * Increments the count of scanned sketches.
      *
      * @param addend  Amount of raw sketches to add.
      */
-    public static void accumulateWeightCheckRawSketches(long addend) {
-        getBardQueryInfo().rawSketches.getAndAdd(addend);
+    public static void accumulateSketchesScanned(long addend) {
+        getBardQueryInfo().sketchesScanned.getAndAdd(addend);
     }
 
     /**
-     * Increments the count of total sketches.
+     * Increments the count of scanned lines.
      *
      * @param addend  Amount of raw sketches to add.
      */
-    public static void accumulateWeightCheckTotalSketches(long addend) {
-        getBardQueryInfo().totalSketches.getAndAdd(addend);
+    public static void accumulateLinesScanned(long addend) {
+        getBardQueryInfo().linesScanned.getAndAdd(addend);
+    }
+    /**
+     * Increments the count of output sketches.
+     *
+     * @param addend  Amount of raw sketches to add.
+     */
+    public static void accumulateSketchesOutput(long addend) {
+        getBardQueryInfo().sketchesOutput.getAndAdd(addend);
     }
 
     /**
-     * Increments the count of raw lines aggregated over.
+     * Increments the count of output lines.
      *
      * @param addend  Amount of raw sketches to add.
      */
-    public static void accumulateWeightCheckRawLines(long addend) {
-        getBardQueryInfo().rawLines.getAndAdd(addend);
+    public static void accumulateLinesOutput(long addend) {
+        getBardQueryInfo().linesOutput.getAndAdd(addend);
     }
 
     /**

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandler.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandler.java
@@ -128,14 +128,21 @@ public class WeightCheckRequestHandler extends BaseDataRequestHandler {
                     JsonNode row = jsonResult.get(0);
                     // If the weight limit query is empty or reports acceptable rows, run the full query
                     if (row != null) {
-                        long rawSketchCount = row.get("event").get(WeightEvaluationQuery.RAW_SKETCHES).asLong();
-                        long rawLines = row.get("event").get(WeightEvaluationQuery.LINE_COUNT).asLong();
-                        long sketches = row.get("event").get(WeightEvaluationQuery.RESULT_SKETCHES).asLong();
-                        BardQueryInfo.accumulateWeightCheckRawSketches(rawSketchCount);
-                        BardQueryInfo.accumulateWeightCheckRawLines(rawLines);
-                        BardQueryInfo.accumulateWeightCheckTotalSketches(rawLines * rawSketchCount);
-                        if (sketches > queryRowLimit) {
-                            dispatchInsufficientStorage(response, druidQuery, sketches, queryRowLimit);
+                        long linesScanned = row.get("event").get(WeightEvaluationQuery.SCANNED_LINES).asLong();
+                        BardQueryInfo.accumulateLinesScanned(linesScanned);
+
+                        long resultSketchCount = row.get("event").get(WeightEvaluationQuery.OUTPUT_SKETCHES).asLong();
+                        BardQueryInfo.accumulateSketchesOutput(resultSketchCount);
+
+                        long linesOutput = row.get("event").get(WeightEvaluationQuery.OUTPUT_LINE_COUNT).asLong();
+                        BardQueryInfo.accumulateLinesOutput(linesOutput);
+
+                        int sketchesPerLine = row.get("event").get(WeightEvaluationQuery.SKETCHES_PER_ROW).asInt();
+
+                        BardQueryInfo.accumulateSketchesScanned(sketchesPerLine * linesScanned);
+
+                        if (resultSketchCount > queryRowLimit) {
+                            dispatchInsufficientStorage(response, druidQuery, resultSketchCount, queryRowLimit);
                             return;
                         }
                     }

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/BardQueryInfoSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/logging/blocks/BardQueryInfoSpec.groovy
@@ -40,15 +40,16 @@ class BardQueryInfoSpec extends Specification {
     def "BardQueryInfo with weight check is serialized correctly"() {
         when:
         BardQueryInfo.incrementCountWeightCheck()
-        BardQueryInfo.accumulateWeightCheckRawSketches(500L)
-        BardQueryInfo.accumulateWeightCheckRawLines(5000L)
-        BardQueryInfo.accumulateWeightCheckTotalSketches(5000L * 5)
+        BardQueryInfo.accumulateSketchesScanned( 5000 * 5)
+        BardQueryInfo.accumulateLinesScanned(5000L)
+        BardQueryInfo.accumulateLinesOutput(100)
+        BardQueryInfo.accumulateSketchesOutput(500L )
 
         then:
         new ObjectMappersSuite().jsonMapper.writeValueAsString(
                 bardQueryInfo
         ) == """{"type":"test","queryCounter":{"factCacheHits":0,"factCachePutErrors":0,"factCachePutTimeouts":0,"factQueryCount":0,""" +
-            """"weightCheckQueries":1,"weightCheckRawLines":5000,"weightCheckRawSketches":500,"weightCheckTotalSketches":25000},"cacheStats":[]}"""
+            """"weightCheckLinesOutput":100,"weightCheckLinesScanned":5000,"weightCheckQueries":1,"weightCheckSketchesOutput":500,"weightCheckSketchesScanned":25000},"cacheStats":[]}"""
     }
 
     @Ignore

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/endpoints/ErrorDataServletSpec.groovy
@@ -32,6 +32,7 @@ import com.yahoo.bard.webservice.data.dimension.BardDimensionField
 import com.yahoo.bard.webservice.data.dimension.DimensionDictionary
 import com.yahoo.bard.webservice.data.time.TimeGrain
 import com.yahoo.bard.webservice.druid.client.DruidServiceConfig
+import com.yahoo.bard.webservice.druid.model.query.WeightEvaluationQuery
 import com.yahoo.bard.webservice.models.druid.client.impl.TestDruidWebService
 import com.yahoo.bard.webservice.util.GroovyTestUtils
 import com.yahoo.bard.webservice.util.JsonSlurper
@@ -868,7 +869,12 @@ class ErrorDataServletSpec extends Specification {
         String description = ErrorMessageFormat.WEIGHT_CHECK_FAILED.format()
         String statusName = "507"
         String expectedJson = buildFailureJson( statusCode, statusName, reason, description)
-        testWebService.weightResponse = """[{"version":"v1","timestamp":"2014-09-01T00:00:00.000Z","event":{"resultSketches":30000, "rawSketches": 300, "lines":100}}]"""
+        testWebService.
+                weightResponse = """[{"version":"v1","timestamp":"2014-09-01T00:00:00.000Z",
+                "event":{"${WeightEvaluationQuery.OUTPUT_SKETCHES}":30000,
+                "${WeightEvaluationQuery.SCANNED_LINES}": 1000,
+                "${WeightEvaluationQuery.SKETCHES_PER_ROW}": 300,
+                "${WeightEvaluationQuery.OUTPUT_LINE_COUNT}":100}}]"""
         testWebService.setFailure(statusCode, statusName, reason, description)
 
         // create 10 dimensionRows per dimension to get past worst case estimate
@@ -909,7 +915,12 @@ class ErrorDataServletSpec extends Specification {
         String description = ErrorMessageFormat.WEIGHT_CHECK_FAILED.format()
         String statusName = "507"
         String expectedJson = buildFailureJson(statusCode, statusName, reason, description)
-        testWebService.weightResponse = """[{"version":"v1","timestamp":"2014-09-01T00:00:00.000Z","event":{"resultSketches":429820, "lines": 42982, "rawSketches":10}}]"""
+        testWebService.weightResponse = """[{"version":"v1","timestamp":"2014-09-01T00:00:00.000Z",
+                "event":{"${WeightEvaluationQuery.OUTPUT_SKETCHES}":429820,
+                "${WeightEvaluationQuery.SCANNED_LINES}": 1000,
+                "${WeightEvaluationQuery.SKETCHES_PER_ROW}": 10,
+                "${WeightEvaluationQuery.OUTPUT_LINE_COUNT}":42982}}]"""
+
         testWebService.setFailure(statusCode, statusName, reason, description)
 
         // create 10 dimensionRows per dimension to get past worst case estimate

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandlerSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/handlers/WeightCheckRequestHandlerSpec.groovy
@@ -198,9 +198,10 @@ class WeightCheckRequestHandlerSpec extends Specification {
             "version" : "v1",
             "timestamp" : "2012-01-01T00:00:00.000Z",
             "event" : {
-                "resultSketches" : "$expectedCount",
-                "lines" : 100,
-                "rawSketches" : 100
+                "${WeightEvaluationQuery.OUTPUT_SKETCHES}" : "$expectedCount",
+                "${WeightEvaluationQuery.OUTPUT_LINE_COUNT}" : 100,
+                "${WeightEvaluationQuery.SCANNED_LINES}" : 10000,
+                "${WeightEvaluationQuery.SKETCHES_PER_ROW}" : 100
             }
         } ]
         """
@@ -236,9 +237,10 @@ class WeightCheckRequestHandlerSpec extends Specification {
             "version" : "v1",
             "timestamp" : "2012-01-01T00:00:00.000Z",
             "event" : {
-                "resultSketches" : "$expectedCount",
-                "rawSketches":    10,
-                "lines":    100
+                "${WeightEvaluationQuery.OUTPUT_SKETCHES}" : "$expectedCount",
+                "${WeightEvaluationQuery.OUTPUT_LINE_COUNT}" : 100,
+                "${WeightEvaluationQuery.SCANNED_LINES}" : 10000,
+                "${WeightEvaluationQuery.SKETCHES_PER_ROW}" : 10
             }
         } ]
         """


### PR DESCRIPTION
Four corner metrics establish lines scanned, returned, sketches scanned, returned.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
