### PR TITLE
Remove the word "error" from the no-content warning.

### DIFF
--- a/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoadTask.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/metadata/DataSourceMetadataLoadTask.java
@@ -232,8 +232,8 @@ public class DataSourceMetadataLoadTask extends LoadTask<Boolean> {
             // Usually, it means Druid knows about the data source, but no segments have been loaded
             if (statusCode == NO_CONTENT.getStatusCode()) {
                 String msg = String.format(
-                        "Druid returned 204 NO CONTENT when loading metadata for the '%s' datasource. While not an " +
-                                "error, it is unusual for a Druid data source to report having no data in it. Please " +
+                        "Druid returned 204 NO CONTENT when loading metadata for the '%s' datasource. " +
+                                "It is unusual for a Druid data source to report having no data in it. Please " +
                                 "verify that your cluster is healthy.",
                         dataSourceName.asName()
                 );


### PR DESCRIPTION
-- The presence of the word "error" causes this warning (which may or may not be a problem, depending on the setup of someone's system) to show up when searching logs for errors. So we remove that message to cut down on potential noise.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
