### PR TITLE
Unifies DataApiRequest and TablesApiRequest under ApiRequestWithTable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Current
 
 ### Changed:
 
+- [Add new interface ApiRequestWithTable](https://github.com/yahoo/fili/pull/1287)
+   - Allows apirequests that contain a table to leverage the same request mappers for e.g. security rules
+
 - [Updated Groovy to 3.0](https://github.com/yahoo/fili/pull/1171)
 
 - [More flexible security in RoleBased Request Mapping](https://github.com/yahoo/fili/issues/1283)

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestWithTable.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/ApiRequestWithTable.java
@@ -1,0 +1,22 @@
+// Copyright 2022 Yahoo Inc.
+// Licensed under the terms of the Apache license. Please see LICENSE.md file distributed with this work for terms.
+package com.yahoo.bard.webservice.web.apirequest;
+
+import com.yahoo.bard.webservice.table.LogicalTable;
+
+/**
+ * An interface for ApiRequests that contain a table. Useful
+ * if you want to apply security filters based on table, and you
+ * want those filters to apply to any requests (such as those
+ * against both the data and tables endpoints) that involve
+ * a table.
+ */
+public interface ApiRequestWithTable extends ApiRequest {
+
+    /**
+     * The logical table for this request.
+     *
+     * @return A logical table
+     */
+    LogicalTable getTable();
+}

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/DataApiRequest.java
@@ -40,7 +40,7 @@ import javax.ws.rs.core.Response;
 /**
  * DataApiRequest Request binds, validates, and models the parts of a request to the data endpoint.
  */
-public interface DataApiRequest extends ApiRequest {
+public interface DataApiRequest extends ApiRequestWithTable {
 
     SystemConfig SYSTEM_CONFIG = SystemConfigProvider.getInstance();
 
@@ -100,13 +100,6 @@ public interface DataApiRequest extends ApiRequest {
 
 
     // Schema fields
-
-    /**
-     * The logical table for this request.
-     *
-     * @return A logical table
-     */
-    LogicalTable getTable();
 
     /**
      * The grain to group the results of this request.

--- a/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequest.java
+++ b/fili-core/src/main/java/com/yahoo/bard/webservice/web/apirequest/TablesApiRequest.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.Response;
 /**
  * Tables API Request. Such an API Request binds, validates, and models the parts of a request to the tables endpoint.
  */
-public interface TablesApiRequest extends ApiRequest {
+public interface TablesApiRequest extends ApiRequestWithTable {
     String REQUEST_MAPPER_NAMESPACE = "tablesApiRequestMapper";
     String EXCEPTION_HANDLER_NAMESPACE = "tablesApiRequestExceptionHandler";
 
@@ -34,13 +34,6 @@ public interface TablesApiRequest extends ApiRequest {
      * @return the set of LogicalTables associated with a table API request
      */
     Set<LogicalTable> getTables();
-
-    /**
-     * Returns the LogicalTable requested in the table API request URL.
-     *
-     * @return the LogicalTable requested in the table API request URL
-     */
-    LogicalTable getTable();
 
     /**
      * Returns the grain to group the results of this request.

--- a/fili-security/src/main/java/com/yahoo/bard/webservice/web/security/RoleBasedTableValidatorRequestMapper.java
+++ b/fili-security/src/main/java/com/yahoo/bard/webservice/web/security/RoleBasedTableValidatorRequestMapper.java
@@ -6,7 +6,7 @@ import com.yahoo.bard.webservice.data.config.ResourceDictionaries;
 import com.yahoo.bard.webservice.web.ChainingRequestMapper;
 import com.yahoo.bard.webservice.web.RequestMapper;
 import com.yahoo.bard.webservice.web.RequestValidationException;
-import com.yahoo.bard.webservice.web.apirequest.DataApiRequest;
+import com.yahoo.bard.webservice.web.apirequest.ApiRequestWithTable;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -22,7 +22,7 @@ import javax.ws.rs.core.SecurityContext;
  *
  * @param <T> Type of API Request this RequestMapper will work on
  */
-public class RoleBasedTableValidatorRequestMapper<T extends DataApiRequest> extends ChainingRequestMapper<T> {
+public class RoleBasedTableValidatorRequestMapper<T extends ApiRequestWithTable> extends ChainingRequestMapper<T> {
 
     public static String DEFAULT_SECURITY_MAPPER_NAME = "__default";
 


### PR DESCRIPTION
-- It is not unusual for customers to apply security filters based on the table in the request. Sometimes, these rules (especially for rules that control whether customers can even *see* a given table) need to be applied to both the data and tables endpoint.

However, as things are currently structured, this necessitates code duplication, or handrolled checks for the tables endpoint because the RoleBasedTableValidatorRequestMapper only applies to DataApiRequests. So a new interface `ApiRequestWithTable` is introduced that extends `ApiRequest` and adds the `getTable` method. This allows us to generalize the `RoleBasedTableValidatorRequestMapper` (and possibly others if necessary) to both DataApiRequests and TablesApiRequests.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
