### PR TITLE
Renaming 'isUI' to 'useExtended...' and 'uiMeter' to 'extended meter'

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/RateLimitFilter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/filters/RateLimitFilter.java
@@ -80,7 +80,7 @@ public class RateLimitFilter implements ContainerRequestFilter, ContainerRespons
             if (token.isBound()) {
                 request.setProperty(PROPERTY_TOKEN, token);
             } else {
-                String msg = String.format("Rate limit reached. Reject %s", uri.toString());
+                String msg = String.format("Rate limit reached. %s Reject %s", token.getMessage(), uri.toString());
                 LOG.debug(msg);
                 RequestLog.stopTiming(this);
                 request.abortWith(Response.status(RATE_LIMIT).entity(msg).build());

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ratelimit/BypassRateLimitRequestToken.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ratelimit/BypassRateLimitRequestToken.java
@@ -13,6 +13,11 @@ public class BypassRateLimitRequestToken implements RateLimitRequestToken {
     }
 
     @Override
+    public String getMessage() {
+        return "Bypass token";
+    }
+
+    @Override
     public boolean bind() {
         return true;
     }

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ratelimit/CallbackRateLimitRequestToken.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ratelimit/CallbackRateLimitRequestToken.java
@@ -14,6 +14,7 @@ public class CallbackRateLimitRequestToken implements RateLimitRequestToken {
 
     private final RateLimitCleanupOnRequestComplete rateLimitCleanup;
     private boolean isBound;
+    private String message;
 
     /**
      * Constructor.
@@ -24,11 +25,34 @@ public class CallbackRateLimitRequestToken implements RateLimitRequestToken {
     public CallbackRateLimitRequestToken(boolean isBound, RateLimitCleanupOnRequestComplete rateLimitCleanup) {
         this.rateLimitCleanup = rateLimitCleanup;
         this.isBound = isBound;
+        this.message = "";
     }
 
+
+    /**
+     * Constructor.
+     *
+     * @param isBound  Indicate whether or not the request associated with this token is valid (bound) or not
+     * @param rateLimitCleanup  The callback for cleaning up after the request associated with this token is complete
+     * @param message A message to display when logging this token.
+     */
+    public CallbackRateLimitRequestToken(
+            boolean isBound,
+            RateLimitCleanupOnRequestComplete rateLimitCleanup,
+            String message
+    ) {
+        this.rateLimitCleanup = rateLimitCleanup;
+        this.isBound = isBound;
+        this.message = message;
+    }
     @Override
     public boolean isBound() {
         return isBound;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
     }
 
     @Override

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ratelimit/DefaultRateLimiter.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ratelimit/DefaultRateLimiter.java
@@ -33,8 +33,13 @@ import javax.ws.rs.core.SecurityContext;
 public class DefaultRateLimiter implements RateLimiter {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultRateLimiter.class);
     protected static final SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
+
     protected static final RateLimitRequestToken REJECT_REQUEST_TOKEN =
-            new CallbackRateLimitRequestToken(false, () -> { });
+            new CallbackRateLimitRequestToken(false, () -> { }, "Exceeded user request limit.");
+
+    protected static final RateLimitRequestToken GLOBAL_REJECT_REQUEST_TOKEN =
+            new CallbackRateLimitRequestToken(false, () -> { }, "Global request limit exceeded.");
+
     protected static final RateLimitRequestToken BYPASS_TOKEN =
             new BypassRateLimitRequestToken();
 
@@ -43,13 +48,13 @@ public class DefaultRateLimiter implements RateLimiter {
             SYSTEM_CONFIG.getPackageVariableName("request_limit_global");
     protected static final @NotNull String REQUEST_LIMIT_PER_USER_KEY =
             SYSTEM_CONFIG.getPackageVariableName("request_limit_per_user");
-    protected static final @NotNull String REQUEST_LIMIT_UI_KEY =
+    protected static final @NotNull String EXTENDED_RATE_LIMIT_KEY =
             SYSTEM_CONFIG.getPackageVariableName("request_limit_ui");
 
     // Default values
     protected static final int DEFAULT_REQUEST_LIMIT_GLOBAL = 70;
     protected static final int DEFAULT_REQUEST_LIMIT_PER_USER = 2;
-    protected static final int DEFAULT_REQUEST_LIMIT_UI = 52;
+    protected static final int DEFAULT_REQUEST_LIMIT_EXTENDED = 52;
 
     protected static final MetricRegistry REGISTRY = MetricRegistryFactory.getRegistry();
 
@@ -58,7 +63,7 @@ public class DefaultRateLimiter implements RateLimiter {
     // Request limits
     protected final int requestLimitGlobal;
     protected final int requestLimitPerUser;
-    protected final int requestLimitUi;
+    protected final int requestLimitExtended;
 
     // Live count holders
     protected final AtomicInteger globalCount = new AtomicInteger();
@@ -68,9 +73,9 @@ public class DefaultRateLimiter implements RateLimiter {
     protected final Counter usersCounter;
 
     protected final Meter requestBypassMeter;
-    protected final Meter requestUiMeter;
+    protected final Meter requestExtendedMeter;
     protected final Meter requestUserMeter;
-    protected final Meter rejectUiMeter;
+    protected final Meter rejectExtendedMeter;
     protected final Meter rejectUserMeter;
 
     /**
@@ -82,7 +87,7 @@ public class DefaultRateLimiter implements RateLimiter {
         // Load limits
         requestLimitGlobal = SYSTEM_CONFIG.getIntProperty(REQUEST_LIMIT_GLOBAL_KEY, DEFAULT_REQUEST_LIMIT_GLOBAL);
         requestLimitPerUser = SYSTEM_CONFIG.getIntProperty(REQUEST_LIMIT_PER_USER_KEY, DEFAULT_REQUEST_LIMIT_PER_USER);
-        requestLimitUi = SYSTEM_CONFIG.getIntProperty(REQUEST_LIMIT_UI_KEY, DEFAULT_REQUEST_LIMIT_UI);
+        requestLimitExtended = SYSTEM_CONFIG.getIntProperty(EXTENDED_RATE_LIMIT_KEY, DEFAULT_REQUEST_LIMIT_EXTENDED);
 
         // Register counters for currently active requests
         usersCounter = REGISTRY.counter("ratelimit.count.users");
@@ -90,22 +95,22 @@ public class DefaultRateLimiter implements RateLimiter {
 
         // Register meters for number of requests
         requestUserMeter = REGISTRY.meter("ratelimit.meter.request.user");
-        requestUiMeter = REGISTRY.meter("ratelimit.meter.request.ui");
+        requestExtendedMeter = REGISTRY.meter("ratelimit.meter.request.ui");
         requestBypassMeter = REGISTRY.meter("ratelimit.meter.request.bypass");
         rejectUserMeter = REGISTRY.meter("ratelimit.meter.reject.user");
-        rejectUiMeter = REGISTRY.meter("ratelimit.meter.reject.ui");
+        rejectExtendedMeter = REGISTRY.meter("ratelimit.meter.reject.ui");
     }
 
     /**
      * Get the current count for this username. If user does not have a counter, create one.
      *
      * @param request  The request context
-     * @param isUIQuery  Flag to check if it is a UI query
+     * @param isExtendedLimitQuery  Flag to check if it is a query with the extended rate limit
      * @param userName  Username to get the count for
      *
      * @return The atomic count for the user
      */
-    protected AtomicInteger getCount(ContainerRequestContext request, boolean isUIQuery, String userName) {
+    protected AtomicInteger getCount(ContainerRequestContext request, boolean isExtendedLimitQuery, String userName) {
         AtomicInteger count = userCounts.get(userName);
 
         // Create a counter if we don't have one yet
@@ -142,12 +147,17 @@ public class DefaultRateLimiter implements RateLimiter {
      *
      * @param rejectMeter  Meter to count the rejection in
      * @param isRejectGlobal  Whether or not the rejection is on the global rate limit
-     * @param isUIQuery  Whether or not the request is a UI Query
+     * @param isExtendedRateLimit  Whether or not the request is a UI Query
      * @param userName  Username of the user who made the request
      */
-    protected void rejectRequest(Meter rejectMeter, boolean isRejectGlobal, boolean isUIQuery, String userName) {
+    protected void rejectRequest(
+            Meter rejectMeter,
+            boolean isRejectGlobal,
+            boolean isExtendedRateLimit,
+            String userName
+    ) {
         rejectMeter.mark();
-        String limitType = isRejectGlobal ? "GLOBAL" : isUIQuery ? "UI" : "USER";
+        String limitType = isRejectGlobal ? "GLOBAL" : isExtendedRateLimit ? "UI" : "USER";
         LOG.info("{} limit {}", limitType, userName);
     }
 
@@ -167,15 +177,16 @@ public class DefaultRateLimiter implements RateLimiter {
         Principal user = securityContext == null ? null : securityContext.getUserPrincipal();
         String userName = String.valueOf(user == null ? null : user.getName());
 
-        boolean isUIQuery = DataApiRequestTypeIdentifier.isUi(headers);
+        // Extended rate limits support cases such as dashboard UI views
+        boolean isUIQuery = useExtendedRateLimit(headers);
         Meter requestMeter;
         Meter rejectMeter;
         int requestLimit;
 
         if (isUIQuery) {
-            requestMeter = requestUiMeter;
-            rejectMeter = rejectUiMeter;
-            requestLimit = requestLimitUi;
+            requestMeter = requestExtendedMeter;
+            rejectMeter = rejectExtendedMeter;
+            requestLimit = requestLimitExtended;
         } else {
             requestMeter = requestUserMeter;
             rejectMeter = rejectUserMeter;
@@ -183,7 +194,27 @@ public class DefaultRateLimiter implements RateLimiter {
         }
 
         AtomicInteger count = getCount(request, isUIQuery, userName);
-        return createNewRateLimitRequestToken(count, userName, isUIQuery, requestLimit, requestMeter, rejectMeter);
+        return createNewRateLimitRequestToken(
+                count,
+                userName,
+                isUIQuery,
+                request,
+                requestLimit,
+                requestMeter,
+                rejectMeter
+        );
+    }
+
+    /**
+     * Check if the extended rate limit should be used.
+     *
+     * @param headers Request headers to use to understand the request.
+     *
+     * @return true if the extended rate limit should be applied.
+     */
+    protected boolean useExtendedRateLimit(final MultivaluedMap<String, String> headers) {
+        boolean isUIQuery = DataApiRequestTypeIdentifier.isUi(headers);
+        return isUIQuery;
     }
 
     /**
@@ -191,7 +222,8 @@ public class DefaultRateLimiter implements RateLimiter {
      *
      * @param count  The atomic reference that holds the amount of in-flight requests the user owns
      * @param userName  The user who launched the request
-     * @param isUIQuery  Whether or not this query was generated from the UI
+     * @param useExtendedRateLimit  Whether or not this query was generated from the UI
+     * @param request  The request associated with this token
      * @param requestLimit  The limit of requests the user is allowed to launch
      * @param requestMeter  Meter tracking the amount of requests that have been launched
      * @param rejectMeter  Meter tracking the amount of requests that have been rejected
@@ -199,20 +231,42 @@ public class DefaultRateLimiter implements RateLimiter {
      * @return a new RateLimitRequestToken, representing an in-flight (or rejected) request that is tracked by the
      * RateLimiter
      */
-    protected RateLimitRequestToken createNewRateLimitRequestToken(AtomicInteger count, String userName,
-            boolean isUIQuery, int requestLimit, Meter requestMeter, Meter rejectMeter) {
+    protected RateLimitRequestToken createNewRateLimitRequestToken(
+            AtomicInteger count,
+            String userName,
+            boolean useExtendedRateLimit,
+            ContainerRequestContext request,
+            int requestLimit,
+            Meter requestMeter,
+            Meter rejectMeter
+    ) {
         if (!incrementAndCheckCount(globalCount, requestLimitGlobal)) {
-            rejectRequest(rejectMeter, true, isUIQuery, userName);
-            return REJECT_REQUEST_TOKEN;
+            rejectRequest(rejectMeter, true, useExtendedRateLimit, userName);
+            return getGlobalRateLimitExceededRequestToken(
+                    count,
+                    userName,
+                    useExtendedRateLimit,
+                    request,
+                    requestLimit,
+                    requestMeter,
+                    rejectMeter
+            );
         }
-
 
         // Bind to the user
         if (!incrementAndCheckCount(count, requestLimit)) {
             // Decrement the global count that had already been incremented
             globalCount.decrementAndGet();
-            rejectRequest(rejectMeter, false, isUIQuery, userName);
-            return REJECT_REQUEST_TOKEN;
+            rejectRequest(rejectMeter, false, useExtendedRateLimit, userName);
+            return getPersonalRateLimitExceededRequestToken(
+                    count,
+                    userName,
+                    useExtendedRateLimit,
+                    request,
+                    requestLimit,
+                    requestMeter,
+                    rejectMeter
+            );
         }
 
         // Measure the accepted request and current open connections
@@ -220,8 +274,86 @@ public class DefaultRateLimiter implements RateLimiter {
         requestGlobalCounter.inc();
 
         // Return new request token
-        RateLimitCleanupOnRequestComplete callback = generateCleanupClosure(count, userName);
+        RateLimitCleanupOnRequestComplete callback = generateCleanupClosure(count, userName, request);
         return new CallbackRateLimitRequestToken(true, callback);
+    }
+
+    /**
+     * The token to reflect global rate limiting.
+     * (Added to encourage extension in subclasses.)
+     *
+     * @param count  The atomic reference that holds the amount of in-flight requests the user owns
+     * @param userName  The user who launched the request
+     * @param useExtendedRateLimit  Whether or not this query was generated from the UI
+     * @param request  The request associated with this token
+     * @param requestLimit  The limit of requests the user is allowed to launch
+     * @param requestMeter  Meter tracking the amount of requests that have been launched
+     * @param rejectMeter  Meter tracking the amount of requests that have been rejected
+     *
+     * @return A token that indicates global request limits are full.
+     */
+    protected RateLimitRequestToken getPersonalRateLimitExceededRequestToken(
+            AtomicInteger count,
+            String userName,
+            boolean useExtendedRateLimit,
+            ContainerRequestContext request,
+            int requestLimit,
+            Meter requestMeter,
+            Meter rejectMeter
+    ) {
+        return REJECT_REQUEST_TOKEN;
+    }
+
+    /**
+     * The token to reflect global rate limiting.
+     * (Added to encourage extension in subclasses.)
+     *
+     * @param count  The atomic reference that holds the amount of in-flight requests the user owns
+     * @param userName  The user who launched the request
+     * @param useExtendedRateLimit  Whether or not this query was generated from the UI
+     * @param request  The request associated with this token
+     * @param requestLimit  The limit of requests the user is allowed to launch
+     * @param requestMeter  Meter tracking the amount of requests that have been launched
+     * @param rejectMeter  Meter tracking the amount of requests that have been rejected
+     *
+     * @return A token that indicates global request limits are full.
+     */
+    protected RateLimitRequestToken getGlobalRateLimitExceededRequestToken(
+            AtomicInteger count,
+            String userName,
+            boolean useExtendedRateLimit,
+            ContainerRequestContext request,
+            int requestLimit,
+            Meter requestMeter,
+            Meter rejectMeter
+    ) {
+        return GLOBAL_REJECT_REQUEST_TOKEN;
+    }
+
+    /**
+     * The token to reflect global rate limiting.
+     * (Added to encourage extension in subclasses.)
+     *
+     * @param count  The atomic reference that holds the amount of in-flight requests the user owns
+     * @param userName  The user who launched the request
+     * @param useExtendedRateLimit  Whether or not this query was generated from the UI
+     * @param request  The request associated with this token
+     * @param requestLimit  The limit of requests the user is allowed to launch
+     * @param requestMeter  Meter tracking the amount of requests that have been launched
+     * @param rejectMeter  Meter tracking the amount of requests that have been rejected
+     *
+     * @return A token that indicates global request limits are full.
+     */
+    protected RateLimitRequestToken getPersonalRateLimitToken(
+            AtomicInteger count,
+            String userName,
+            boolean useExtendedRateLimit,
+            ContainerRequestContext request,
+            int requestLimit,
+            Meter requestMeter,
+            Meter rejectMeter
+    ) {
+        return REJECT_REQUEST_TOKEN;
     }
 
     /**
@@ -230,10 +362,15 @@ public class DefaultRateLimiter implements RateLimiter {
      *
      * @param count  The AtomicInteger that stores the amount of in-flight requests an individual user owns
      * @param userName  The name of the user that made the request
+     * @param request The request being wrapped
      *
      * @return A callback implementation to be given to a CallbackRateLimitRequestToken
      */
-    protected RateLimitCleanupOnRequestComplete generateCleanupClosure(AtomicInteger count, String userName) {
+    protected RateLimitCleanupOnRequestComplete generateCleanupClosure(
+            AtomicInteger count,
+            String userName,
+            ContainerRequestContext request
+    ) {
         return () -> {
             if (globalCount.decrementAndGet() < 0) {
                 // Reset to 0 if it falls below 0

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/ratelimit/RateLimitRequestToken.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/ratelimit/RateLimitRequestToken.java
@@ -17,6 +17,13 @@ public interface RateLimitRequestToken extends Closeable {
     boolean isBound();
 
     /**
+     * Retrieve a message (if any) about this token.
+     *
+     * @return a message about this token
+     */
+    String getMessage();
+
+    /**
      * Bind the counters to the token.
      *
      * @return true if the token was able to be bound or is already bounf, or false if rejected.

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/RateLimitFilterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/filters/RateLimitFilterSpec.groovy
@@ -36,13 +36,13 @@ class RateLimitFilterSpec extends Specification {
     static void setDefaults() {
         originalGlobalLimit = systemConfig.setProperty(DefaultRateLimiter.REQUEST_LIMIT_GLOBAL_KEY, LIMIT_GLOBAL as String)
         originalUserLimit = systemConfig.setProperty(DefaultRateLimiter.REQUEST_LIMIT_PER_USER_KEY, LIMIT_PER_USER as String)
-        originalUiLimit = systemConfig.setProperty(DefaultRateLimiter.REQUEST_LIMIT_UI_KEY, LIMIT_UI as String)
+        originalUiLimit = systemConfig.setProperty(DefaultRateLimiter.EXTENDED_RATE_LIMIT_KEY, LIMIT_UI as String)
     }
 
     static void clearDefaults() {
         systemConfig.resetProperty(DefaultRateLimiter.REQUEST_LIMIT_GLOBAL_KEY, originalGlobalLimit)
         systemConfig.resetProperty(DefaultRateLimiter.REQUEST_LIMIT_PER_USER_KEY, originalUserLimit)
-        systemConfig.resetProperty(DefaultRateLimiter.REQUEST_LIMIT_UI_KEY, originalUiLimit)
+        systemConfig.resetProperty(DefaultRateLimiter.EXTENDED_RATE_LIMIT_KEY, originalUiLimit)
     }
 
     def setupSpec() {
@@ -63,7 +63,7 @@ class RateLimitFilterSpec extends Specification {
                 it.dec(it.count)
                 assert it.count == 0
             }
-            [requestBypassMeter, requestUiMeter, requestUserMeter, rejectUiMeter, rejectUserMeter].each {
+            [requestBypassMeter, requestExtendedMeter, requestUserMeter, rejectExtendedMeter, rejectUserMeter].each {
                 it.mark(-it.count)
                 assert it.count == 0
             }
@@ -128,7 +128,7 @@ class RateLimitFilterSpec extends Specification {
         expect:
         TestRateLimitFilter.instance.rateLimiter.requestLimitGlobal == LIMIT_GLOBAL
         TestRateLimitFilter.instance.rateLimiter.requestLimitPerUser == LIMIT_PER_USER
-        TestRateLimitFilter.instance.rateLimiter.requestLimitUi == LIMIT_UI
+        TestRateLimitFilter.instance.rateLimiter.requestLimitExtended == LIMIT_UI
     }
 
     def "User limit reached"() {
@@ -139,9 +139,9 @@ class RateLimitFilterSpec extends Specification {
         TestRateLimitFilter.instance.rateLimiter.globalCount.get() == 0
         TestRateLimitFilter.instance.rateLimiter.requestGlobalCounter.count == LIMIT_PER_USER
         TestRateLimitFilter.instance.rateLimiter.requestBypassMeter.count == 0
-        TestRateLimitFilter.instance.rateLimiter.requestUiMeter.count == 0
+        TestRateLimitFilter.instance.rateLimiter.requestExtendedMeter.count == 0
         TestRateLimitFilter.instance.rateLimiter.requestUserMeter.count == LIMIT_PER_USER
-        TestRateLimitFilter.instance.rateLimiter.rejectUiMeter.count == 0
+        TestRateLimitFilter.instance.rateLimiter.rejectExtendedMeter.count == 0
         TestRateLimitFilter.instance.rateLimiter.rejectUserMeter.count == 12 - LIMIT_PER_USER
 
         TestMultiAccess.ok.get() + TestMultiAccess.fail.get() == 12
@@ -163,9 +163,9 @@ class RateLimitFilterSpec extends Specification {
         TestRateLimitFilter.instance.rateLimiter.globalCount.get() == 0
         TestRateLimitFilter.instance.rateLimiter.requestGlobalCounter.count == 20
         TestRateLimitFilter.instance.rateLimiter.requestBypassMeter.count == 0
-        TestRateLimitFilter.instance.rateLimiter.requestUiMeter.count == 0
+        TestRateLimitFilter.instance.rateLimiter.requestExtendedMeter.count == 0
         TestRateLimitFilter.instance.rateLimiter.requestUserMeter.count == 20
-        TestRateLimitFilter.instance.rateLimiter.rejectUiMeter.count == 0
+        TestRateLimitFilter.instance.rateLimiter.rejectExtendedMeter.count == 0
         TestRateLimitFilter.instance.rateLimiter.rejectUserMeter.count == 0
 
         TestMultiAccess.fail.get() == 0
@@ -184,9 +184,9 @@ class RateLimitFilterSpec extends Specification {
         TestRateLimitFilter.instance.rateLimiter.globalCount.get() == 0
         TestRateLimitFilter.instance.rateLimiter.requestGlobalCounter.count == LIMIT_GLOBAL
         TestRateLimitFilter.instance.rateLimiter.requestBypassMeter.count == 0
-        TestRateLimitFilter.instance.rateLimiter.requestUiMeter.count == 0
+        TestRateLimitFilter.instance.rateLimiter.requestExtendedMeter.count == 0
         TestRateLimitFilter.instance.rateLimiter.requestUserMeter.count == LIMIT_GLOBAL
-        TestRateLimitFilter.instance.rateLimiter.rejectUiMeter.count == 0
+        TestRateLimitFilter.instance.rateLimiter.rejectExtendedMeter.count == 0
         TestRateLimitFilter.instance.rateLimiter.rejectUserMeter.count == 30 - LIMIT_GLOBAL
 
         threads.size() == 30
@@ -227,9 +227,9 @@ class RateLimitFilterSpec extends Specification {
         TestRateLimitFilter.instance.rateLimiter.globalCount.get() == 0
         TestRateLimitFilter.instance.rateLimiter.requestGlobalCounter.count == LIMIT_UI
         TestRateLimitFilter.instance.rateLimiter.requestBypassMeter.count == 0
-        TestRateLimitFilter.instance.rateLimiter.requestUiMeter.count == LIMIT_UI
+        TestRateLimitFilter.instance.rateLimiter.requestExtendedMeter.count == LIMIT_UI
         TestRateLimitFilter.instance.rateLimiter.requestUserMeter.count == 0
-        TestRateLimitFilter.instance.rateLimiter.rejectUiMeter.count == 20 - LIMIT_UI
+        TestRateLimitFilter.instance.rateLimiter.rejectExtendedMeter.count == 20 - LIMIT_UI
         TestRateLimitFilter.instance.rateLimiter.rejectUserMeter.count == 0
 
         TestMultiAccess.ok.get() + TestMultiAccess.fail.get() == 20
@@ -245,9 +245,9 @@ class RateLimitFilterSpec extends Specification {
         TestRateLimitFilter.instance.rateLimiter.globalCount.get() == 0
         TestRateLimitFilter.instance.rateLimiter.requestGlobalCounter.count == 0
         TestRateLimitFilter.instance.rateLimiter.requestBypassMeter.count == 30
-        TestRateLimitFilter.instance.rateLimiter.requestUiMeter.count == 0
+        TestRateLimitFilter.instance.rateLimiter.requestExtendedMeter.count == 0
         TestRateLimitFilter.instance.rateLimiter.requestUserMeter.count == 0
-        TestRateLimitFilter.instance.rateLimiter.rejectUiMeter.count == 0
+        TestRateLimitFilter.instance.rateLimiter.rejectExtendedMeter.count == 0
         TestRateLimitFilter.instance.rateLimiter.rejectUserMeter.count == 0
 
         TestOptions.ok.get() + TestOptions.fail.get() == 30

--- a/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ratelimit/DefaultRateLimiterSpec.groovy
+++ b/fili-core/src/test/groovy/com/yahoo/bard/webservice/web/ratelimit/DefaultRateLimiterSpec.groovy
@@ -57,7 +57,7 @@ class DefaultRateLimiterSpec extends Specification {
         // reset metrics to 0
         rateLimiter.with {
             [requestGlobalCounter, usersCounter].each { it.dec(it.count) }
-            [requestBypassMeter, requestUiMeter, requestUserMeter, rejectUiMeter, rejectUserMeter].each {
+            [requestBypassMeter, requestExtendedMeter, requestUserMeter, rejectExtendedMeter, rejectUserMeter].each {
                 it.mark(-it.count)
             }
         }
@@ -86,9 +86,9 @@ class DefaultRateLimiterSpec extends Specification {
         rateLimiter.requestGlobalCounter.count == 0
         rateLimiter.usersCounter.count == 0
         rateLimiter.requestBypassMeter.count == 1
-        rateLimiter.requestUiMeter.count == 0
+        rateLimiter.requestExtendedMeter.count == 0
         rateLimiter.requestUserMeter.count == 0
-        rateLimiter.rejectUiMeter.count == 0
+        rateLimiter.rejectExtendedMeter.count == 0
         rateLimiter.rejectUserMeter.count == 0
     }
 
@@ -106,9 +106,9 @@ class DefaultRateLimiterSpec extends Specification {
         rateLimiter.requestGlobalCounter.count == 0
         rateLimiter.usersCounter.count == 0
         rateLimiter.requestBypassMeter.count == 1
-        rateLimiter.requestUiMeter.count == 0
+        rateLimiter.requestExtendedMeter.count == 0
         rateLimiter.requestUserMeter.count == 0
-        rateLimiter.rejectUiMeter.count == 0
+        rateLimiter.rejectExtendedMeter.count == 0
         rateLimiter.rejectUserMeter.count == 0
     }
 
@@ -121,9 +121,9 @@ class DefaultRateLimiterSpec extends Specification {
         rateLimiter.requestGlobalCounter.count == 1
         rateLimiter.usersCounter.count == 1
         rateLimiter.requestBypassMeter.count == 0
-        rateLimiter.requestUiMeter.count == 0
+        rateLimiter.requestExtendedMeter.count == 0
         rateLimiter.requestUserMeter.count == 1
-        rateLimiter.rejectUiMeter.count == 0
+        rateLimiter.rejectExtendedMeter.count == 0
         rateLimiter.rejectUserMeter.count == 0
     }
 
@@ -141,9 +141,9 @@ class DefaultRateLimiterSpec extends Specification {
         rateLimiter.requestGlobalCounter.count == 1
         rateLimiter.usersCounter.count == 1
         rateLimiter.requestBypassMeter.count == 0
-        rateLimiter.requestUiMeter.count == 1
+        rateLimiter.requestExtendedMeter.count == 1
         rateLimiter.requestUserMeter.count == 0
-        rateLimiter.rejectUiMeter.count == 0
+        rateLimiter.rejectExtendedMeter.count == 0
         rateLimiter.rejectUserMeter.count == 0
     }
 
@@ -185,13 +185,13 @@ class DefaultRateLimiterSpec extends Specification {
         rateLimiter.requestBypassMeter.count == 0
 
         and: "We have not allowed any UI requests"
-        rateLimiter.requestUiMeter.count == 0
+        rateLimiter.requestExtendedMeter.count == 0
 
         and: "We have allowed the per-user limit of user requests"
         rateLimiter.requestUserMeter.count == RateLimitFilterSpec.LIMIT_PER_USER
 
         and: "We have not rejected any UI requests"
-        rateLimiter.rejectUiMeter.count == 0
+        rateLimiter.rejectExtendedMeter.count == 0
 
         and: "We have rejected the global limit of requests except for the per-user limit that we had allowed"
         rateLimiter.rejectUserMeter.count == RateLimitFilterSpec.LIMIT_GLOBAL-RateLimitFilterSpec.LIMIT_PER_USER
@@ -220,9 +220,9 @@ class DefaultRateLimiterSpec extends Specification {
         rateLimiter.globalCount.get() == 0
         rateLimiter.requestGlobalCounter.count == 1
         rateLimiter.requestBypassMeter.count == 0
-        rateLimiter.requestUiMeter.count == 0
+        rateLimiter.requestExtendedMeter.count == 0
         rateLimiter.requestUserMeter.count == 1
-        rateLimiter.rejectUiMeter.count == 0
+        rateLimiter.rejectExtendedMeter.count == 0
         rateLimiter.rejectUserMeter.count == 0
     }
 
@@ -242,9 +242,9 @@ class DefaultRateLimiterSpec extends Specification {
         rateLimiter.globalCount.get() == 0
         rateLimiter.requestGlobalCounter.count == 1
         rateLimiter.requestBypassMeter.count == 0
-        rateLimiter.requestUiMeter.count == 0
+        rateLimiter.requestExtendedMeter.count == 0
         rateLimiter.requestUserMeter.count == 1
-        rateLimiter.rejectUiMeter.count == 0
+        rateLimiter.rejectExtendedMeter.count == 0
         rateLimiter.rejectUserMeter.count == 0
     }
 
@@ -270,9 +270,9 @@ class DefaultRateLimiterSpec extends Specification {
         rateLimiter.globalCount.get() == 0
         rateLimiter.requestGlobalCounter.count == 1
         rateLimiter.requestBypassMeter.count == 0
-        rateLimiter.requestUiMeter.count == 0
+        rateLimiter.requestExtendedMeter.count == 0
         rateLimiter.requestUserMeter.count == 1
-        rateLimiter.rejectUiMeter.count == 0
+        rateLimiter.rejectExtendedMeter.count == 0
         rateLimiter.rejectUserMeter.count == 0
     }
 }


### PR DESCRIPTION
##  **Design implementation for updating DigitRateLimiter**

### Fili changes:
	Add _ContainerRequestContext_ to methods which create RateLimitTokens and RateLimitCallbacks
	Add message to the Token so that rate limit failure messages can be extended.
	

### Digits Changes:
	Subclass  _CallbackRateLimitRequestToken_ to hold a reference to the request and the original thread id
		Add a _hashCode_() that does something reasonable like hashes username and original thread id

	Add to _DigitsRateLimiter_ a  ConcurrentHashMap from user id to a set of tokens.  
		Perhaps a _CopyOnWriteArraySet_. 
		Or possibly _Collections.synchronizedSet_ or _ConcurrentHashMap_ keyed by threadId
		Possibly WeakReferences to tokens to prevent leaks on thread death

		Have the 'unbind' method in the token remove the token from the user's Set of tokens.

	Add messaging to User Limit Reject tokens to indicate personal URIs that are in flight.

	Add logging to Global Limit Reject Tokens to indicate the global total in-flight requests and on internal logging the cardinality by user.

	add a _RateLimitEndpoint_ that 
		1- accepts a user id and returns a dump of their context tokens, with URIs, original thread ids
		2- at the top level lists the users active and cardinality of requests by user





