### PR TITLE
Fix DataSource name mis-match problem

### DIFF
--- a/sample-applications/fili-wikipedia-example/README.md
+++ b/sample-applications/fili-wikipedia-example/README.md
@@ -18,6 +18,7 @@ This example is an entirely self contained example that provides a Fili applicat
     ```bash
     cd fili
     mvn install
+    cd sample-applications
     mvn -pl fili-wikipedia-example exec:java
     ```
 - Note that if your setup is different you can adjust it by changing the default parameters below

--- a/sample-applications/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/names/WikiDruidTableName.java
+++ b/sample-applications/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/names/WikiDruidTableName.java
@@ -10,7 +10,8 @@ import java.util.Locale;
  * Hold the list of raw Druid table names.
  */
 public enum WikiDruidTableName implements TableName {
-    WIKITICKER;
+
+    WIKIPEDIA;
 
     private final String lowerCaseName;
 

--- a/sample-applications/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/WikiTableLoader.java
+++ b/sample-applications/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/table/WikiTableLoader.java
@@ -87,7 +87,7 @@ public class WikiTableLoader extends BaseTableLoader {
         // Physical Tables
         Set<PhysicalTableDefinition> samplePhysicalTableDefinition = Utils.asLinkedHashSet(
                 new ConcretePhysicalTableDefinition(
-                        WikiDruidTableName.WIKITICKER,
+                        WikiDruidTableName.WIKIPEDIA,
                         HOUR.buildZonedTimeGrain(DateTimeZone.UTC),
                         druidMetricNames.get(WikiLogicalTableName.WIKIPEDIA),
                         dimsBasefactDruidTableName

--- a/sample-applications/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/application/ConfigurationLoadTaskSpec.groovy
+++ b/sample-applications/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/application/ConfigurationLoadTaskSpec.groovy
@@ -4,7 +4,6 @@ package com.yahoo.wiki.webservice.application
 
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.DAY
 import static com.yahoo.bard.webservice.data.time.DefaultTimeGrain.HOUR
-import static com.yahoo.wiki.webservice.data.config.names.WikiDruidTableName.WIKITICKER
 import static com.yahoo.wiki.webservice.data.config.names.WikiLogicalTableName.WIKIPEDIA
 
 import com.yahoo.bard.webservice.data.config.ConfigurationLoader
@@ -81,6 +80,6 @@ class ConfigurationLoadTaskSpec extends Specification {
 
     def "test fetching of physicalTable by its name"() {
         expect: "fetched table has the same name as that requested"
-        physicalTableDictionary.get(WIKITICKER.asName()).getName() == WIKITICKER.asName()
+        physicalTableDictionary.get(WIKIPEDIA.asName()).getName() == WIKIPEDIA.asName()
     }
 }

--- a/sample-applications/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SingleDimensionMultipleComplexMetricDataServletSpec.groovy
+++ b/sample-applications/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SingleDimensionMultipleComplexMetricDataServletSpec.groovy
@@ -109,7 +109,7 @@ class SingleDimensionMultipleComplexMetricDataServletSpec extends BaseDataServle
           ],
           "context": {},
           "dataSource": {
-            "name": "${WikiDruidTableName.WIKITICKER.asName()}",
+            "name": "${WikiDruidTableName.WIKIPEDIA.asName()}",
             "type": "table"
           },
           "dimensions": [

--- a/sample-applications/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
+++ b/sample-applications/fili-wikipedia-example/src/test/groovy/com/yahoo/wiki/webservice/web/endpoints/SlicesServletSpec.groovy
@@ -2,7 +2,7 @@
 // Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
 package com.yahoo.wiki.webservice.web.endpoints
 
-import static com.yahoo.wiki.webservice.data.config.names.WikiDruidTableName.WIKITICKER
+import static com.yahoo.wiki.webservice.data.config.names.WikiDruidTableName.WIKIPEDIA
 
 import com.yahoo.bard.webservice.application.JerseyTestBinder
 import com.yahoo.bard.webservice.table.availability.AvailabilityTestingUtils
@@ -37,7 +37,7 @@ class SlicesServletSpec extends Specification {
 
     def "The slices are correctly configured, and the slices endpoint returns the appropriate metadata"() {
         setup:
-        String sliceNameHour = WIKITICKER.asName()
+        String sliceNameHour = WIKIPEDIA.asName()
         String expectedResponse = """{
             "rows":
             [
@@ -110,7 +110,7 @@ class SlicesServletSpec extends Specification {
         metrics == expectedMetrics
 
         where:
-        sliceName = WIKITICKER.asName().toLowerCase()
+        sliceName = WIKIPEDIA.asName().toLowerCase()
         granularity = "hour"
         dimensionNames = ("comment, countryIsoCode, regionIsoCode, page, user, isUnpatrolled, isNew, isRobot, isAnonymous," +
                 " isMinor, namespace, channel, countryName, regionName, metroCode, cityName").split(',').collect { it.trim()}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## Why This PR Exists

Our team is setting up a Fili instance in order to report our customer's behavior data. We were referring to [fili-wikipedia-example](https://github.com/yahoo/fili/tree/master/sample-applications/fili-wikipedia-example) as setup guide and found that fili-wikipedia-example returned no data within a data-populated time interval

## Steps to produce the Issue

1. Setting up a [Druid instance locally](https://druid.apache.org/docs/latest/tutorials/index.html)
2. Setting up a fili-wikipedia-example app by following its [README](https://github.com/yahoo/fili/tree/master/sample-applications/fili-wikipedia-example)
3. Send a fili query in command line with

    `curl "http://localhost:9998/v1/data/wikipedia/day/?metrics=count&dateTime=2015-09-12/P2D" -H "Content-Type: application/json" | python -m json.tool`

The query above returns no data, which actually exists in Druid

## What This PR Do to Solve the Issue

Druid official asks people to set Datasource name to "wikipedia":

<img width="813" alt="page 5" src="https://user-images.githubusercontent.com/16126939/190334990-d858b9dc-0233-42c2-a673-35e59ace9e07.png">

However, fili-wikipedia-example [hardcode the Datasource name to "wikiticker"](https://github.com/yahoo/fili/blob/master/sample-applications/fili-wikipedia-example/src/main/java/com/yahoo/wiki/webservice/data/config/names/WikiDruidTableName.java#L13)

So we changed `WIKITICKER` to `WIKIPEDIA` in this PR.
